### PR TITLE
fix(templates): skill-dev applicability check for native stacks

### DIFF
--- a/packages/cli/templates/tier-l/.claude/skills/skill-dev/SKILL.md
+++ b/packages/cli/templates/tier-l/.claude/skills/skill-dev/SKILL.md
@@ -21,6 +21,31 @@ Do not optimize for theoretical purity. Optimize for pragmatic, production-grade
 
 ---
 
+## Applicability check
+
+Before Step 0: check `CLAUDE.md` for the Framework and Language fields.
+
+**Web stacks** (Next.js, React, Express, Django, Rails, or any stack with a web frontend): run all checks — proceed to Step 0.
+
+**Native or backend-only stacks** (Swift, Kotlin, Rust, Go, .NET/C#, Java, Python without a web frontend): several checks target TypeScript/React patterns that do not exist in your codebase. Proceed to Step 0 with these adjustments:
+
+Skip entirely:
+- CHECK D1 — Next.js `@/components/` cross-module import patterns (TypeScript/Next.js only)
+- CHECK D2 — `ContentStatusBadge` and inline CSS class maps (React/TypeScript only)
+- CHECK D3 — Supabase `from().select()` N+1 patterns (ORM-specific)
+- CHECK D8 — TypeScript type safety suppressions and `any` usage (language-specific)
+- CHECK D9 — useEffect antipatterns (React only — entire check)
+- CHECK J3 — Client/Server component boundary placement (Next.js only)
+
+Run as-is (stack-agnostic):
+- CHECK D4 (dead exports), D5 (duplicated validation logic), D6 (magic strings/numbers), D7 (TODO/FIXME/HACK)
+- CHECK D10 (empty catch blocks, console.log in production)
+- CHECK J1 (over-large modules), J2 (coupling depth), J4 (utility consolidation — adapt directory name from `lib/` to your project's equivalent)
+
+Announce skipped checks and reason at the top of the audit report.
+
+---
+
 ## Step 0 — Target resolution
 
 Parse `$ARGUMENTS` for a `target:` token.

--- a/packages/cli/templates/tier-m/.claude/skills/skill-dev/SKILL.md
+++ b/packages/cli/templates/tier-m/.claude/skills/skill-dev/SKILL.md
@@ -21,6 +21,31 @@ Do not optimize for theoretical purity. Optimize for pragmatic, production-grade
 
 ---
 
+## Applicability check
+
+Before Step 0: check `CLAUDE.md` for the Framework and Language fields.
+
+**Web stacks** (Next.js, React, Express, Django, Rails, or any stack with a web frontend): run all checks — proceed to Step 0.
+
+**Native or backend-only stacks** (Swift, Kotlin, Rust, Go, .NET/C#, Java, Python without a web frontend): several checks target TypeScript/React patterns that do not exist in your codebase. Proceed to Step 0 with these adjustments:
+
+Skip entirely:
+- CHECK D1 — Next.js `@/components/` cross-module import patterns (TypeScript/Next.js only)
+- CHECK D2 — `ContentStatusBadge` and inline CSS class maps (React/TypeScript only)
+- CHECK D3 — Supabase `from().select()` N+1 patterns (ORM-specific)
+- CHECK D8 — TypeScript type safety suppressions and `any` usage (language-specific)
+- CHECK D9 — useEffect antipatterns (React only — entire check)
+- CHECK J3 — Client/Server component boundary placement (Next.js only)
+
+Run as-is (stack-agnostic):
+- CHECK D4 (dead exports), D5 (duplicated validation logic), D6 (magic strings/numbers), D7 (TODO/FIXME/HACK)
+- CHECK D10 (empty catch blocks, console.log in production)
+- CHECK J1 (over-large modules), J2 (coupling depth), J4 (utility consolidation — adapt directory name from `lib/` to your project's equivalent)
+
+Announce skipped checks and reason at the top of the audit report.
+
+---
+
 ## Step 0 — Target resolution
 
 Parse `$ARGUMENTS` for a `target:` token.

--- a/packages/cli/test/integration/run.js
+++ b/packages/cli/test/integration/run.js
@@ -543,6 +543,36 @@ async function scenarioPerfAuditPlaceholders() {
   }
 }
 
+async function scenarioSkillDevApplicabilityCheck() {
+  section('skill-dev — applicability guard present (tier M/L)');
+
+  for (const tier of ['m', 'l']) {
+    const config = { ...BASE, tier, isDiscovery: false };
+    const scenarioDir = path.join(OUTPUT_DIR, `skill-dev-applicability-tier-${tier}`);
+    await fs.ensureDir(scenarioDir);
+    await scaffoldTier(tier, scenarioDir, config, TEMPLATES_DIR);
+
+    const skillPath = path.join(scenarioDir, '.claude/skills/skill-dev/SKILL.md');
+    if (!fs.existsSync(skillPath)) {
+      fail(`Tier ${tier}: skill-dev/SKILL.md missing`);
+      continue;
+    }
+    const raw = fs.readFileSync(skillPath, 'utf8');
+
+    if (raw.includes('Applicability check')) {
+      pass(`Tier ${tier}: skill-dev Applicability check present`);
+    } else {
+      fail(`Tier ${tier}: skill-dev Applicability check missing`);
+    }
+
+    if (raw.includes('CHECK D9') && raw.includes('React only')) {
+      pass(`Tier ${tier}: skill-dev skip list includes D9 (useEffect — React only)`);
+    } else {
+      fail(`Tier ${tier}: skill-dev skip list missing D9 annotation`);
+    }
+  }
+}
+
 async function scenarioSkillPruning() {
   section('Skill pruning — no API, no DB, no frontend');
   const config = {
@@ -734,6 +764,7 @@ async function main() {
   await scenarioStopHookContent();
   await scenarioArchAuditTimestamp();
   await scenarioPerfAuditPlaceholders();
+  await scenarioSkillDevApplicabilityCheck();
   await scenarioPipelineGateCount();
   await scenarioSkillPruning();
   await scenarioUiAuditPruning();


### PR DESCRIPTION
## Summary

Fixes BUG-M identified in round 3 scaffold audit (mac-transcription-collector / Swift). Extends the applicability guard pattern introduced for \`perf-audit\` in PR #33.

## Problem

\`skill-dev/SKILL.md\` had 20+ React/Next.js/TypeScript references distributed across operational checks, with no mechanism to signal inapplicability on native stacks:

| Check | Issue |
|---|---|
| D1 | Greps for Next.js \`@/components/\` import patterns |
| D2 | References \`ContentStatusBadge\` and inline CSS class maps |
| D3 | Greps for Supabase \`from().select()\` inside loops |
| D8 | Audits TypeScript \`@ts-ignore\`, \`any\`, \`router.push\` floating promises |
| D9 | Entire check is useEffect antipatterns (React only) |
| J3 | Client/Server component boundary placement (Next.js only) |

On a Swift project, \`/skill-dev\` runs ~40% of checks against patterns that don't exist, producing false negatives and irrelevant output without surfacing the mismatch.

## Fix

Add \`## Applicability check\` before Step 0 with two branches:
- **Web stacks**: run all checks as-is
- **Native or backend-only stacks**: skip D1, D2, D3, D8, D9, J3; run D4–D7, D10, J1, J2, J4 (stack-agnostic checks)

Skill announces skipped checks at the top of the audit report.

## Test plan
- [x] \`node packages/cli/test/integration/run.js\` — 218/218 ✓
- [x] skill-dev Applicability check present in tier M and L
- [x] Skip list includes D9 with "React only" annotation (tier M and L)

🤖 Generated with [Claude Code](https://claude.com/claude-code)