### PR TITLE
chore: rename npm package to @marcoguillermaz/claude-dev-kit

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,7 +10,7 @@ labels: bug
 
 ## Steps to reproduce
 
-1. Run `npx claude-dev-kit ...`
+1. Run `npx @marcoguillermaz/claude-dev-kit ...`
 2. ...
 
 ## Expected behavior

--- a/.github/workflows/claude-dev-kit-verify.yml
+++ b/.github/workflows/claude-dev-kit-verify.yml
@@ -3,7 +3,7 @@
 # Verifies that the claude-dev-kit scaffold is present and not bypassed.
 # Add this to your project's .github/workflows/ to enforce governance at PR time.
 #
-# What it checks (mirrors `npx claude-dev-kit doctor`):
+# What it checks (mirrors `npx @marcoguillermaz/claude-dev-kit doctor`):
 #   - .claude/settings.json exists
 #   - Stop hook is configured and contains no unfilled [TEST_COMMAND] placeholder
 #   - CLAUDE.md is present
@@ -35,7 +35,7 @@ jobs:
           node-version: '20'
 
       - name: Run claude-dev-kit doctor
-        run: npx claude-dev-kit@latest doctor --report
+        run: npx @marcoguillermaz/claude-dev-kit@latest doctor --report
         # --report: outputs JSON compliance report + exits 1 if any check fails
         # Use --ci for silent mode (no output, just exit code)
 
@@ -47,7 +47,7 @@ jobs:
           fi
           if grep -q '\[TEST_COMMAND\]' .claude/settings.json; then
             echo "ERROR: Stop hook contains unfilled [TEST_COMMAND] placeholder"
-            echo "Run: npx claude-dev-kit doctor to see all issues"
+            echo "Run: npx @marcoguillermaz/claude-dev-kit doctor to see all issues"
             exit 1
           fi
           echo "OK: Stop hook is configured"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ packages/
 ## Reporting bugs
 
 Use the **Bug Report** issue template. Include:
-- What you ran (`npx claude-dev-kit init`, `doctor`, etc.)
+- What you ran (`npx @marcoguillermaz/claude-dev-kit init`, `doctor`, etc.)
 - What you expected vs what happened
 - Node.js version (`node --version`)
 - OS

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # claude-dev-kit
 
-[![npm version](https://img.shields.io/npm/v/claude-dev-kit.svg)](https://www.npmjs.com/package/claude-dev-kit)
+[![npm version](https://img.shields.io/npm/v/@marcoguillermaz/claude-dev-kit.svg)](https://www.npmjs.com/package/@marcoguillermaz/claude-dev-kit)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Node.js ≥ 18](https://img.shields.io/badge/node-%3E%3D18-brightgreen.svg)](https://nodejs.org)
 [![CI](https://github.com/marcoguillermaz/claude-dev-kit/actions/workflows/ci.yml/badge.svg)](https://github.com/marcoguillermaz/claude-dev-kit/actions/workflows/ci.yml)
@@ -16,20 +16,20 @@
 
 You want to build end-to-end with Claude Code — or evaluate it for your team. You don't need a full pipeline yet. You need to get started, understand what the tool can do, and have a process you can actually review.
 
-**`npx claude-dev-kit init`** → choose **Discovery** → 3 files, 5 minutes, working.
+**`npx @marcoguillermaz/claude-dev-kit init`** → choose **Discovery** → 3 files, 5 minutes, working.
 
 ### Team already shipping with Claude Code
 
 You're using Claude Code but the process is ad-hoc. Claude makes autonomous decisions you can't always trace. You want a structured, reviewable workflow without inventing one from scratch.
 
-**`npx claude-dev-kit init`** → choose your tier (S / M / L) → full development scaffold.
+**`npx @marcoguillermaz/claude-dev-kit init`** → choose your tier (S / M / L) → full development scaffold.
 
 ---
 
 ## Quickstart
 
 ```bash
-npx claude-dev-kit init
+npx @marcoguillermaz/claude-dev-kit init
 ```
 
 The wizard asks one routing question first:
@@ -51,9 +51,9 @@ Three init paths to choose from:
 ### Validate your setup
 
 ```bash
-npx claude-dev-kit doctor          # interactive report
-npx claude-dev-kit doctor --report # JSON output for CI pipelines
-npx claude-dev-kit doctor --ci     # silent mode: exit 1 if any check fails
+npx @marcoguillermaz/claude-dev-kit doctor          # interactive report
+npx @marcoguillermaz/claude-dev-kit doctor --report # JSON output for CI pipelines
+npx @marcoguillermaz/claude-dev-kit doctor --ci     # silent mode: exit 1 if any check fails
 ```
 
 11 checks: Claude CLI, CLAUDE.md present + size, settings.json, Stop hook configured + no unfilled placeholder, pipeline.md, security.md, .env in .gitignore, no secrets in CLAUDE.md, CODEOWNERS.
@@ -63,7 +63,7 @@ npx claude-dev-kit doctor --ci     # silent mode: exit 1 if any check fails
 ### Keep up to date
 
 ```bash
-npx claude-dev-kit upgrade
+npx @marcoguillermaz/claude-dev-kit upgrade
 ```
 
 Updates non-destructive files (context-review, security rules, git rules) to the latest template.
@@ -72,9 +72,9 @@ Files with your customizations (CLAUDE.md, pipeline.md, settings.json) are flagg
 ### Upgrade your tier
 
 ```bash
-npx claude-dev-kit upgrade --tier=s   # add Fast Lane pipeline
-npx claude-dev-kit upgrade --tier=m   # add Standard pipeline + docs
-npx claude-dev-kit upgrade --tier=l   # add Full pipeline + audit skills
+npx @marcoguillermaz/claude-dev-kit upgrade --tier=s   # add Fast Lane pipeline
+npx @marcoguillermaz/claude-dev-kit upgrade --tier=m   # add Standard pipeline + docs
+npx @marcoguillermaz/claude-dev-kit upgrade --tier=l   # add Full pipeline + audit skills
 ```
 
 Upgrade is non-destructive — adds new files without overwriting your existing ones.
@@ -300,13 +300,13 @@ Full operational guide for your team: [`docs/operational-guide.docs`](docs/opera
 
 **v0.5.2 changes**: UAT scenario definition at scope gate — when Phase 4 E2E activates, the user must explicitly list numbered user journeys (1–5 scenarios) at Phase 1. Claude implements exactly those scenarios, never invents test cases. Phase 4 renamed "UAT / E2E tests" across Tier M/L pipelines.
 
-**v0.5.1 changes**: interactive tier selector (3 diagnostic questions → auto-suggest tier with explanation), conditional Phase 4 E2E testing in Tier M/L (opt-in via init wizard, per-block scope gate confirmation), `npx claude-dev-kit doctor` now checks Stop hook for unfilled `[TEST_COMMAND]` placeholder, `FIRST_SESSION.md` scaffolded for Tier M/L (team guide to first block cycle).
+**v0.5.1 changes**: interactive tier selector (3 diagnostic questions → auto-suggest tier with explanation), conditional Phase 4 E2E testing in Tier M/L (opt-in via init wizard, per-block scope gate confirmation), `npx @marcoguillermaz/claude-dev-kit doctor` now checks Stop hook for unfilled `[TEST_COMMAND]` placeholder, `FIRST_SESSION.md` scaffolded for Tier M/L (team guide to first block cycle).
 
 **v0.5.3 changes**: critical fix — Stop hook was missing from Tier S `settings.json`, breaking the core governance contract ("tests must pass in every tier"). Now enforced in all four tiers.
 
 **v0.5.2 changes**: UAT scenario definition at scope gate — when Phase 4 E2E activates, the user must explicitly list numbered user journeys (1–5 scenarios) at Phase 1. Claude implements exactly those scenarios, never invents test cases. Phase 4 renamed "UAT / E2E tests" across Tier M/L pipelines.
 
-**v0.5.1 changes**: interactive tier selector (3 diagnostic questions → auto-suggest tier with explanation), conditional Phase 4 E2E testing in Tier M/L (opt-in via init wizard, per-block scope gate confirmation), `npx claude-dev-kit doctor` now checks Stop hook for unfilled `[TEST_COMMAND]` placeholder, `FIRST_SESSION.md` scaffolded for Tier M/L (team guide to first block cycle).
+**v0.5.1 changes**: interactive tier selector (3 diagnostic questions → auto-suggest tier with explanation), conditional Phase 4 E2E testing in Tier M/L (opt-in via init wizard, per-block scope gate confirmation), `npx @marcoguillermaz/claude-dev-kit doctor` now checks Stop hook for unfilled `[TEST_COMMAND]` placeholder, `FIRST_SESSION.md` scaffolded for Tier M/L (team guide to first block cycle).
 
 **v0.5.0 changes**: session recovery (`.claude/session/`), scope gate with Tier 1/2 sweep auto-selection, Interaction Protocol in CLAUDE.md templates, three new settings hooks (arch-audit reminder, InstructionsLoaded, PostCompact), Phase 8.5 mandatory closing message, Phase 8 3-commit sequence, Phase 5b/5c/5d block-scoped quality audits (Tier L), Structural Requirements Changes pipeline R1–R4 (Tier L), Fast Lane session file + escalation rule + scope-confirm gate, evolved C1–C11 context review with explicit grep commands.
 

--- a/docs/operational-guide.docs
+++ b/docs/operational-guide.docs
@@ -72,7 +72,7 @@ What you get: three files, one hard constraint (tests must pass before Claude de
 When you're ready for more structure — usually after a few sessions, once Claude Code is part of the daily workflow — run:
 
 ```bash
-npx claude-dev-kit upgrade --tier=s
+npx @marcoguillermaz/claude-dev-kit upgrade --tier=s
 ```
 
 This adds the Fast Lane pipeline non-destructively. Your existing files are not overwritten.
@@ -119,7 +119,7 @@ npm install -g @anthropic-ai/claude-code
 Run this from any directory:
 
 ```bash
-npx claude-dev-kit init
+npx @marcoguillermaz/claude-dev-kit init
 ```
 
 You will be asked to choose one of three paths:
@@ -289,7 +289,7 @@ From that point on, `CONTEXT_IMPORT.md` is a historical record. Claude does not 
 
 ## 6. The four pipeline tiers
 
-The pipeline is the sequence of phases Claude follows for every development task. You choose the tier when running `init`. You can change it later by upgrading: `npx claude-dev-kit upgrade --tier=m`.
+The pipeline is the sequence of phases Claude follows for every development task. You choose the tier when running `init`. You can change it later by upgrading: `npx @marcoguillermaz/claude-dev-kit upgrade --tier=m`.
 
 ### Tier 0 — Discovery
 
@@ -311,9 +311,9 @@ The pipeline is the sequence of phases Claude follows for every development task
 
 **Upgrading from Tier 0:**
 ```bash
-npx claude-dev-kit upgrade --tier=s   # adds branch discipline + commit rules
-npx claude-dev-kit upgrade --tier=m   # adds phased pipeline + review gates + docs
-npx claude-dev-kit upgrade --tier=l   # adds full governance + audit skills
+npx @marcoguillermaz/claude-dev-kit upgrade --tier=s   # adds branch discipline + commit rules
+npx @marcoguillermaz/claude-dev-kit upgrade --tier=m   # adds phased pipeline + review gates + docs
+npx @marcoguillermaz/claude-dev-kit upgrade --tier=l   # adds full governance + audit skills
 ```
 Upgrade is non-destructive — it adds new files without overwriting your existing `CLAUDE.md` or `settings.json`.
 
@@ -1349,7 +1349,7 @@ Never commit `.env`, `.env.local`, `.env.production`, or any file containing tok
 ### Upgrading
 
 ```bash
-npx claude-dev-kit upgrade
+npx @marcoguillermaz/claude-dev-kit upgrade
 ```
 
 Non-destructive files are updated to the latest template version:
@@ -1369,9 +1369,9 @@ Review the diff and apply the relevant parts manually.
 ### Checking setup health
 
 ```bash
-npx claude-dev-kit doctor           # interactive report (default)
-npx claude-dev-kit doctor --report  # JSON compliance output for CI pipelines
-npx claude-dev-kit doctor --ci      # silent mode: exit 1 if any check fails
+npx @marcoguillermaz/claude-dev-kit doctor           # interactive report (default)
+npx @marcoguillermaz/claude-dev-kit doctor --report  # JSON compliance output for CI pipelines
+npx @marcoguillermaz/claude-dev-kit doctor --ci      # silent mode: exit 1 if any check fails
 ```
 
 Runs 11 checks and reports pass/fail:
@@ -1430,7 +1430,7 @@ Do not edit the scaffolded rule files directly if you want to preserve upgrade c
 
 ## 14. Frequently asked questions
 
-**Q: Do I need to run `npx claude-dev-kit init` every time I start a session?**
+**Q: Do I need to run `npx @marcoguillermaz/claude-dev-kit init` every time I start a session?**
 
 No. You run it once to scaffold the governance layer. After that, you just open Claude Code (`claude`) from the project root. The governance files load automatically.
 
@@ -1440,7 +1440,7 @@ No. You run it once to scaffold the governance layer. After that, you just open 
 
 The Stop hook is a mechanical enforcement: it does not rely on Claude following instructions. Even if Claude tries to declare a task complete without running tests, the hook blocks it.
 
-The STOP gates rely on Claude respecting the instructions in `pipeline.md`. If you observe Claude skipping a gate, check that `pipeline.md` is being loaded (run `npx claude-dev-kit doctor`).
+The STOP gates rely on Claude respecting the instructions in `pipeline.md`. If you observe Claude skipping a gate, check that `pipeline.md` is being loaded (run `npx @marcoguillermaz/claude-dev-kit doctor`).
 
 ---
 
@@ -1478,7 +1478,7 @@ Rules:
 
 **Q: Can I switch tiers on an existing project?**
 
-Yes. Edit `.claude/rules/pipeline.md` directly, or run `npx claude-dev-kit upgrade` which will show you a diff between your current pipeline and the latest template for the tier of your choice.
+Yes. Edit `.claude/rules/pipeline.md` directly, or run `npx @marcoguillermaz/claude-dev-kit upgrade` which will show you a diff between your current pipeline and the latest template for the tier of your choice.
 
 ---
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "claude-dev-kit",
+  "name": "@marcoguillermaz/claude-dev-kit",
   "version": "1.0.0",
   "description": "Scaffold for legible, reviewable AI-assisted development",
   "type": "module",

--- a/packages/cli/src/commands/init-greenfield.js
+++ b/packages/cli/src/commands/init-greenfield.js
@@ -217,7 +217,7 @@ export async function initGreenfield(options) {
     console.log(`  2. Run ${chalk.cyan('claude')} from this directory to start your first session`);
     console.log(`  3. Read ${chalk.cyan('GETTING_STARTED.md')} — or share it with your team`);
     console.log();
-    console.log(chalk.dim("When you're ready for more structure: npx claude-dev-kit upgrade --tier=s"));
+    console.log(chalk.dim("When you're ready for more structure: npx @marcoguillermaz/claude-dev-kit upgrade --tier=s"));
   } else {
     console.log(chalk.green.bold('✓ Greenfield scaffold complete'));
     console.log();

--- a/packages/cli/src/utils/print-plan.js
+++ b/packages/cli/src/utils/print-plan.js
@@ -47,7 +47,7 @@ export function printNextSteps(config) {
     console.log('  3. Claude will detect ' + chalk.cyan('CONTEXT_IMPORT.md') + ' and start the discovery pass automatically');
     console.log('     It will read your source repos and docs, then populate CLAUDE.md and docs/');
     console.log('  4. Confirm the discovery summary and answer any gap questions');
-    console.log('  5. Run ' + chalk.cyan('npx claude-dev-kit doctor') + ' after discovery completes');
+    console.log('  5. Run ' + chalk.cyan('npx @marcoguillermaz/claude-dev-kit doctor') + ' after discovery completes');
   }
 
   if (mode === 'in-place') {
@@ -55,7 +55,7 @@ export function printNextSteps(config) {
     console.log('  2. Claude will detect ' + chalk.cyan('CONTEXT_IMPORT.md') + ' and start the discovery pass automatically');
     console.log('     It will read the existing codebase and populate CLAUDE.md, requirements.md, etc.');
     console.log('  3. Confirm the discovery summary and answer any gap questions');
-    console.log('  4. Run ' + chalk.cyan('npx claude-dev-kit doctor') + ' after discovery completes');
+    console.log('  4. Run ' + chalk.cyan('npx @marcoguillermaz/claude-dev-kit doctor') + ' after discovery completes');
     if (config.includePreCommit) {
       console.log('  5. Run ' + chalk.cyan('pip install pre-commit && pre-commit install') + ' to activate secret scanning');
     }

--- a/packages/templates/common/CONTEXT_IMPORT.md
+++ b/packages/templates/common/CONTEXT_IMPORT.md
@@ -131,7 +131,7 @@ After the developer confirms the summary and all gap questions are answered:
 **Gaps resolved**: [list of questions answered by developer]
 ```
 
-3. Run `npx claude-dev-kit doctor` to validate the setup.
+3. Run `npx @marcoguillermaz/claude-dev-kit doctor` to validate the setup.
 
 ---
 

--- a/packages/templates/tier-0/GETTING_STARTED.md
+++ b/packages/templates/tier-0/GETTING_STARTED.md
@@ -85,9 +85,9 @@ Tier 0 (what you have now) gives you the minimum viable scaffold:
 When your team grows or your project complexity increases, upgrade to a higher tier:
 
 ```bash
-npx claude-dev-kit upgrade --tier=s   # Fast Lane: branch discipline + commit rules
-npx claude-dev-kit upgrade --tier=m   # Standard: phased pipeline with review gates
-npx claude-dev-kit upgrade --tier=l   # Full: audit skills, security review, multi-agent
+npx @marcoguillermaz/claude-dev-kit upgrade --tier=s   # Fast Lane: branch discipline + commit rules
+npx @marcoguillermaz/claude-dev-kit upgrade --tier=m   # Standard: phased pipeline with review gates
+npx @marcoguillermaz/claude-dev-kit upgrade --tier=l   # Full: audit skills, security review, multi-agent
 ```
 
 Upgrade is non-destructive — it adds new files without overwriting your existing ones.
@@ -102,7 +102,7 @@ Upgrade is non-destructive — it adds new files without overwriting your existi
 | Give Claude context | Edit `CLAUDE.md` |
 | Run tests manually | `[TEST_COMMAND]` |
 | See what Claude can do | Ask: "What slash commands are available?" |
-| Add more structure | `npx claude-dev-kit upgrade --tier=s` |
+| Add more structure | `npx @marcoguillermaz/claude-dev-kit upgrade --tier=s` |
 
 ---
 

--- a/packages/templates/tier-l/.claude/cheatsheet.md
+++ b/packages/templates/tier-l/.claude/cheatsheet.md
@@ -69,5 +69,5 @@ Run these on demand. Each skill reads the codebase, produces a structured report
 cat ~/.claude/audit/[PROJECT_NAME].jsonl | tail -20 | jq .
 
 # Validate Claude setup
-npx claude-dev-kit doctor
+npx @marcoguillermaz/claude-dev-kit doctor
 ```

--- a/packages/templates/tier-l/FIRST_SESSION.md
+++ b/packages/templates/tier-l/FIRST_SESSION.md
@@ -124,7 +124,7 @@ At the scope gate, Claude also declares whether **Phase 4 E2E** and **Phase 5d q
 | `/responsive-audit` | Breakpoint correctness (375px / 768px / 1024px) |
 | `/perf-audit` | Rendering boundaries, bundle size, N+1 patterns |
 | `/compact` | Frees context window (run at Phase 8.5) |
-| `npx claude-dev-kit doctor` | Checks your scaffold setup |
+| `npx @marcoguillermaz/claude-dev-kit doctor` | Checks your scaffold setup |
 
 ---
 

--- a/packages/templates/tier-m/.claude/cheatsheet.md
+++ b/packages/templates/tier-m/.claude/cheatsheet.md
@@ -69,5 +69,5 @@ Run these on demand. Each skill reads the codebase, produces a structured report
 cat ~/.claude/audit/[PROJECT_NAME].jsonl | tail -20 | jq .
 
 # Validate Claude setup
-npx claude-dev-kit doctor
+npx @marcoguillermaz/claude-dev-kit doctor
 ```

--- a/packages/templates/tier-m/FIRST_SESSION.md
+++ b/packages/templates/tier-m/FIRST_SESSION.md
@@ -107,7 +107,7 @@ You can always override the selection. The Tier 2 sweep adds EARS-style analysis
 | `/security-audit` | Reviews API routes and auth guards |
 | `/skill-dev` | Code quality and tech debt audit |
 | `/compact` | Frees context window (run at Phase 8.5) |
-| `npx claude-dev-kit doctor` | Checks your scaffold setup |
+| `npx @marcoguillermaz/claude-dev-kit doctor` | Checks your scaffold setup |
 
 ---
 


### PR DESCRIPTION
## Summary
- Resolves name collision with unrelated `claude-dev-kit@2.1.1` on npm
- Updates package name to `@marcoguillermaz/claude-dev-kit` (binary name `claude-dev-kit` unchanged)
- Updates all `npx claude-dev-kit` references across README, docs, templates, CI, and source

## Test plan
- [ ] CI green on Node 18/20/22
- [ ] `npx @marcoguillermaz/claude-dev-kit --help` works after publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)