### PR TITLE
chore: bump version to 1.1.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mg-claude-dev-kit",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Scaffold for legible, reviewable AI-assisted development",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Version bump following npm publish of v1.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)