### PR TITLE
feat(templates): integrate Boris Cherny agentic patterns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,16 @@ node packages/cli/test/integration/run.js
 ## Interaction Protocol
 **Perimeter questions** (scope, vision, user, future): always use the `AskUserQuestion` tool — never present as inline text. Max 4 questions per call, each with 2–4 options. Open-ended questions get representative options + "Other" for custom input.
 
+## Agentic Behavior
+
+**Plan Mode Default**: use `EnterPlanMode` for any task with 3+ steps or architectural decisions. If execution goes off track → STOP and re-plan before continuing.
+
+**Subagent Strategy**: keep main context window clean. Offload research, codebase exploration, and parallel analysis to subagents. One focused task per subagent.
+
+**Verification Gate**: before marking any task complete — run integration tests, diff behavior, ask "Would a staff engineer approve this?" No green = not done.
+
+**Lessons Capture**: after any user correction, check if the pattern is non-obvious. If so, save it as a feedback memory immediately.
+
 ## Reference Documents
 - `README.md` — public-facing, must stay in sync with all template/CLI changes
 - `docs/operational-guide.docs` — full reference, must stay in sync

--- a/packages/cli/templates/tier-l/.claude/rules/pipeline.md
+++ b/packages/cli/templates/tier-l/.claude/rules/pipeline.md
@@ -251,7 +251,8 @@ Only after explicit confirmation:
 4. Update `docs/requirements.md` if spec changed during implementation.
 5. If Mode A was used: move `docs/specs/[block-name].md` → `docs/specs/archive/[block-name].md` and mark as `Status: IMPLEMENTED`.
 5. Write ADR in `docs/adr/` if an architectural decision was made.
-6. Update `MEMORY.md` (project root) only if new lessons emerged not already documented.
+6. **Lessons capture**: review corrections received during this block. Add any non-obvious pattern rule to `tasks/lessons.md` (rule + why it exists). Do not wait for the next block.
+7. Update `MEMORY.md` (project root) only if new lessons emerged not already documented.
 7. **Commit sequence** — up to 3 commits, never mixed:
    - **Commit 1** (already done in Phase 3): source files only.
    - **Commit 2 — docs**: `docs/` changes + `README.md` if updated — separate commit.

--- a/packages/cli/templates/tier-l/tasks/lessons.md
+++ b/packages/cli/templates/tier-l/tasks/lessons.md
@@ -1,0 +1,8 @@
+# Lessons Learned
+
+> Updated after every user correction. Each entry is a rule that prevents the same mistake.
+> Format: **Rule** — why it exists (what correction prompted it).
+
+<!-- Add entries below. Example:
+- **Never use semantic tokens without verifying both themes** — light/dark divergence caught in review, 2026-01-15.
+-->

--- a/packages/cli/templates/tier-m/.claude/rules/pipeline.md
+++ b/packages/cli/templates/tier-m/.claude/rules/pipeline.md
@@ -209,7 +209,8 @@ Only after explicit confirmation:
 3. Update `CLAUDE.md` only if block introduces non-obvious patterns or changes conventions.
 4. Update `docs/requirements.md` if spec changed during implementation.
 5. If Mode A was used: move `docs/specs/[block-name].md` → `docs/specs/archive/[block-name].md` and mark as `Status: IMPLEMENTED`.
-6. Update `MEMORY.md` (project root) only if new lessons emerged not already documented.
+6. **Lessons capture**: review corrections received during this block. Add any non-obvious pattern rule to `tasks/lessons.md` (rule + why it exists). Do not wait for the next block.
+7. Update `MEMORY.md` (project root) only if new lessons emerged not already documented.
 7. **Commit sequence**:
    - **Commit 1** (already done in Phase 3): source files only.
    - **Commit 2 — docs**: `docs/` changes + `README.md` if updated.

--- a/packages/cli/templates/tier-m/tasks/lessons.md
+++ b/packages/cli/templates/tier-m/tasks/lessons.md
@@ -1,0 +1,8 @@
+# Lessons Learned
+
+> Updated after every user correction. Each entry is a rule that prevents the same mistake.
+> Format: **Rule** — why it exists (what correction prompted it).
+
+<!-- Add entries below. Example:
+- **Never use semantic tokens without verifying both themes** — light/dark divergence caught in review, 2026-01-15.
+-->


### PR DESCRIPTION
## Summary
- Add `## Agentic Behavior` section to project `CLAUDE.md` (plan mode default, subagent strategy, verification gate, lessons capture)
- Scaffold `tasks/lessons.md` in Tier M and Tier L templates as self-improving lessons log
- Add **Lessons Capture** step in Phase 8 of both Tier M and Tier L pipelines (review corrections → update `tasks/lessons.md` before block closure)

## Inspiration
Patterns from Boris Cherny's (Claude Code creator) personal CLAUDE.md, filtered to what's genuinely new and actionable for this kit.

## Test plan
- [x] Integration tests: 98/98 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)