### PR TITLE
feat(templates): sync agnostic governance improvements from staff-manager pilot

### DIFF
--- a/packages/cli/templates/tier-l/.claude/rules/pipeline.md
+++ b/packages/cli/templates/tier-l/.claude/rules/pipeline.md
@@ -119,6 +119,7 @@ Then:
 - Present data flow, data structures, main trade-offs.
 - State discarded alternatives and rationale.
 - For simple blocks (≤3 files, no shared types, no migration, no new patterns): skip, stating so.
+- **All clarification questions arising during design review must use the `AskUserQuestion` tool** — no inline open questions.
 
 ***** STOP — wait for design confirmation before writing code. *****
 
@@ -198,14 +199,23 @@ If either condition is false: **skip this phase and state so explicitly** — do
 - Output: "smoke test OK" or describe the problem and fix before proceeding.
 - Fix on `feature/` branch, re-merge if issues found.
 
-## Phase 5d — Block-scoped quality audit *(blocks with UI changes)*
+## Phase 5d — Block-scoped quality audit *(blocks with UI or API changes)*
 
+**Track A — UI audit** *(if block adds/modifies UI routes or components — runs on localhost)*
 - Run `/ui-audit` scoped to the block's new/modified routes only (token compliance, component adoption, accessibility, empty states).
 - Run `/visual-audit` scoped to the block's new/modified pages (typography, spacing, hierarchy, colour, density, dark-mode, micro-polish).
 - Run `/ux-audit` scoped to the block's user flows (task completion, feedback clarity, cognitive load).
 - Run `/responsive-audit` only if the block modifies routes used by non-admin roles.
 - **Execution order**: `/ui-audit` is static — launch it concurrently with the first Playwright-based skill. Then: `/visual-audit` → `/ux-audit` → `/responsive-audit` sequentially (they share the Playwright session).
-- **Severity actions**: fix all **Critical** issues before Phase 6. Flag **Major** issues in the Phase 6 checklist. Log **Minor** issues in `docs/refactoring-backlog.md`.
+
+**Track B — API/DB audit** *(if block creates/modifies API routes or applies migrations — static analysis, no dev server needed)*
+- Run `/security-audit` if the block creates or modifies any API route. Run `/api-design` if the block adds new API routes. Both are static — run them concurrently.
+- Run `/skill-db` only if the block applies migrations.
+
+**Severity handling — both tracks**:
+- **Critical**: fix before Phase 6. Do not proceed with open Critical issues.
+- **Major**: flag in Phase 6 checklist with planned resolution sprint.
+- **Minor**: append to `docs/refactoring-backlog.md` — assign ID prefix (`PERF-`, `API-`, `DB-`, `DEV-`).
 - Output per skill: one-paragraph summary only.
 
 ## Phase 6 — Outcome checklist ⏸ STOP
@@ -262,7 +272,7 @@ Only after explicit confirmation:
 ## Phase 8.5 — Context review + compact
 
 **C1–C3** (grep-only — delegate to agent):
-Invoke the `context-reviewer` agent via the Agent tool. It runs C1 (credential patterns), C2 (non-English prose), C3 (field name staleness) in a single call and returns pass/fail per check with matched lines. Apply any fix in the main session before proceeding.
+Invoke the `context-reviewer` agent via the Agent tool with `model: "haiku"`. It runs C1 (credential patterns), C2 (non-English prose), C3 (field name staleness) in a single call and returns pass/fail per check with matched lines. Apply any fix in the main session before proceeding.
 
 **C4–C11** (judgment-required — run in main session):
 Execute checks C4 through C11 from `.claude/rules/context-review.md` in order.

--- a/packages/cli/templates/tier-l/.claude/skills/api-design/SKILL.md
+++ b/packages/cli/templates/tier-l/.claude/skills/api-design/SKILL.md
@@ -65,7 +65,13 @@ Flag: any write route without explicit validation.
 **CHECK N5 — Consistent error response shape**
 Pattern: all error responses must use the same JSON shape.
 Grep: in route `catch` blocks and error returns, identify the response shape used (`{ error: message }`, `{ message }`, `{ errors: [] }`, etc.).
-Flag: routes using a different error shape from the majority."
+Flag: routes using a different error shape from the majority.
+
+**CHECK N6 — Top-level array response**
+Pattern: no route should return a bare array as the top-level JSON response.
+Grep: `Response\.json\(\s*\[|json\(\s*\[` across all route files.
+Expected: 0 matches. All list responses must be wrapped in an object (`{ items: [...] }`, not `[...]`). This allows adding `meta`, `pagination`, or `error` fields later without a breaking change.
+Flag: any route returning a top-level array."
 
 ---
 
@@ -79,14 +85,15 @@ Read 10 representative route handlers (mix of GET, POST, PATCH, DELETE):
 - 200: success with body
 - 201: resource created (POST that creates)
 - 204: success with no body (DELETE, PATCH with no return)
-- 400: validation error
-- 401: not authenticated
-- 403: not authorized
+- 400: malformed request — bad JSON, validation failure, missing required field
+- 401: not authenticated (no valid session)
+- 403: authenticated but lacks permission
 - 404: resource not found
-- 409: conflict (duplicate)
-- 500: unexpected server error
+- 409: valid request conflicts with current server state (e.g., duplicate, state machine conflict — approving an already-approved record)
+- 422: semantically invalid data that passes schema validation but violates a business rule
+- 500: unexpected server error (no internal details in response)
 
-Flag: routes returning 200 for errors, 500 for validation errors, 200 for deletes, etc.
+Flag: routes returning 200 for errors, 500 for validation errors, 400 for state-conflict scenarios (should be 409), or 200 on deletes.
 
 **R3 — Pagination pattern**: for routes returning lists, verify a consistent pagination approach (offset/limit, cursor-based, or page/size) is used. Flag any list route with no pagination (unbounded response).
 
@@ -107,6 +114,7 @@ Output format:
 | N3 Path vs query params | N | ✅/❌ |
 | N4 Missing validation | N | ✅/❌ |
 | N5 Inconsistent error shape | N | ✅/❌ |
+| N6 Top-level array response | N | ✅/❌ |
 
 ### Response Consistency
 | Check | Issues found | Verdict |
@@ -127,6 +135,6 @@ For each High finding, append to `docs/backlog-refinement.md`:
 - Priority index entry + full detail section
 
 ### Severity guide
-- **High**: GET route mutating state; missing validation on write route; unbounded list with no pagination
-- **Medium**: inconsistent error shape; wrong HTTP status code; ID in query param instead of path
-- **Low**: naming inconsistency (singular vs plural); envelope shape deviation on one route
+- **High**: GET route mutating state; missing validation on write route; unbounded list with no pagination; N6 top-level array response
+- **Medium**: inconsistent error shape; wrong HTTP status code (incl. 400 used for state conflicts instead of 409); ID in query param instead of path
+- **Low**: naming inconsistency (singular vs plural); 422 vs 400 distinction for business rule violations; envelope shape deviation on one route

--- a/packages/cli/templates/tier-l/.claude/skills/arch-audit/SKILL.md
+++ b/packages/cli/templates/tier-l/.claude/skills/arch-audit/SKILL.md
@@ -116,6 +116,33 @@ Run: check each referenced path. Report any that resolve to "No such file or dir
 Expected: all paths resolve. Any missing = FAIL.
 RECOMMEND if failing.
 
+**C7 — CLAUDE.md is gitignored**
+Check: `CLAUDE.md` must be listed in `.gitignore` (project convention: personal CLAUDE.md is never committed — exposes internal context, causes commit history pollution).
+Run: `git check-ignore -q CLAUDE.md && echo "PASS" || echo "FAIL"`
+Expected: "PASS" (exit 0). "FAIL" = FAIL.
+RECOMMEND if failing — requires user to add `CLAUDE.md` to `.gitignore` explicitly.
+
+**C8 — CLAUDE.md line budget**
+Check: `CLAUDE.md` must stay within 200 lines. Beyond this threshold, instruction adherence degrades — lower-priority rules get silently ignored.
+Run: `wc -l CLAUDE.md | awk '{print $1}'`
+Expected: ≤ 200. Any count above 200 = WARN.
+RECOMMEND if failing: identify sections to remove or convert to `@import` references. Do not auto-fix — pruning requires judgment.
+
+**C9 — Deprecated model IDs**
+Check: no `SKILL.md` file or `.claude/settings.json` should reference deprecated model IDs.
+Run: `grep -rn "claude-3-haiku\|claude-3-5-haiku\|claude-3-opus\|claude-3-sonnet\|claude-3-5-sonnet" .claude/skills/ .claude/settings.json 2>/dev/null`
+Expected: 0 matches. Any match = FAIL.
+AUTO-FIX: replace deprecated IDs with current equivalents:
+- `claude-3-haiku-*` or `claude-3-5-haiku-*` → `claude-haiku-4-5-20251001`
+- `claude-3-opus-*` → `claude-opus-4-6`
+- `claude-3-sonnet-*` or `claude-3-5-sonnet-*` → `claude-sonnet-4-6`
+
+**C10 — `allowed-tools` frontmatter on MCP-dependent skills**
+Check: any `SKILL.md` that calls `mcp__*` tools in its instructions must declare those tools in `allowed-tools:` frontmatter. This ensures Claude requests the correct permissions upfront, preventing mid-execution permission prompts.
+Run: `for f in .claude/skills/*/SKILL.md; do if grep -q "mcp__" "$f" && ! grep -q "allowed-tools:" "$f"; then echo "MISSING allowed-tools: $f"; fi; done`
+Expected: 0 MISSING lines. Any match = FAIL.
+AUTO-FIX: for each failing skill, read the `mcp__*` tool names from its body and add `allowed-tools: [mcp__tool1, mcp__tool2, ...]` to its frontmatter after the `context:` line.
+
 ---
 
 ## Step 3c — Anthropic Prompting Guide compliance
@@ -196,13 +223,17 @@ Output a structured report in this exact format:
 ### ✓ Compliant (no action needed)
 - [area]: [brief confirmation]
 
-### Ecosystem consistency (C1–C6)
+### Ecosystem consistency (C1–C10)
 - C1 Hook integrity: [PASS/FAIL — list missing hooks if any]
 - C2 Stop hook: [PASS/FAIL]
 - C3 STOP gate count: [PASS/FAIL — actual count]
 - C4 context:fork coverage: [PASS/FAIL — list missing skills if any]
 - C5 Interaction Protocol: [PASS/FAIL]
 - C6 Dead path refs: [PASS/FAIL — list missing paths if any]
+- C7 CLAUDE.md gitignored: [PASS/FAIL]
+- C8 CLAUDE.md line budget: [PASS/WARN — actual count]
+- C9 Deprecated model IDs: [PASS/FAIL — list matches if any]
+- C10 allowed-tools on MCP skills: [PASS/FAIL — list missing skills if any]
 
 ### Prompting compliance (P1–P5) — judgment-based, PASS/WARN only
 - P1 CLAUDE.md content type: [PASS/WARN — note any sections failing Anthropic's inclusion test]

--- a/packages/cli/templates/tier-m/.claude/rules/pipeline.md
+++ b/packages/cli/templates/tier-m/.claude/rules/pipeline.md
@@ -113,6 +113,7 @@ Branch prefix `feature/` activates this pipeline automatically.
 - Present data flow, data structures, main trade-offs.
 - State discarded alternatives and rationale.
 - Skip for simple blocks (≤3 files, no shared types, no migration, no new patterns).
+- **All clarification questions arising during design review must use the `AskUserQuestion` tool** — no inline open questions.
 
 ***** STOP — wait for design confirmation before writing code. *****
 
@@ -173,6 +174,26 @@ If either condition is false: **skip this phase and state so explicitly** — do
 - Output: "smoke test OK" or describe the problem and fix before proceeding.
 - Fix issues on `feature/` branch, re-merge if needed.
 
+## Phase 5d — Block-scoped quality audit *(blocks with UI or API changes)*
+
+**Track A — UI audit** *(if block adds/modifies UI routes or components)*
+- Run `/ui-audit` scoped to the block's new/modified routes only (token compliance, component adoption, accessibility, empty states).
+- Run `/visual-audit` scoped to the block's new/modified pages (typography, spacing, hierarchy, colour, density, dark-mode, micro-polish).
+- Run `/ux-audit` scoped to the block's user flows (task completion, feedback clarity, cognitive load).
+- Run `/responsive-audit` only if the block modifies routes used by non-admin roles.
+- **Execution order**: `/ui-audit` is static — launch it concurrently with the first Playwright-based skill. Then: `/visual-audit` → `/ux-audit` → `/responsive-audit` sequentially (they share the Playwright session).
+
+**Track B — API/DB audit** *(if block creates/modifies API routes or applies migrations — static analysis, no dev server needed)*
+- Run `/security-audit` if the block creates or modifies any API route.
+- Run `/api-design` if the block adds new API routes. Both are static — run them concurrently.
+- Run `/skill-db` only if the block applies migrations.
+
+**Severity handling — both tracks**:
+- **Critical**: fix before Phase 6. Do not proceed with open Critical issues.
+- **Major**: flag in Phase 6 checklist with planned resolution sprint.
+- **Minor**: append to `docs/refactoring-backlog.md` — assign ID prefix (`PERF-`, `API-`, `DB-`, `DEV-`).
+- Output per skill: one-paragraph summary only.
+
 ## Phase 6 — Outcome checklist ⏸ STOP
 
 Present this checklist with actual results:
@@ -219,7 +240,11 @@ Only after explicit confirmation:
 
 ## Phase 8.5 — Context review + compact
 
-Execute checks C1 through C11 from `.claude/rules/context-review.md` in order.
+**C1–C3** (grep-only — delegate to agent):
+Invoke the `context-reviewer` agent via the Agent tool with `model: "haiku"`. Pass the exact grep commands from `.claude/rules/context-review.md` for C1–C3 and the relevant file paths. Collect results; apply any fix in the main session before proceeding.
+
+**C4–C11** (judgment-required — run in main session):
+Execute checks C4 through C11 from `.claude/rules/context-review.md` in order.
 Apply any fix before moving to the next check.
 **Complete only when all checks pass.**
 
@@ -232,6 +257,8 @@ Apply any fix before moving to the next check.
 - Next: [next block name] OR "No next block defined"
 ```
 
+This message is **non-negotiable** — never skip it, even if the block was small or the session is long.
+
 Then run `/compact` to free the session context.
 
 ---
@@ -241,6 +268,7 @@ Then run `/compact` to free the session context.
 - **Never commit to `main` or `staging` directly.**
 - **STOP gates are hard stops** — not suggestions. Never proceed to the next phase without explicit confirmation.
 - **Execution keywords**: `Execute` · `Proceed` · `Confirmed` · `Go ahead` — these are the only phrases that authorize autonomous action after a STOP gate.
+- **Exception — active Phase 2**: once a plan is confirmed and an execution keyword was given, proceed autonomously through implementation without re-confirming each file edit. The confirmation covers the approved plan, not each step.
 - **Green before commit**: type check + tests must pass before every commit.
 - **Conventional commits**: `feat(scope):`, `fix(scope):`, `docs:`, `chore:` — imperative, under 72 chars.
 - **No unrequested changes**: implement only what was approved in Phase 1.

--- a/packages/cli/templates/tier-m/.claude/skills/api-design/SKILL.md
+++ b/packages/cli/templates/tier-m/.claude/skills/api-design/SKILL.md
@@ -65,7 +65,13 @@ Flag: any write route without explicit validation.
 **CHECK N5 — Consistent error response shape**
 Pattern: all error responses must use the same JSON shape.
 Grep: in route `catch` blocks and error returns, identify the response shape used (`{ error: message }`, `{ message }`, `{ errors: [] }`, etc.).
-Flag: routes using a different error shape from the majority."
+Flag: routes using a different error shape from the majority.
+
+**CHECK N6 — Top-level array response**
+Pattern: no route should return a bare array as the top-level JSON response.
+Grep: `Response\.json\(\s*\[|json\(\s*\[` across all route files.
+Expected: 0 matches. All list responses must be wrapped in an object (`{ items: [...] }`, not `[...]`). This allows adding `meta`, `pagination`, or `error` fields later without a breaking change.
+Flag: any route returning a top-level array."
 
 ---
 
@@ -79,14 +85,15 @@ Read 10 representative route handlers (mix of GET, POST, PATCH, DELETE):
 - 200: success with body
 - 201: resource created (POST that creates)
 - 204: success with no body (DELETE, PATCH with no return)
-- 400: validation error
-- 401: not authenticated
-- 403: not authorized
+- 400: malformed request — bad JSON, validation failure, missing required field
+- 401: not authenticated (no valid session)
+- 403: authenticated but lacks permission
 - 404: resource not found
-- 409: conflict (duplicate)
-- 500: unexpected server error
+- 409: valid request conflicts with current server state (e.g., duplicate, state machine conflict — approving an already-approved record)
+- 422: semantically invalid data that passes schema validation but violates a business rule
+- 500: unexpected server error (no internal details in response)
 
-Flag: routes returning 200 for errors, 500 for validation errors, 200 for deletes, etc.
+Flag: routes returning 200 for errors, 500 for validation errors, 400 for state-conflict scenarios (should be 409), or 200 on deletes.
 
 **R3 — Pagination pattern**: for routes returning lists, verify a consistent pagination approach (offset/limit, cursor-based, or page/size) is used. Flag any list route with no pagination (unbounded response).
 
@@ -107,6 +114,7 @@ Output format:
 | N3 Path vs query params | N | ✅/❌ |
 | N4 Missing validation | N | ✅/❌ |
 | N5 Inconsistent error shape | N | ✅/❌ |
+| N6 Top-level array response | N | ✅/❌ |
 
 ### Response Consistency
 | Check | Issues found | Verdict |
@@ -127,6 +135,6 @@ For each High finding, append to `docs/backlog-refinement.md`:
 - Priority index entry + full detail section
 
 ### Severity guide
-- **High**: GET route mutating state; missing validation on write route; unbounded list with no pagination
-- **Medium**: inconsistent error shape; wrong HTTP status code; ID in query param instead of path
-- **Low**: naming inconsistency (singular vs plural); envelope shape deviation on one route
+- **High**: GET route mutating state; missing validation on write route; unbounded list with no pagination; N6 top-level array response
+- **Medium**: inconsistent error shape; wrong HTTP status code (incl. 400 used for state conflicts instead of 409); ID in query param instead of path
+- **Low**: naming inconsistency (singular vs plural); 422 vs 400 distinction for business rule violations; envelope shape deviation on one route

--- a/packages/cli/templates/tier-m/.claude/skills/arch-audit/SKILL.md
+++ b/packages/cli/templates/tier-m/.claude/skills/arch-audit/SKILL.md
@@ -116,6 +116,33 @@ Run: check each referenced path. Report any that resolve to "No such file or dir
 Expected: all paths resolve. Any missing = FAIL.
 RECOMMEND if failing.
 
+**C7 — CLAUDE.md is gitignored**
+Check: `CLAUDE.md` must be listed in `.gitignore` (project convention: personal CLAUDE.md is never committed — exposes internal context, causes commit history pollution).
+Run: `git check-ignore -q CLAUDE.md && echo "PASS" || echo "FAIL"`
+Expected: "PASS" (exit 0). "FAIL" = FAIL.
+RECOMMEND if failing — requires user to add `CLAUDE.md` to `.gitignore` explicitly.
+
+**C8 — CLAUDE.md line budget**
+Check: `CLAUDE.md` must stay within 200 lines. Beyond this threshold, instruction adherence degrades — lower-priority rules get silently ignored.
+Run: `wc -l CLAUDE.md | awk '{print $1}'`
+Expected: ≤ 200. Any count above 200 = WARN.
+RECOMMEND if failing: identify sections to remove or convert to `@import` references. Do not auto-fix — pruning requires judgment.
+
+**C9 — Deprecated model IDs**
+Check: no `SKILL.md` file or `.claude/settings.json` should reference deprecated model IDs.
+Run: `grep -rn "claude-3-haiku\|claude-3-5-haiku\|claude-3-opus\|claude-3-sonnet\|claude-3-5-sonnet" .claude/skills/ .claude/settings.json 2>/dev/null`
+Expected: 0 matches. Any match = FAIL.
+AUTO-FIX: replace deprecated IDs with current equivalents:
+- `claude-3-haiku-*` or `claude-3-5-haiku-*` → `claude-haiku-4-5-20251001`
+- `claude-3-opus-*` → `claude-opus-4-6`
+- `claude-3-sonnet-*` or `claude-3-5-sonnet-*` → `claude-sonnet-4-6`
+
+**C10 — `allowed-tools` frontmatter on MCP-dependent skills**
+Check: any `SKILL.md` that calls `mcp__*` tools in its instructions must declare those tools in `allowed-tools:` frontmatter. This ensures Claude requests the correct permissions upfront, preventing mid-execution permission prompts.
+Run: `for f in .claude/skills/*/SKILL.md; do if grep -q "mcp__" "$f" && ! grep -q "allowed-tools:" "$f"; then echo "MISSING allowed-tools: $f"; fi; done`
+Expected: 0 MISSING lines. Any match = FAIL.
+AUTO-FIX: for each failing skill, read the `mcp__*` tool names from its body and add `allowed-tools: [mcp__tool1, mcp__tool2, ...]` to its frontmatter after the `context:` line.
+
 ---
 
 ## Step 3c — Anthropic Prompting Guide compliance
@@ -196,13 +223,17 @@ Output a structured report in this exact format:
 ### ✓ Compliant (no action needed)
 - [area]: [brief confirmation]
 
-### Ecosystem consistency (C1–C6)
+### Ecosystem consistency (C1–C10)
 - C1 Hook integrity: [PASS/FAIL — list missing hooks if any]
 - C2 Stop hook: [PASS/FAIL]
 - C3 STOP gate count: [PASS/FAIL — actual count]
 - C4 context:fork coverage: [PASS/FAIL — list missing skills if any]
 - C5 Interaction Protocol: [PASS/FAIL]
 - C6 Dead path refs: [PASS/FAIL — list missing paths if any]
+- C7 CLAUDE.md gitignored: [PASS/FAIL]
+- C8 CLAUDE.md line budget: [PASS/WARN — actual count]
+- C9 Deprecated model IDs: [PASS/FAIL — list matches if any]
+- C10 allowed-tools on MCP skills: [PASS/FAIL — list missing skills if any]
 
 ### Prompting compliance (P1–P5) — judgment-based, PASS/WARN only
 - P1 CLAUDE.md content type: [PASS/WARN — note any sections failing Anthropic's inclusion test]


### PR DESCRIPTION
## Summary

- **Pipeline (Tier M + L)**: Phase 1.5 AskUserQuestion rule; Phase 5d Track A/B split with backlog ID prefixes; Phase 8.5 Haiku subagent delegation for C1-C3; Tier M gains Exception active Phase 2 + non-negotiable closing message
- **arch-audit skill (Tier M + L)**: 4 new checks — C7 CLAUDE.md gitignored, C8 line budget ≤200, C9 deprecated model IDs with auto-fix, C10 `allowed-tools` on MCP skills; report extended to C1-C10
- **api-design skill (Tier M + L)**: 409/422 status code distinction, N6 top-level array response check, updated severity guide

## Context

Extracted from `staff-manager` staging branch (pipeline.md + all skills). All domain-specific content (worktree setup, Supabase project IDs, Next.js specifics, Italian keywords, test accounts) was filtered out. Only structurally agnostic governance improvements were ported.

A `sync-from-pilot` command was also created locally (uncommitted) to automate future syncs with a configurable domain-token filter.

## Test plan
- [ ] Run integration tests: `node packages/cli/test/integration/run.js`
- [ ] Verify `doctor` command still passes on a Tier M/L initialized project
- [ ] Spot-check that Phase 5d appears correctly in a `tier-m` init output

🤖 Generated with [Claude Code](https://claude.com/claude-code)