### PR TITLE
chore: fix bin path format

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,7 +4,7 @@
   "description": "Scaffold for legible, reviewable AI-assisted development",
   "type": "module",
   "bin": {
-    "claude-dev-kit": "./src/index.js"
+    "claude-dev-kit": "src/index.js"
   },
   "files": [
     "src/",


### PR DESCRIPTION
Removes leading ./ from bin path as required by npm pkg fix. Eliminates publish warning.