### PR TITLE
chore(deps): bump ora/commander/inquirer to latest + GitHub Actions to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,14 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [20, 22]
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/claude-dev-kit-verify.yml
+++ b/.github/workflows/claude-dev-kit-verify.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,14 +15,14 @@
     "dev": "node --watch src/index.js"
   },
   "dependencies": {
-    "commander": "^12.0.0",
-    "inquirer": "^10.0.0",
+    "commander": "^14.0.0",
+    "inquirer": "^13.0.0",
     "chalk": "^5.3.0",
-    "ora": "^8.0.0",
+    "ora": "^9.0.0",
     "fs-extra": "^11.2.0"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "keywords": [
     "claude",


### PR DESCRIPTION
## Summary

Consolidates all 5 pending dependabot bumps (#2, #3, #4, #5 + actions/checkout) into a single PR.

### npm dependencies

| Package | From | To | Notes |
|---------|------|----|-------|
| `ora` | 8.2.0 | 9.3.0 | Node 20+ required |
| `commander` | 12.1.0 | 14.0.3 | Node 20+ required; excess-arg default change (v13) not applicable — CLI has no positional args |
| `inquirer` | 10.2.2 | 13.3.2 | `inquirer.prompt()` API preserved in v13; confirmed via import test |
| `engines.node` | `>=18.0.0` | `>=20.0.0` | Aligned with ora 9 + commander 14 requirements |

### GitHub Actions

| Action | From | To | Scope |
|--------|------|----|-------|
| `actions/checkout` | v4 | v6 | ci.yml + claude-dev-kit-verify.yml |
| `actions/setup-node` | v4 | v6 | ci.yml + claude-dev-kit-verify.yml |

CI matrix: removed Node 18 (below new minimum), retained 20 + 22.

## Test plan

- [x] `node packages/cli/src/index.js --help` → OK
- [x] `inquirer.prompt` type check → `function` (API preserved)
- [x] 194/194 integration tests pass
- [ ] CI checks on this PR (Node 20 + 22)

## Closes

Supersedes dependabot PRs: #2, #3, #4, #5 (and actions/checkout #1 equivalent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)