### PR TITLE
fix(templates): context-review C4 — replace literal ... in MEMORY.md path

### DIFF
--- a/packages/cli/templates/common/context-review.md
+++ b/packages/cli/templates/common/context-review.md
@@ -42,7 +42,7 @@ Each check has a specific, verifiable pass/fail condition.
 
 **What**: references like "(Block N)", "(optional, Block N)", "from Block N" must not describe closed blocks as if they are open or future.
 **Run on CLAUDE.md**: `grep -n "Block [0-9]" CLAUDE.md`
-**Run on auto-memory**: `grep -n "Block [0-9]" ~/.claude/projects/.../memory/MEMORY.md`
+**Run on auto-memory**: same grep on `~/.claude/projects/<project-path-hash>/memory/MEMORY.md` (run `ls ~/.claude/projects/` to find your project hash)
 **Pass**: every match is either a historical note in past tense ("renamed in Block 3") or references a genuinely open block.
 **Fail**: remove forward-looking block references for closed blocks; convert to past tense if the historical context is useful.
 


### PR DESCRIPTION
## Summary

- C4 check in `context-review.md` (line 45) had the same `~/.claude/projects/.../memory/MEMORY.md` literal-`...` path that C2 (line 25) had before PR #32
- Applies identical fix: `<project-path-hash>` placeholder + `ls ~/.claude/projects/` discovery hint
- Identified as BUG-N during round 4 scaffold audit

## Test plan

- [x] 218/218 integration checks pass (`node packages/cli/test/integration/run.js`)
- [x] C4 wording consistent with C2 pattern already in file

🤖 Generated with [Claude Code](https://claude.com/claude-code)