### PR TITLE
fix(templates): round 2 audit — hooks safety, arch-audit timer, perf-audit native guard

### DIFF
--- a/packages/cli/src/scaffold/index.js
+++ b/packages/cli/src/scaffold/index.js
@@ -304,5 +304,9 @@ function interpolate(content, config) {
     .replace(/\[HAS_E2E\]/g, config.hasE2E ? 'true' : 'false')
     .replace(/\[AUDIT_MODEL\]/g, config.auditModel || AUDIT_MODEL_DEFAULT)
     .replace(/\[DESIGN_SYSTEM_NAME\]/g, config.designSystemName || 'component library')
-    .replace(/\[HAS_PRD\]/g, config.hasPrd ? 'true' : 'false');
+    .replace(/\[HAS_PRD\]/g, config.hasPrd ? 'true' : 'false')
+    .replace(/\[FRAMEWORK\]/g, ['swift', 'kotlin', 'rust', 'dotnet'].includes(config.techStack) ? 'N/A — native app' : config.hasFrontend === false ? 'N/A — no web frontend' : 'your frontend framework')
+    .replace(/\[SITEMAP_OR_ROUTE_LIST\]/g, config.hasFrontend === false ? 'N/A — no web frontend' : 'docs/sitemap.md')
+    .replace(/\[API_ROUTES_PATH\]/g, config.hasApi === false ? 'N/A — no API routes' : 'src/app/api/')
+    .replace(/\[BUNDLE_TOOL\]/g, 'your build tool\'s bundle analyzer');
 }

--- a/packages/cli/templates/common/files-guide.md
+++ b/packages/cli/templates/common/files-guide.md
@@ -171,7 +171,7 @@ No `settings.local.json` is currently active — personal overrides are in `~/.c
 Key settings configured:
 - `attribution.commit/pr: ""` — suppresses automatic Co-Authored-By (pipeline adds it manually in commit heredoc)
 - `includeGitInstructions: false` — removes redundant built-in git instructions from system prompt (pipeline.md covers this); replaces the old `env.CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS` env var approach
-- `hooks.SessionStart` — checks `~/.claude/projects/.../last-audit` timestamp; if >7 days since last `/arch-audit`, prints a reminder at session open
+- `hooks.SessionStart` — checks `.claude/session/last-arch-audit` timestamp in the project directory; if >7 days since last `/arch-audit`, prints a reminder at session open
 - `hooks.InstructionsLoaded` — appends raw hook payload (JSON) to `/tmp/claude-instructions-YYYYMMDD.log` (async, non-blocking); inspect this file to debug which CLAUDE.md or rules files were loaded and when
 
 ---

--- a/packages/cli/templates/tier-0/.claude/settings.json
+++ b/packages/cli/templates/tier-0/.claude/settings.json
@@ -9,7 +9,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[TEST_COMMAND] || echo '{\"decision\": \"block\", \"reason\": \"Tests must pass before Claude can complete a task. Fix the failing tests first.\"}'"
+            "command": "[ \"$stop_hook_active\" = \"1\" ] && exit 0; [TEST_COMMAND] || echo '{\"decision\": \"block\", \"reason\": \"Tests must pass before Claude can complete a task. Fix the failing tests first.\"}'"
           }
         ]
       }

--- a/packages/cli/templates/tier-l/.claude/agents/dependency-scanner.md
+++ b/packages/cli/templates/tier-l/.claude/agents/dependency-scanner.md
@@ -18,8 +18,9 @@ The caller provides:
 
 ### Check 1 — Route consumers
 For each affected route path:
-- Grep for `href="[route]"`, `href={`, `router.push`, `redirect(`, `Link href` matching the route
-- Glob for pages/layouts that define the route segment
+- **Web projects** (Next.js, React Router, Express): grep for `href="[route]"`, `href={`, `router.push`, `redirect(`, `Link href` matching the route; glob for pages/layouts that define the route segment
+- **Native projects** (Swift/iOS/macOS): grep for `NavigationLink`, `navigationDestination`, `.sheet(`, `fullScreenCover(`, deep link URL patterns matching the route
+- **No frontend** (`[HAS_FRONTEND]` is `false`): mark Check 1 as N/A
 - Report: file path + line number + usage type
 
 ### Check 2 — Component import consumers

--- a/packages/cli/templates/tier-l/.claude/settings.json
+++ b/packages/cli/templates/tier-l/.claude/settings.json
@@ -31,7 +31,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd $CLAUDE_PROJECT_DIR && [TEST_COMMAND] 2>&1 | tail -10; [[ ${PIPESTATUS[0]} -ne 0 ]] && echo '{\"decision\": \"block\", \"reason\": \"Tests must pass before completing. Fix failing tests first.\"}'",
+            "command": "[ \"$stop_hook_active\" = \"1\" ] && exit 0; cd $CLAUDE_PROJECT_DIR && [TEST_COMMAND] 2>&1 | tail -10; [[ ${PIPESTATUS[0]} -ne 0 ]] && echo '{\"decision\": \"block\", \"reason\": \"Tests must pass before completing. Fix failing tests first.\"}'",
             "timeout": 600000
           }
         ]
@@ -79,7 +79,7 @@
           },
           {
             "type": "command",
-            "command": "LAST=$(cat ~/.claude/projects/$(echo $CLAUDE_PROJECT_DIR | tr '/' '-' | sed 's/^-//')/last-audit 2>/dev/null || echo 0); NOW=$(date +%s); DIFF=$((NOW - LAST)); if [ $DIFF -gt 604800 ]; then DAYS=$((DIFF / 86400)); LAST_DATE=$([ $LAST -eq 0 ] && echo 'never' || date -r $LAST '+%Y-%m-%d' 2>/dev/null || echo 'unknown'); echo \"⚠️  Arch audit overdue — last run: $LAST_DATE (${DAYS}d ago). Run /arch-audit to check compliance with latest Anthropic docs.\"; fi",
+            "command": "LAST=$(cat \"$CLAUDE_PROJECT_DIR/.claude/session/last-arch-audit\" 2>/dev/null || echo 0); NOW=$(date +%s); DIFF=$((NOW - LAST)); if [ $DIFF -gt 604800 ]; then DAYS=$((DIFF / 86400)); LAST_DATE=$([ $LAST -eq 0 ] && echo 'never' || date -r $LAST '+%Y-%m-%d' 2>/dev/null || date -d \"@$LAST\" '+%Y-%m-%d' 2>/dev/null || echo 'unknown'); echo \"⚠️  Arch audit overdue — last run: $LAST_DATE (${DAYS}d ago). Run /arch-audit to check compliance with latest Anthropic docs.\"; fi",
             "async": true
           }
         ]

--- a/packages/cli/templates/tier-l/.claude/skills/arch-audit/SKILL.md
+++ b/packages/cli/templates/tier-l/.claude/skills/arch-audit/SKILL.md
@@ -461,6 +461,7 @@ For each AUTO-FIX from Step 3, Step 3b, and Step H1: apply the change, note the 
 ## Step 5 — Update timestamp
 
 ```bash
+date +%s > "$CLAUDE_PROJECT_DIR/.claude/session/last-arch-audit"
 ```
 
 ## Step 6 — Produce audit report

--- a/packages/cli/templates/tier-l/.claude/skills/perf-audit/SKILL.md
+++ b/packages/cli/templates/tier-l/.claude/skills/perf-audit/SKILL.md
@@ -15,8 +15,16 @@ argument-hint: [target:section:<section>|target:page:<route>|mode:audit|mode:app
 > - `[BUNDLE_TOOL]` — e.g. `@next/bundle-analyzer`, `vite-bundle-visualizer`, `webpack-bundle-analyzer`
 > - Note: if this is a **public-facing** app, remove the "Out of scope" restriction on Core Web Vitals
 
+## Applicability check
 
+Before any other step: read `CLAUDE.md` and check the Framework and Language fields.
 
+- If the project is a native application (Swift, Kotlin, Objective-C, C++, desktop GUI) or the Framework field is `N/A — native app`: output the following and stop — do not proceed to Step 1:
+
+  > **perf-audit** targets web applications (Core Web Vitals, bundle composition, server/client boundaries). This project uses a native stack. Use platform-native profiling tools instead: Instruments (Swift/macOS/iOS), Android Studio Profiler (Kotlin/Android), Valgrind/perf (C/C++).
+
+- If `[HAS_FRONTEND]` is `false`: output the same message and stop.
+- If the project is a web application: proceed to Step 1.
 
 
 

--- a/packages/cli/templates/tier-l/.claude/skills/skill-dev/SKILL.md
+++ b/packages/cli/templates/tier-l/.claude/skills/skill-dev/SKILL.md
@@ -15,8 +15,8 @@ Do not optimize for theoretical purity. Optimize for pragmatic, production-grade
 
 **Severity model**:
 - **Critical**: production/data/security risk or correctness failure
-- **High**: architecture flaw or maintainability issue affecting delivery speed or stability; `useEffect` with no dependency array; floating promise on auth/data-write path
-- **Medium**: meaningful improvement with clear benefit, not urgent; over-large component; `'use client'` at page level when only a subcomponent needs it; console.log in production
+- **High**: architecture flaw or maintainability issue affecting delivery speed or stability; unhandled error on async data-write path; missing null check on external input entering business logic
+- **Medium**: meaningful improvement with clear benefit, not urgent; over-large module (300+ lines, 4+ responsibilities); console.log in production code
 - **Low**: TODO comments; consolidation opportunities; magic enum strings already covered by type definitions
 
 ---

--- a/packages/cli/templates/tier-m/.claude/agents/dependency-scanner.md
+++ b/packages/cli/templates/tier-m/.claude/agents/dependency-scanner.md
@@ -18,8 +18,9 @@ The caller provides:
 
 ### Check 1 — Route consumers
 For each affected route path:
-- Grep for `href="[route]"`, `href={`, `router.push`, `redirect(`, `Link href` matching the route
-- Glob for pages/layouts that define the route segment
+- **Web projects** (Next.js, React Router, Express): grep for `href="[route]"`, `href={`, `router.push`, `redirect(`, `Link href` matching the route; glob for pages/layouts that define the route segment
+- **Native projects** (Swift/iOS/macOS): grep for `NavigationLink`, `navigationDestination`, `.sheet(`, `fullScreenCover(`, deep link URL patterns matching the route
+- **No frontend** (`[HAS_FRONTEND]` is `false`): mark Check 1 as N/A
 - Report: file path + line number + usage type
 
 ### Check 2 — Component import consumers

--- a/packages/cli/templates/tier-m/.claude/settings.json
+++ b/packages/cli/templates/tier-m/.claude/settings.json
@@ -27,7 +27,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd $CLAUDE_PROJECT_DIR && [TEST_COMMAND] 2>&1 | tail -5; [[ ${PIPESTATUS[0]} -ne 0 ]] && echo '{\"decision\": \"block\", \"reason\": \"Tests must pass before completing the task. Fix failing tests first.\"}'",
+            "command": "[ \"$stop_hook_active\" = \"1\" ] && exit 0; cd $CLAUDE_PROJECT_DIR && [TEST_COMMAND] 2>&1 | tail -5; [[ ${PIPESTATUS[0]} -ne 0 ]] && echo '{\"decision\": \"block\", \"reason\": \"Tests must pass before completing the task. Fix failing tests first.\"}'",
             "timeout": 300000
           }
         ]
@@ -55,7 +55,7 @@
           },
           {
             "type": "command",
-            "command": "LAST=$(cat ~/.claude/projects/$(echo $CLAUDE_PROJECT_DIR | tr '/' '-' | sed 's/^-//')/last-audit 2>/dev/null || echo 0); NOW=$(date +%s); DIFF=$((NOW - LAST)); if [ $DIFF -gt 604800 ]; then DAYS=$((DIFF / 86400)); LAST_DATE=$([ $LAST -eq 0 ] && echo 'never' || date -r $LAST '+%Y-%m-%d' 2>/dev/null || echo 'unknown'); echo \"⚠️  Arch audit overdue — last run: $LAST_DATE (${DAYS}d ago). Run /arch-audit to check compliance with latest Anthropic docs.\"; fi",
+            "command": "LAST=$(cat \"$CLAUDE_PROJECT_DIR/.claude/session/last-arch-audit\" 2>/dev/null || echo 0); NOW=$(date +%s); DIFF=$((NOW - LAST)); if [ $DIFF -gt 604800 ]; then DAYS=$((DIFF / 86400)); LAST_DATE=$([ $LAST -eq 0 ] && echo 'never' || date -r $LAST '+%Y-%m-%d' 2>/dev/null || date -d \"@$LAST\" '+%Y-%m-%d' 2>/dev/null || echo 'unknown'); echo \"⚠️  Arch audit overdue — last run: $LAST_DATE (${DAYS}d ago). Run /arch-audit to check compliance with latest Anthropic docs.\"; fi",
             "async": true
           }
         ]

--- a/packages/cli/templates/tier-m/.claude/skills/arch-audit/SKILL.md
+++ b/packages/cli/templates/tier-m/.claude/skills/arch-audit/SKILL.md
@@ -461,6 +461,7 @@ For each AUTO-FIX from Step 3, Step 3b, and Step H1: apply the change, note the 
 ## Step 5 — Update timestamp
 
 ```bash
+date +%s > "$CLAUDE_PROJECT_DIR/.claude/session/last-arch-audit"
 ```
 
 ## Step 6 — Produce audit report

--- a/packages/cli/templates/tier-m/.claude/skills/perf-audit/SKILL.md
+++ b/packages/cli/templates/tier-m/.claude/skills/perf-audit/SKILL.md
@@ -15,8 +15,16 @@ argument-hint: [target:section:<section>|target:page:<route>|mode:audit|mode:app
 > - `[BUNDLE_TOOL]` — e.g. `@next/bundle-analyzer`, `vite-bundle-visualizer`, `webpack-bundle-analyzer`
 > - Note: if this is a **public-facing** app, remove the "Out of scope" restriction on Core Web Vitals
 
+## Applicability check
 
+Before any other step: read `CLAUDE.md` and check the Framework and Language fields.
 
+- If the project is a native application (Swift, Kotlin, Objective-C, C++, desktop GUI) or the Framework field is `N/A — native app`: output the following and stop — do not proceed to Step 1:
+
+  > **perf-audit** targets web applications (Core Web Vitals, bundle composition, server/client boundaries). This project uses a native stack. Use platform-native profiling tools instead: Instruments (Swift/macOS/iOS), Android Studio Profiler (Kotlin/Android), Valgrind/perf (C/C++).
+
+- If `[HAS_FRONTEND]` is `false`: output the same message and stop.
+- If the project is a web application: proceed to Step 1.
 
 
 

--- a/packages/cli/templates/tier-m/.claude/skills/skill-dev/SKILL.md
+++ b/packages/cli/templates/tier-m/.claude/skills/skill-dev/SKILL.md
@@ -15,8 +15,8 @@ Do not optimize for theoretical purity. Optimize for pragmatic, production-grade
 
 **Severity model**:
 - **Critical**: production/data/security risk or correctness failure
-- **High**: architecture flaw or maintainability issue affecting delivery speed or stability; `useEffect` with no dependency array; floating promise on auth/data-write path
-- **Medium**: meaningful improvement with clear benefit, not urgent; over-large component; `'use client'` at page level when only a subcomponent needs it; console.log in production
+- **High**: architecture flaw or maintainability issue affecting delivery speed or stability; unhandled error on async data-write path; missing null check on external input entering business logic
+- **Medium**: meaningful improvement with clear benefit, not urgent; over-large module (300+ lines, 4+ responsibilities); console.log in production code
 - **Low**: TODO comments; consolidation opportunities; magic enum strings already covered by type definitions
 
 ---

--- a/packages/cli/templates/tier-s/.claude/settings.json
+++ b/packages/cli/templates/tier-s/.claude/settings.json
@@ -23,7 +23,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[TEST_COMMAND] || echo '{\"decision\": \"block\", \"reason\": \"Tests must pass before declaring complete.\"}'"
+            "command": "[ \"$stop_hook_active\" = \"1\" ] && exit 0; [TEST_COMMAND] || echo '{\"decision\": \"block\", \"reason\": \"Tests must pass before declaring complete.\"}'"
           }
         ]
       }
@@ -45,7 +45,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "LAST=$(cat ~/.claude/projects/$(echo $CLAUDE_PROJECT_DIR | tr '/' '-' | sed 's/^-//')/last-audit 2>/dev/null || echo 0); NOW=$(date +%s); DIFF=$((NOW - LAST)); if [ $DIFF -gt 604800 ]; then DAYS=$((DIFF / 86400)); LAST_DATE=$([ $LAST -eq 0 ] && echo 'never' || date -r $LAST '+%Y-%m-%d' 2>/dev/null || echo 'unknown'); echo \"⚠️  Arch audit overdue — last run: $LAST_DATE (${DAYS}d ago). Run /arch-audit to check compliance with latest Anthropic docs.\"; fi",
+            "command": "LAST=$(cat \"$CLAUDE_PROJECT_DIR/.claude/session/last-arch-audit\" 2>/dev/null || echo 0); NOW=$(date +%s); DIFF=$((NOW - LAST)); if [ $DIFF -gt 604800 ]; then DAYS=$((DIFF / 86400)); LAST_DATE=$([ $LAST -eq 0 ] && echo 'never' || date -r $LAST '+%Y-%m-%d' 2>/dev/null || date -d \"@$LAST\" '+%Y-%m-%d' 2>/dev/null || echo 'unknown'); echo \"⚠️  Arch audit overdue — last run: $LAST_DATE (${DAYS}d ago). Run /arch-audit to check compliance with latest Anthropic docs.\"; fi",
             "async": true
           }
         ]

--- a/packages/cli/templates/tier-s/.claude/skills/arch-audit/SKILL.md
+++ b/packages/cli/templates/tier-s/.claude/skills/arch-audit/SKILL.md
@@ -461,6 +461,7 @@ For each AUTO-FIX from Step 3, Step 3b, and Step H1: apply the change, note the 
 ## Step 5 — Update timestamp
 
 ```bash
+date +%s > "$CLAUDE_PROJECT_DIR/.claude/session/last-arch-audit"
 ```
 
 ## Step 6 — Produce audit report

--- a/packages/cli/test/integration/run.js
+++ b/packages/cli/test/integration/run.js
@@ -465,6 +465,81 @@ async function scenarioStopHookContent() {
     } else {
       warn(`Tier ${tier}: custom testCommand not found in settings.json`);
     }
+
+    if (raw.includes('stop_hook_active')) {
+      pass(`Tier ${tier}: stop_hook_active guard present in Stop hook`);
+    } else {
+      fail(`Tier ${tier}: stop_hook_active guard missing from Stop hook`);
+    }
+  }
+}
+
+async function scenarioArchAuditTimestamp() {
+  section('Arch audit — timestamp system');
+
+  for (const tier of ['s', 'm', 'l']) {
+    const config = {
+      ...BASE,
+      tier,
+      isDiscovery: false,
+      includePreCommit: false,
+      includeGithub: false,
+    };
+    const scenarioDir = path.join(OUTPUT_DIR, `arch-audit-ts-tier-${tier}`);
+    await fs.ensureDir(scenarioDir);
+    await scaffoldTier(tier, scenarioDir, config, TEMPLATES_DIR);
+
+    const settingsPath = path.join(scenarioDir, '.claude/settings.json');
+    if (fs.existsSync(settingsPath)) {
+      const raw = fs.readFileSync(settingsPath, 'utf8');
+      if (raw.includes('.claude/session/last-arch-audit')) {
+        pass(`Tier ${tier}: SessionStart reads from .claude/session/last-arch-audit`);
+      } else {
+        fail(`Tier ${tier}: SessionStart still uses external ~/.claude/projects/ path for last-audit`);
+      }
+    }
+
+    const skillPath = path.join(scenarioDir, '.claude/skills/arch-audit/SKILL.md');
+    if (fs.existsSync(skillPath)) {
+      const skillRaw = fs.readFileSync(skillPath, 'utf8');
+      if (skillRaw.includes('last-arch-audit')) {
+        pass(`Tier ${tier}: arch-audit Step 5 writes last-arch-audit timestamp`);
+      } else {
+        fail(`Tier ${tier}: arch-audit Step 5 bash block is empty — timestamp never written`);
+      }
+    }
+  }
+}
+
+async function scenarioPerfAuditPlaceholders() {
+  section('perf-audit — placeholder resolution + applicability guard');
+
+  for (const tier of ['m', 'l']) {
+    const config = { ...BASE, tier, isDiscovery: false, hasFrontend: true, hasApi: true };
+    const scenarioDir = path.join(OUTPUT_DIR, `perf-audit-tier-${tier}`);
+    await fs.ensureDir(scenarioDir);
+    await scaffoldTier(tier, scenarioDir, config, TEMPLATES_DIR);
+
+    const skillPath = path.join(scenarioDir, '.claude/skills/perf-audit/SKILL.md');
+    if (!fs.existsSync(skillPath)) {
+      fail(`Tier ${tier}: perf-audit/SKILL.md missing`);
+      continue;
+    }
+    const raw = fs.readFileSync(skillPath, 'utf8');
+
+    for (const placeholder of ['[FRAMEWORK]', '[SITEMAP_OR_ROUTE_LIST]', '[API_ROUTES_PATH]', '[BUNDLE_TOOL]']) {
+      if (raw.includes(placeholder)) {
+        fail(`Tier ${tier}: perf-audit contains unresolved placeholder ${placeholder}`);
+      } else {
+        pass(`Tier ${tier}: perf-audit placeholder ${placeholder} resolved`);
+      }
+    }
+
+    if (raw.includes('Applicability check')) {
+      pass(`Tier ${tier}: perf-audit Applicability check present`);
+    } else {
+      fail(`Tier ${tier}: perf-audit Applicability check missing`);
+    }
   }
 }
 
@@ -657,6 +732,8 @@ async function main() {
   await scenarioTierL();
   await scenarioInPlaceSafe();
   await scenarioStopHookContent();
+  await scenarioArchAuditTimestamp();
+  await scenarioPerfAuditPlaceholders();
   await scenarioPipelineGateCount();
   await scenarioSkillPruning();
   await scenarioUiAuditPruning();


### PR DESCRIPTION
## Summary

Fixes 5 CDK bugs identified in the round 2 scaffold audit (mac-transcription-collector / Swift). All bugs were absent from PR #32. Integration tests: 194 → 214 checks (20 new).

### BUG-H — stop_hook_active guard (all tiers)
Stop hook lacked the `stop_hook_active` guard required by `claudemd-standards.md` S5. Without it, a Stop event that generates an error can cascade into a loop. Guard added to tier-0, s, m, l.

### BUG-I — arch-audit timestamp system (tier s/m/l)
Two-part fix:
- `arch-audit/SKILL.md` Step 5 had an empty bash block (same pattern as commit Step 6 in PR #32) — the timestamp was never written, so the SessionStart reminder fired every session
- SessionStart was reconstructing `~/.claude/projects/...` via `tr '/' '-'` which doesn't match Claude Code's internal path format — moved to `.claude/session/last-arch-audit` in the project dir (already gitignored, no external dependency). Added Linux `date -d @$LAST` fallback for cross-platform compatibility.

### BUG-J — perf-audit: placeholder resolution + native guard (tier m/l)
Four placeholders (`[FRAMEWORK]`, `[SITEMAP_OR_ROUTE_LIST]`, `[API_ROUTES_PATH]`, `[BUNDLE_TOOL]`) were unhandled by `interpolate()`. Added to `scaffold/index.js` with stack-aware defaults. Added `## Applicability check` guard: native stacks (Swift/Kotlin/Rust/.NET) or `hasFrontend=false` exit immediately with a message pointing to platform-native profiling tools.

### BUG-K — skill-dev severity examples (tier m/l)
Severity model examples were React-specific (`useEffect` no dep array, `'use client'` at page level). Replaced with stack-agnostic equivalents.

### BUG-L — dependency-scanner Check 1 (tier m/l)
Check 1 grep patterns (`href=`, `router.push`, `Link href`) only matched web routing. Made conditional: web patterns for web projects, Swift navigation patterns (`NavigationLink`, `navigationDestination`) for native, N/A when `hasFrontend=false`.

## Test plan
- [x] `node packages/cli/test/integration/run.js` — 214/214 ✓
- [x] BUG-H: `stop_hook_active` present in Stop hook (×4 tiers)
- [x] BUG-I: SessionStart reads `.claude/session/last-arch-audit`; arch-audit Step 5 writes timestamp (×3 tiers each)
- [x] BUG-J: no unresolved `[FRAMEWORK]`/`[SITEMAP_OR_ROUTE_LIST]`/`[API_ROUTES_PATH]`/`[BUNDLE_TOOL]` after scaffold; Applicability check present (×2 tiers, ×5 checks each)

🤖 Generated with [Claude Code](https://claude.com/claude-code)