### PR TITLE
fix(templates): remove empty Step 0.5 code blocks from visual/ux/responsive-audit

### DIFF
--- a/packages/cli/templates/tier-l/.claude/skills/responsive-audit/SKILL.md
+++ b/packages/cli/templates/tier-l/.claude/skills/responsive-audit/SKILL.md
@@ -43,14 +43,6 @@ Announce at start:
 
 ---
 
-## Step 0.5 — Screenshot directory setup
-
-Before any navigation, create the temp screenshot directory:
-```bash
-```
-
----
-
 ## Step 1 — Load reference
 
 Read `docs/sitemap.md`. Extract:

--- a/packages/cli/templates/tier-l/.claude/skills/ux-audit/SKILL.md
+++ b/packages/cli/templates/tier-l/.claude/skills/ux-audit/SKILL.md
@@ -43,14 +43,6 @@ Announce at start:
 
 ---
 
-## Step 0.5 — Screenshot directory setup
-
-Before any navigation, create the temp screenshot directory:
-```bash
-```
-
----
-
 ## Step 1 — Load architecture context
 
 Read in parallel:

--- a/packages/cli/templates/tier-l/.claude/skills/visual-audit/SKILL.md
+++ b/packages/cli/templates/tier-l/.claude/skills/visual-audit/SKILL.md
@@ -33,14 +33,6 @@ Announce at start:
 
 ---
 
-## Step 0.5 — Screenshot directory setup
-
-Before any navigation, create the temp screenshot directory:
-```bash
-```
-
----
-
 ## Step 1 — Load context (parallel)
 
 Read in parallel:

--- a/packages/cli/templates/tier-m/.claude/skills/responsive-audit/SKILL.md
+++ b/packages/cli/templates/tier-m/.claude/skills/responsive-audit/SKILL.md
@@ -43,14 +43,6 @@ Announce at start:
 
 ---
 
-## Step 0.5 — Screenshot directory setup
-
-Before any navigation, create the temp screenshot directory:
-```bash
-```
-
----
-
 ## Step 1 — Load reference
 
 Read `docs/sitemap.md`. Extract:

--- a/packages/cli/templates/tier-m/.claude/skills/ux-audit/SKILL.md
+++ b/packages/cli/templates/tier-m/.claude/skills/ux-audit/SKILL.md
@@ -43,14 +43,6 @@ Announce at start:
 
 ---
 
-## Step 0.5 — Screenshot directory setup
-
-Before any navigation, create the temp screenshot directory:
-```bash
-```
-
----
-
 ## Step 1 — Load architecture context
 
 Read in parallel:

--- a/packages/cli/templates/tier-m/.claude/skills/visual-audit/SKILL.md
+++ b/packages/cli/templates/tier-m/.claude/skills/visual-audit/SKILL.md
@@ -33,14 +33,6 @@ Announce at start:
 
 ---
 
-## Step 0.5 — Screenshot directory setup
-
-Before any navigation, create the temp screenshot directory:
-```bash
-```
-
----
-
 ## Step 1 — Load context (parallel)
 
 Read in parallel:


### PR DESCRIPTION
## Summary

- Step 0.5 "Screenshot directory setup" had an empty ` ```bash ``` ` block in 6 skill files (tier-m + tier-l: visual-audit, ux-audit, responsive-audit)
- Root cause: agnosticity filter removed the pilot-specific `mkdir -p /tmp/sm-audit/...` command during the staff-manager→CDK sync, leaving the heading + prose + empty code block behind
- Fix: removed the entire Step 0.5 section from all 6 files — the step had no meaningful stack-agnostic content without that command

## Files modified

- `tier-m/.claude/skills/visual-audit/SKILL.md`
- `tier-m/.claude/skills/ux-audit/SKILL.md`
- `tier-m/.claude/skills/responsive-audit/SKILL.md`
- `tier-l/.claude/skills/visual-audit/SKILL.md`
- `tier-l/.claude/skills/ux-audit/SKILL.md`
- `tier-l/.claude/skills/responsive-audit/SKILL.md`

## Test plan

- [x] `grep -r "Step 0.5" packages/cli/templates/` → clean
- [x] 194/194 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)