### PR TITLE
fix: pipeline.md not scaffolded in tier S/M/L + integration test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ npm-debug.log*
 
 # npm
 packages/cli/package-lock.json
+
+# Integration test output (local only)
+packages/cli/test/integration/output/

--- a/packages/cli/src/scaffold/index.js
+++ b/packages/cli/src/scaffold/index.js
@@ -40,9 +40,8 @@ export async function scaffoldTier(tier, targetDir, config, templatesDir) {
   const commonDir = path.join(templatesDir, 'common');
   const tierDir = path.join(templatesDir, `tier-${tier.toLowerCase()}`);
 
-  // Copy common files
+  // Copy common files — skip rules/ here, handled separately below
   await copyTemplateDir(commonDir, targetDir, config, {
-    // Map template filenames to target filenames
     'gitignore': '.gitignore',
     'pre-commit-config.yaml': '.pre-commit-config.yaml',
     'adr-template.md': 'docs/adr/template.md',
@@ -50,11 +49,11 @@ export async function scaffoldTier(tier, targetDir, config, templatesDir) {
     'CODEOWNERS': '.github/CODEOWNERS',
     'context-review.md': '.claude/rules/context-review.md',
     'files-guide.md': '.claude/files-guide.md',
-  }, config);
+  }, config, ['rules']);
 
-  // Copy tier-specific files (these override anything from common with the same target path)
+  // Copy tier-specific files (includes tier rules/ like pipeline.md)
   if (await fs.pathExists(tierDir)) {
-    await copyTemplateDir(tierDir, targetDir, config, {}, config);
+    await copyTemplateDir(tierDir, targetDir, config, {}, config, []);
   }
 
   // Copy rules/ subdirectory from common
@@ -85,18 +84,17 @@ export async function scaffoldTier(tier, targetDir, config, templatesDir) {
   }
 }
 
-async function copyTemplateDir(srcDir, destDir, config, fileNameMap, userConfig) {
+async function copyTemplateDir(srcDir, destDir, config, fileNameMap, userConfig, skipDirs = []) {
   if (!(await fs.pathExists(srcDir))) return;
 
   const entries = await fs.readdir(srcDir, { withFileTypes: true });
 
   for (const entry of entries) {
     if (entry.isDirectory()) {
-      // Recursively copy subdirectories (except 'rules' — handled separately)
-      if (entry.name === 'rules') continue;
+      if (skipDirs.includes(entry.name)) continue;
       const subSrc = path.join(srcDir, entry.name);
       const subDest = path.join(destDir, entry.name);
-      await copyTemplateDir(subSrc, subDest, config, {}, userConfig);
+      await copyTemplateDir(subSrc, subDest, config, {}, userConfig, []);
       continue;
     }
 
@@ -135,10 +133,10 @@ export async function scaffoldTierSafe(tier, targetDir, config, templatesDir) {
     'CODEOWNERS': '.github/CODEOWNERS',
     'context-review.md': '.claude/rules/context-review.md',
     'files-guide.md': '.claude/files-guide.md',
-  }, config);
+  }, config, ['rules']);
 
   if (await fs.pathExists(tierDir)) {
-    await copyTemplateDirSafe(tierDir, targetDir, config, {}, config);
+    await copyTemplateDirSafe(tierDir, targetDir, config, {}, config, []);
   }
 
   const commonRulesDir = path.join(commonDir, 'rules');
@@ -165,17 +163,17 @@ export async function scaffoldTierSafe(tier, targetDir, config, templatesDir) {
   }
 }
 
-async function copyTemplateDirSafe(srcDir, destDir, config, fileNameMap, userConfig) {
+async function copyTemplateDirSafe(srcDir, destDir, config, fileNameMap, userConfig, skipDirs = []) {
   if (!(await fs.pathExists(srcDir))) return;
 
   const entries = await fs.readdir(srcDir, { withFileTypes: true });
 
   for (const entry of entries) {
     if (entry.isDirectory()) {
-      if (entry.name === 'rules') continue;
+      if (skipDirs.includes(entry.name)) continue;
       const subSrc = path.join(srcDir, entry.name);
       const subDest = path.join(destDir, entry.name);
-      await copyTemplateDirSafe(subSrc, subDest, config, {}, userConfig);
+      await copyTemplateDirSafe(subSrc, subDest, config, {}, userConfig, []);
       continue;
     }
 

--- a/packages/cli/templates/tier-l/MEMORY.md
+++ b/packages/cli/templates/tier-l/MEMORY.md
@@ -1,0 +1,17 @@
+# [PROJECT_NAME] — Memory
+
+## Active plan
+
+| Block | Status | Notes |
+|---|---|---|
+| [Block name] | ⏳ planned / 🔄 in progress / ✅ complete | [brief note] |
+
+## Lessons / Patterns
+
+<!-- Add project-specific learnings here as you discover them.
+     Format: observation → root cause → fix
+     Only add what would NOT be obvious from reading the code.
+
+     Example:
+     - **PostgREST join fails silently**: `table.select('col, other(col2)')` returns null even
+       with valid FK when using service role. Fix: always use separate queries + in-memory merge. -->

--- a/packages/cli/test/integration/run.js
+++ b/packages/cli/test/integration/run.js
@@ -1,0 +1,510 @@
+/**
+ * claude-dev-kit — Integration test suite
+ *
+ * Tests the scaffold layer directly (bypasses Inquirer).
+ * Validates file structure, placeholder resolution, and Stop hook presence
+ * across all tier/mode combinations.
+ *
+ * Usage:
+ *   node packages/cli/test/integration/run.js
+ *   node packages/cli/test/integration/run.js --verbose
+ *
+ * Output dir: packages/cli/test/integration/output/  (gitignored)
+ */
+
+import fs from 'fs-extra';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { scaffoldTier, scaffoldTierSafe } from '../../src/scaffold/index.js';
+import { generateClaudeMd } from '../../src/generators/claude-md.js';
+import { generateReadme } from '../../src/generators/readme.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const TEMPLATES_DIR = path.resolve(__dirname, '../../templates');
+const OUTPUT_DIR = path.resolve(__dirname, 'output');
+const VERBOSE = process.argv.includes('--verbose');
+
+// ── Colours (no dependency on chalk to keep the script standalone) ──────────
+
+const c = {
+  green: (s) => `\x1b[32m${s}\x1b[0m`,
+  red: (s) => `\x1b[31m${s}\x1b[0m`,
+  yellow: (s) => `\x1b[33m${s}\x1b[0m`,
+  cyan: (s) => `\x1b[36m${s}\x1b[0m`,
+  dim: (s) => `\x1b[2m${s}\x1b[0m`,
+  bold: (s) => `\x1b[1m${s}\x1b[0m`,
+};
+
+// ── Test state ───────────────────────────────────────────────────────────────
+
+let passed = 0;
+let failed = 0;
+let warned = 0;
+const failures = [];
+
+function pass(label) {
+  passed++;
+  if (VERBOSE) console.log(`  ${c.green('✓')} ${c.dim(label)}`);
+}
+
+function fail(label, detail = '') {
+  failed++;
+  const msg = detail ? `${label} — ${detail}` : label;
+  failures.push(msg);
+  console.log(`  ${c.red('✗')} ${label}${detail ? c.dim(' — ' + detail) : ''}`);
+}
+
+function warn(label, detail = '') {
+  warned++;
+  if (VERBOSE) console.log(`  ${c.yellow('⚠')} ${label}${detail ? c.dim(' — ' + detail) : ''}`);
+}
+
+// ── Assertions ───────────────────────────────────────────────────────────────
+
+function assertExists(dir, relPath) {
+  const full = path.join(dir, relPath);
+  if (fs.existsSync(full)) {
+    pass(`exists: ${relPath}`);
+  } else {
+    fail(`missing: ${relPath}`);
+  }
+}
+
+function assertNotExists(dir, relPath) {
+  const full = path.join(dir, relPath);
+  if (!fs.existsSync(full)) {
+    pass(`absent: ${relPath}`);
+  } else {
+    fail(`should be absent: ${relPath}`);
+  }
+}
+
+// Placeholders the wizard MUST resolve. Any of these left unfilled = real bug.
+const WIZARD_PLACEHOLDERS = [
+  'PROJECT_NAME',
+  'TECH_STACK_SUMMARY',
+  'TEST_COMMAND',
+  'TYPE_CHECK_COMMAND',
+  'BUILD_COMMAND',
+  'DEV_COMMAND',
+  'INSTALL_COMMAND',
+  'TECH_LEAD',
+  'BACKEND_LEAD',
+  'SECURITY_REVIEWER',
+  'E2E_COMMAND',
+];
+// All other placeholders (skill config, ADR template, state machines, etc.)
+// are intentionally left for the user/Claude to fill in at first session.
+
+function assertNoUnfilledWizardPlaceholders(dir) {
+  const allFiles = walkFiles(dir);
+  const hits = [];
+
+  for (const f of allFiles) {
+    const ext = path.extname(f);
+    if (!['.md', '.json', '.yaml', '.yml', ''].includes(ext)) continue;
+    const content = fs.readFileSync(f, 'utf8');
+    const found = WIZARD_PLACEHOLDERS.filter((p) => content.includes(`[${p}]`));
+    if (found.length > 0) {
+      hits.push({ file: path.relative(dir, f), placeholders: found.map((p) => `[${p}]`) });
+    }
+  }
+
+  if (hits.length === 0) {
+    pass('wizard placeholders all resolved');
+  } else {
+    for (const h of hits) {
+      fail(`wizard placeholder not resolved in ${h.file}`, h.placeholders.join(', '));
+    }
+  }
+}
+
+function assertStopHookPresent(dir) {
+  const settingsPath = path.join(dir, '.claude', 'settings.json');
+  if (!fs.existsSync(settingsPath)) {
+    fail('Stop hook check — .claude/settings.json missing');
+    return;
+  }
+  const raw = fs.readFileSync(settingsPath, 'utf8');
+  if (raw.includes('"Stop"')) {
+    pass('Stop hook present in settings.json');
+  } else {
+    fail('Stop hook missing from settings.json');
+  }
+}
+
+function assertStopHookResolved(dir) {
+  const settingsPath = path.join(dir, '.claude', 'settings.json');
+  if (!fs.existsSync(settingsPath)) return;
+  const raw = fs.readFileSync(settingsPath, 'utf8');
+  if (raw.includes('[TEST_COMMAND]')) {
+    fail('Stop hook contains unfilled [TEST_COMMAND] placeholder');
+  } else {
+    pass('Stop hook [TEST_COMMAND] resolved');
+  }
+}
+
+function assertFileUnchanged(dir, relPath, originalContent) {
+  const full = path.join(dir, relPath);
+  if (!fs.existsSync(full)) {
+    fail(`safe-mode: file disappeared: ${relPath}`);
+    return;
+  }
+  const current = fs.readFileSync(full, 'utf8');
+  if (current === originalContent) {
+    pass(`safe-mode: existing file preserved: ${relPath}`);
+  } else {
+    fail(`safe-mode: existing file was overwritten: ${relPath}`);
+  }
+}
+
+function assertDirExists(dir, relPath) {
+  const full = path.join(dir, relPath);
+  if (fs.existsSync(full) && fs.statSync(full).isDirectory()) {
+    pass(`dir exists: ${relPath}`);
+  } else {
+    fail(`missing dir: ${relPath}`);
+  }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function walkFiles(dir) {
+  const results = [];
+  if (!fs.existsSync(dir)) return results;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...walkFiles(full));
+    } else {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+async function scaffold(scenarioName, tier, config, safe = false) {
+  const dir = path.join(OUTPUT_DIR, scenarioName);
+  await fs.ensureDir(dir);
+  const fn = safe ? scaffoldTierSafe : scaffoldTier;
+  await fn(tier, dir, config, TEMPLATES_DIR);
+  await generateClaudeMd(config, dir);
+  if (!config.isDiscovery) await generateReadme(config, dir);
+  return dir;
+}
+
+function section(title) {
+  console.log();
+  console.log(c.bold(c.cyan(`▶ ${title}`)));
+}
+
+// ── Base configs ─────────────────────────────────────────────────────────────
+
+const BASE = {
+  projectName: 'Test Project',
+  description: 'Integration test scaffold',
+  techStack: 'node-ts',
+  testCommand: 'npx vitest run',
+  typeCheckCommand: 'npx tsc --noEmit',
+  devCommand: 'npm run dev',
+  buildCommand: 'npm run build',
+  installCommand: 'npm install',
+  e2eCommand: '',
+  includePreCommit: true,
+  includeGithub: true,
+  techLead: 'tech-lead',
+  backendLead: 'backend-lead',
+  securityReviewer: 'security-reviewer',
+  mode: 'greenfield',
+};
+
+// ── Scenarios ────────────────────────────────────────────────────────────────
+
+async function scenarioTier0() {
+  section('Tier 0 — Discovery');
+  const config = { ...BASE, tier: '0', isDiscovery: true, includePreCommit: false, includeGithub: false };
+  const dir = await scaffold('tier-0', '0', config);
+
+  assertExists(dir, 'CLAUDE.md');
+  assertExists(dir, 'GETTING_STARTED.md');
+  assertExists(dir, '.claude/settings.json');
+  assertDirExists(dir, '.claude/session');
+
+  // Tier 0 must NOT have pipeline or governance files
+  assertNotExists(dir, '.claude/rules/pipeline.md');
+  assertNotExists(dir, 'README.md');
+  assertNotExists(dir, '.github');
+  assertNotExists(dir, '.pre-commit-config.yaml');
+
+  assertStopHookPresent(dir);
+  assertStopHookResolved(dir);
+  assertNoUnfilledWizardPlaceholders(dir);
+}
+
+async function scenarioTierS_full() {
+  section('Tier S — Greenfield (full: precommit + github)');
+  const config = { ...BASE, tier: 's', isDiscovery: false };
+  const dir = await scaffold('tier-s-full', 's', config);
+
+  // Core files
+  assertExists(dir, 'CLAUDE.md');
+  assertExists(dir, 'README.md');
+  assertExists(dir, '.claude/settings.json');
+  assertExists(dir, '.claude/files-guide.md');
+  assertDirExists(dir, '.claude/session');
+
+  // Rules
+  assertExists(dir, '.claude/rules/pipeline.md');
+  assertExists(dir, '.claude/rules/context-review.md');
+  assertExists(dir, '.claude/rules/git.md');
+  assertExists(dir, '.claude/rules/security.md');
+
+  // Skills (arch-audit only in Tier S)
+  assertExists(dir, '.claude/skills/arch-audit/SKILL.md');
+  assertNotExists(dir, '.claude/skills/security-audit/SKILL.md');
+  assertNotExists(dir, '.claude/agents');
+
+  // Optional inclusions
+  assertExists(dir, '.github/PULL_REQUEST_TEMPLATE.md');
+  assertExists(dir, '.github/CODEOWNERS');
+  assertExists(dir, '.pre-commit-config.yaml');
+  assertExists(dir, 'docs/adr/template.md');
+
+  // Tier S must NOT have M/L-only files
+  assertNotExists(dir, 'FIRST_SESSION.md');
+  assertNotExists(dir, 'MEMORY.md');
+
+  assertStopHookPresent(dir);
+  assertStopHookResolved(dir);
+  assertNoUnfilledWizardPlaceholders(dir);
+}
+
+async function scenarioTierS_minimal() {
+  section('Tier S — Greenfield (minimal: no precommit, no github)');
+  const config = { ...BASE, tier: 's', isDiscovery: false, includePreCommit: false, includeGithub: false };
+  const dir = await scaffold('tier-s-minimal', 's', config);
+
+  assertExists(dir, 'CLAUDE.md');
+  assertExists(dir, '.claude/settings.json');
+  assertExists(dir, '.claude/rules/pipeline.md');
+
+  assertNotExists(dir, '.github');
+  assertNotExists(dir, '.pre-commit-config.yaml');
+
+  assertStopHookPresent(dir);
+  assertNoUnfilledWizardPlaceholders(dir);
+}
+
+async function scenarioTierM() {
+  section('Tier M — Greenfield (Standard)');
+  const config = { ...BASE, tier: 'm', isDiscovery: false, e2eCommand: 'npx playwright test' };
+  const dir = await scaffold('tier-m', 'm', config);
+
+  // Core
+  assertExists(dir, 'CLAUDE.md');
+  assertExists(dir, 'README.md');
+  assertExists(dir, 'FIRST_SESSION.md');
+  assertExists(dir, 'MEMORY.md');
+  assertExists(dir, '.claude/settings.json');
+  assertExists(dir, '.claude/rules/pipeline.md');
+
+  // Docs
+  assertExists(dir, 'docs/requirements.md');
+  assertExists(dir, 'docs/implementation-checklist.md');
+  assertExists(dir, 'docs/refactoring-backlog.md');
+  assertExists(dir, 'docs/adr/template.md');
+
+  // Agents (M has dependency-scanner, not context-reviewer)
+  assertExists(dir, '.claude/agents/dependency-scanner.md');
+  assertNotExists(dir, '.claude/agents/context-reviewer.md');
+
+  // Skills (M has full set except visual/responsive/ux which are also in M actually)
+  assertExists(dir, '.claude/skills/arch-audit/SKILL.md');
+  assertExists(dir, '.claude/skills/security-audit/SKILL.md');
+  assertExists(dir, '.claude/skills/skill-dev/SKILL.md');
+  assertExists(dir, '.claude/skills/skill-db/SKILL.md');
+  assertExists(dir, '.claude/skills/api-design/SKILL.md');
+  assertExists(dir, '.claude/skills/perf-audit/SKILL.md');
+
+  // L-only agent must not appear
+  assertNotExists(dir, '.claude/agents/context-reviewer.md');
+
+  assertStopHookPresent(dir);
+  assertStopHookResolved(dir);
+  assertNoUnfilledWizardPlaceholders(dir);
+}
+
+async function scenarioTierL() {
+  section('Tier L — Greenfield (Full)');
+  const config = { ...BASE, tier: 'l', isDiscovery: false, e2eCommand: 'npx playwright test' };
+  const dir = await scaffold('tier-l', 'l', config);
+
+  // Core
+  assertExists(dir, 'CLAUDE.md');
+  assertExists(dir, 'FIRST_SESSION.md');
+  assertExists(dir, 'MEMORY.md');
+  assertExists(dir, '.claude/settings.json');
+  assertExists(dir, '.claude/rules/pipeline.md');
+
+  // Both agents
+  assertExists(dir, '.claude/agents/dependency-scanner.md');
+  assertExists(dir, '.claude/agents/context-reviewer.md');
+
+  // Full skill set
+  assertExists(dir, '.claude/skills/arch-audit/SKILL.md');
+  assertExists(dir, '.claude/skills/security-audit/SKILL.md');
+  assertExists(dir, '.claude/skills/skill-dev/SKILL.md');
+  assertExists(dir, '.claude/skills/skill-db/SKILL.md');
+  assertExists(dir, '.claude/skills/api-design/SKILL.md');
+  assertExists(dir, '.claude/skills/perf-audit/SKILL.md');
+  assertExists(dir, '.claude/skills/responsive-audit/SKILL.md');
+  assertExists(dir, '.claude/skills/ux-audit/SKILL.md');
+  assertExists(dir, '.claude/skills/visual-audit/SKILL.md');
+
+  assertStopHookPresent(dir);
+  assertStopHookResolved(dir);
+  assertNoUnfilledWizardPlaceholders(dir);
+}
+
+async function scenarioInPlaceSafe() {
+  section('In-place — safe mode (existing files not overwritten)');
+
+  const dir = path.join(OUTPUT_DIR, 'in-place-safe');
+  await fs.ensureDir(dir);
+
+  // Pre-seed a CLAUDE.md that must survive
+  const originalContent = '# My Existing Project\n\nThis must not be overwritten.\n';
+  await fs.writeFile(path.join(dir, 'CLAUDE.md'), originalContent);
+
+  const config = { ...BASE, tier: 'm', isDiscovery: false, mode: 'in-place' };
+  await scaffoldTierSafe('m', dir, config, TEMPLATES_DIR);
+
+  // Existing file must be unchanged
+  assertFileUnchanged(dir, 'CLAUDE.md', originalContent);
+
+  // New files must have been created around it
+  assertExists(dir, '.claude/settings.json');
+  assertExists(dir, '.claude/rules/pipeline.md');
+  assertExists(dir, 'docs/adr/template.md');
+}
+
+async function scenarioStopHookContent() {
+  section('Stop hook — content correctness');
+
+  // All tiers must have a Stop hook that runs the test command
+  for (const tier of ['0', 's', 'm', 'l']) {
+    const config = {
+      ...BASE,
+      tier,
+      isDiscovery: tier === '0',
+      includePreCommit: false,
+      includeGithub: false,
+      testCommand: 'npm run test:ci',
+    };
+    const scenarioDir = path.join(OUTPUT_DIR, `stop-hook-tier-${tier}`);
+    await fs.ensureDir(scenarioDir);
+    await scaffoldTier(tier, scenarioDir, config, TEMPLATES_DIR);
+
+    const settingsPath = path.join(scenarioDir, '.claude/settings.json');
+    if (!fs.existsSync(settingsPath)) {
+      fail(`Tier ${tier}: .claude/settings.json missing`);
+      continue;
+    }
+
+    const raw = fs.readFileSync(settingsPath, 'utf8');
+
+    if (!raw.includes('"Stop"')) {
+      fail(`Tier ${tier}: Stop hook absent`);
+    } else {
+      pass(`Tier ${tier}: Stop hook present`);
+    }
+
+    if (raw.includes('[TEST_COMMAND]')) {
+      fail(`Tier ${tier}: [TEST_COMMAND] placeholder not resolved`);
+    } else {
+      pass(`Tier ${tier}: [TEST_COMMAND] resolved`);
+    }
+
+    if (raw.includes('npm run test:ci')) {
+      pass(`Tier ${tier}: custom testCommand injected`);
+    } else {
+      warn(`Tier ${tier}: custom testCommand not found in settings.json`);
+    }
+  }
+}
+
+async function scenarioPipelineGateCount() {
+  section('Pipeline gate counts per tier');
+
+  // Tier S has scope-confirm (not a STOP gate) — 0 STOP gates by design
+  const gateCounts = { m: 2, l: 4 };
+
+  for (const [tier, expectedGates] of Object.entries(gateCounts)) {
+    const config = { ...BASE, tier, isDiscovery: false };
+    const scenarioDir = path.join(OUTPUT_DIR, `gates-tier-${tier}`);
+    await fs.ensureDir(scenarioDir);
+    await scaffoldTier(tier, scenarioDir, config, TEMPLATES_DIR);
+
+    const pipelinePath = path.join(scenarioDir, '.claude/rules/pipeline.md');
+    if (!fs.existsSync(pipelinePath)) {
+      fail(`Tier ${tier}: pipeline.md missing`);
+      continue;
+    }
+
+    const content = fs.readFileSync(pipelinePath, 'utf8');
+    const stopMatches = (content.match(/STOP\s+GATE|STOP gate|\*\*STOP\*\*/gi) || []).length;
+
+    if (stopMatches >= expectedGates) {
+      pass(`Tier ${tier}: pipeline has ≥${expectedGates} STOP gate(s) (found ${stopMatches})`);
+    } else {
+      fail(`Tier ${tier}: expected ≥${expectedGates} STOP gate(s), found ${stopMatches}`);
+    }
+  }
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log();
+  console.log(c.bold('claude-dev-kit — Integration tests'));
+  console.log(c.dim(`Output: ${OUTPUT_DIR}`));
+  console.log(c.dim(`Verbose: ${VERBOSE ? 'on' : 'off (use --verbose for full output)'}`));
+
+  // Clean previous output
+  await fs.remove(OUTPUT_DIR);
+  await fs.ensureDir(OUTPUT_DIR);
+
+  await scenarioTier0();
+  await scenarioTierS_full();
+  await scenarioTierS_minimal();
+  await scenarioTierM();
+  await scenarioTierL();
+  await scenarioInPlaceSafe();
+  await scenarioStopHookContent();
+  await scenarioPipelineGateCount();
+
+  // ── Summary ────────────────────────────────────────────────────────────────
+
+  console.log();
+  console.log(c.bold('─────────────────────────────────'));
+  console.log(
+    `${c.green(`✓ ${passed} passed`)}  ${failed > 0 ? c.red(`✗ ${failed} failed`) : c.dim(`✗ ${failed} failed`)}  ${c.yellow(`⚠ ${warned} warned`)}`
+  );
+
+  if (failures.length > 0) {
+    console.log();
+    console.log(c.bold(c.red('Failures:')));
+    for (const f of failures) {
+      console.log(`  ${c.red('✗')} ${f}`);
+    }
+  }
+
+  console.log();
+
+  if (failed > 0) process.exit(1);
+}
+
+main().catch((err) => {
+  console.error(c.red('\nUnhandled error:'), err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Bug fixed
`copyTemplateDir` was skipping **all** directories named `rules/`, including tier-specific ones that contain `pipeline.md`. Every Tier S/M/L init was silently missing the pipeline — the core governance file.

**Root cause**: the `rules` skip was designed only for the common dir (handled separately), but applied globally via recursion to all nested `rules/` directories.

**Fix**: `skipDirs` parameter — pass `['rules']` only for the common dir copy, `[]` for tier dirs.

## Also fixed
- `MEMORY.md` added to `tier-l` templates (documented as M/L in README, was present in tier-m only)

## Integration test suite added
`packages/cli/test/integration/run.js` — 98 checks, gitignored output:
- All tier/mode combinations (Tier 0, S full, S minimal, M, L)
- In-place safe mode (existing files not overwritten)
- Stop hook presence and `[TEST_COMMAND]` resolution in all 4 tiers
- Pipeline STOP gate counts (M: 2, L: 4)
- Wizard placeholder resolution (PROJECT_NAME, TEST_COMMAND, etc.)
- Boundary checks (files that must NOT appear in lower tiers)

Run locally: `node packages/cli/test/integration/run.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)