### PR TITLE
chore(release): bump version to v1.6.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mg-claude-dev-kit",
-  "version": "1.2.0",
+  "version": "1.6.0",
   "description": "Scaffold for legible, reviewable AI-assisted development",
   "type": "module",
   "bin": {

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -9,7 +9,7 @@ import chalk from 'chalk';
 program
   .name('claude-dev-kit')
   .description('Scaffold for legible, reviewable AI-assisted development')
-  .version('0.1.0');
+  .version('1.6.0');
 
 program
   .command('init')


### PR DESCRIPTION
## Summary

Version bump to align `package.json` and CLI `--version` output with the documented v1.6.0 milestone.

| File | From | To |
|------|------|----|
| `packages/cli/package.json` | `1.2.0` | `1.6.0` |
| `packages/cli/src/index.js` `.version()` | `0.1.0` | `1.6.0` |

## What's in v1.6.0

- Conditional docs scaffold: `docs/sitemap.md` + `docs/db-map.md` (Tier M+L, pruned by `hasFrontend`/`hasDatabase` flags)
- Staff-manager→CDK skill sync: 29 template files updated via 4-level agnosticity filter
- Fix: empty Step 0.5 code blocks removed from visual/ux/responsive-audit (6 files)
- Dep bumps: ora 9, commander 14, inquirer 13, actions/checkout v6, actions/setup-node v6, Node 20+ minimum
- Integration tests: 194 checks

## Test plan

- [x] `claude-dev-kit --version` → `1.6.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)