### PR TITLE
fix(scaffold): native stack command defaults — no npm fallback for Swift/Kotlin/Rust/dotnet/Java

### DIFF
--- a/packages/cli/src/commands/init-in-place.js
+++ b/packages/cli/src/commands/init-in-place.js
@@ -80,7 +80,12 @@ export async function initInPlace(options) {
       type: 'input',
       name: 'testCommand',
       message: 'Test command (reference only — CDK won\'t run it):',
-      default: (a) => a.techStack === 'other' ? '' : (detected.testCommand || 'npm test'),
+      default: (a) => {
+        if (a.techStack === 'other') return '';
+        if (detected.testCommand) return detected.testCommand;
+        const nativeDefaults = { swift: 'xcodebuild test', kotlin: './gradlew test', rust: 'cargo test', dotnet: 'dotnet test', java: 'mvn test' };
+        return nativeDefaults[a.techStack] || 'npm test';
+      },
     },
     {
       type: 'input',

--- a/packages/cli/src/generators/claude-md.js
+++ b/packages/cli/src/generators/claude-md.js
@@ -49,13 +49,28 @@ function techStackSummary(stack) {
   return map[stack] || stack;
 }
 
+const NATIVE_CMD_DEFAULTS = {
+  swift:  { install: '# no install step', dev: 'swift run',     build: 'xcodebuild build',      test: 'xcodebuild test',  typeCheck: '' },
+  kotlin: { install: '# no install step', dev: './gradlew run',  build: './gradlew build',       test: './gradlew test',   typeCheck: '' },
+  rust:   { install: '# no install step', dev: 'cargo run',      build: 'cargo build --release', test: 'cargo test',       typeCheck: '' },
+  dotnet: { install: 'dotnet restore',    dev: 'dotnet run',     build: 'dotnet build',          test: 'dotnet test',      typeCheck: '' },
+  java:   { install: 'mvn install',       dev: 'mvn exec:java',  build: 'mvn package',           test: 'mvn test',         typeCheck: '' },
+};
+
 function buildCommandsBlock(config) {
+  const ncd = NATIVE_CMD_DEFAULTS[config.techStack] || {};
+  const install = config.installCommand || ncd.install || 'npm install';
+  const dev = config.devCommand || ncd.dev || 'npm run dev';
+  const build = config.buildCommand || ncd.build || 'npm run build';
+  const test = config.testCommand || ncd.test || 'npm test';
+  const typeCheck = config.typeCheckCommand || ncd.typeCheck || '';
+
   const lines = ['```bash'];
-  if (config.installCommand) lines.push(`${config.installCommand}     # install dependencies`);
-  if (config.devCommand) lines.push(`${config.devCommand}          # start dev server`);
-  if (config.buildCommand) lines.push(`${config.buildCommand}       # production build`);
-  if (config.testCommand) lines.push(`${config.testCommand}         # run tests`);
-  if (config.typeCheckCommand) lines.push(`${config.typeCheckCommand}  # type check`);
+  if (install) lines.push(`${install}     # install dependencies`);
+  if (dev) lines.push(`${dev}          # start dev server`);
+  if (build) lines.push(`${build}       # production build`);
+  if (test) lines.push(`${test}         # run tests`);
+  if (typeCheck) lines.push(`${typeCheck}  # type check`);
   lines.push('```');
   return lines.join('\n');
 }

--- a/packages/cli/src/scaffold/index.js
+++ b/packages/cli/src/scaffold/index.js
@@ -286,14 +286,23 @@ function interpolate(content, config) {
     other: 'Mixed',
   };
 
+  const nativeCommandDefaults = {
+    swift:  { install: '# no install step', dev: 'swift run',    build: 'xcodebuild build',     test: 'xcodebuild test',  typeCheck: '# type checking handled by compiler' },
+    kotlin: { install: '# no install step', dev: './gradlew run', build: './gradlew build',      test: './gradlew test',   typeCheck: '# type checking handled by compiler' },
+    rust:   { install: '# no install step', dev: 'cargo run',    build: 'cargo build --release', test: 'cargo test',       typeCheck: '# type checking handled by compiler' },
+    dotnet: { install: 'dotnet restore',    dev: 'dotnet run',   build: 'dotnet build',          test: 'dotnet test',      typeCheck: '# type checking handled by compiler' },
+    java:   { install: 'mvn install',       dev: 'mvn exec:java', build: 'mvn package',          test: 'mvn test',         typeCheck: '# type checking handled by compiler' },
+  };
+  const ncd = nativeCommandDefaults[config.techStack] || {};
+
   return content
     .replace(/\[PROJECT_NAME\]/g, config.projectName || 'My Project')
     .replace(/\[TECH_STACK_SUMMARY\]/g, techStackLabels[config.techStack] || config.techStack || 'Mixed')
-    .replace(/\[TYPE_CHECK_COMMAND\]/g, config.typeCheckCommand || 'npx tsc --noEmit')
-    .replace(/\[TEST_COMMAND\]/g, config.testCommand || 'npm test')
-    .replace(/\[BUILD_COMMAND\]/g, config.buildCommand || 'npm run build')
-    .replace(/\[DEV_COMMAND\]/g, config.devCommand || 'npm run dev')
-    .replace(/\[INSTALL_COMMAND\]/g, config.installCommand || 'npm install')
+    .replace(/\[TYPE_CHECK_COMMAND\]/g, config.typeCheckCommand || ncd.typeCheck || 'npx tsc --noEmit')
+    .replace(/\[TEST_COMMAND\]/g, config.testCommand || ncd.test || 'npm test')
+    .replace(/\[BUILD_COMMAND\]/g, config.buildCommand || ncd.build || 'npm run build')
+    .replace(/\[DEV_COMMAND\]/g, config.devCommand || ncd.dev || 'npm run dev')
+    .replace(/\[INSTALL_COMMAND\]/g, config.installCommand || ncd.install || 'npm install')
     .replace(/\[TECH_LEAD\]/g, config.techLead || 'tech-lead')
     .replace(/\[BACKEND_LEAD\]/g, config.backendLead || 'backend-lead')
     .replace(/\[SECURITY_REVIEWER\]/g, config.securityReviewer || 'security-reviewer')

--- a/packages/cli/test/integration/run.js
+++ b/packages/cli/test/integration/run.js
@@ -707,6 +707,55 @@ async function scenarioNewStacks() {
   }
 }
 
+async function scenarioNativeStackCommandDefaults() {
+  section('Native stack command defaults — no npm fallback when commands omitted');
+
+  // Simulates detection failure: no commands supplied → should resolve to native defaults, not npm.
+  const nativeDefaults = [
+    { stack: 'swift',  test: 'xcodebuild test',  install: '# no install step' },
+    { stack: 'kotlin', test: './gradlew test',    install: '# no install step' },
+    { stack: 'rust',   test: 'cargo test',        install: '# no install step' },
+    { stack: 'dotnet', test: 'dotnet test',       install: 'dotnet restore'    },
+    { stack: 'java',   test: 'mvn test',          install: 'mvn install'       },
+  ];
+
+  for (const { stack, test: expectedTest, install: expectedInstall } of nativeDefaults) {
+    const config = {
+      ...BASE,
+      tier: 'm',
+      techStack: stack,
+      testCommand: '',
+      devCommand: '',
+      buildCommand: '',
+      installCommand: '',
+      typeCheckCommand: '',
+      isDiscovery: false,
+    };
+    const dir = await scaffold(`native-cmd-defaults-${stack}`, 'm', config);
+    const claudeMd = path.join(dir, 'CLAUDE.md');
+    if (!fs.existsSync(claudeMd)) { fail(`native-cmd-defaults[${stack}]: CLAUDE.md missing`); continue; }
+    const content = fs.readFileSync(claudeMd, 'utf8');
+
+    if (!content.includes('npm test') && !content.includes('npm install') && !content.includes('npm run')) {
+      pass(`native-cmd-defaults[${stack}]: no npm commands in CLAUDE.md`);
+    } else {
+      fail(`native-cmd-defaults[${stack}]: npm command found in CLAUDE.md for native stack`);
+    }
+
+    if (content.includes(expectedTest)) {
+      pass(`native-cmd-defaults[${stack}]: test command = ${expectedTest}`);
+    } else {
+      fail(`native-cmd-defaults[${stack}]: expected test command "${expectedTest}" not found`);
+    }
+
+    if (content.includes(expectedInstall)) {
+      pass(`native-cmd-defaults[${stack}]: install command = ${expectedInstall}`);
+    } else {
+      fail(`native-cmd-defaults[${stack}]: expected install command "${expectedInstall}" not found`);
+    }
+  }
+}
+
 async function scenarioWizardCoverage() {
   section('Wizard coverage — full CLI execution via --answers');
 
@@ -771,6 +820,7 @@ async function main() {
   await scenarioCommitSkillAllTiers();
   await scenarioNewRuleFiles();
   await scenarioNewStacks();
+  await scenarioNativeStackCommandDefaults();
   await scenarioWizardCoverage();
 
   // ── Summary ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- When wizard detection failed or user left commands blank on a native stack (Swift, Kotlin, Rust, .NET, Java), `CLAUDE.md` was generated with `npm test`, `npm install`, `npm run build`, `npm run dev`
- Root cause: `buildCommandsBlock()` in `claude-md.js` had no per-stack fallbacks — went straight to npm defaults
- Same issue in `scaffold/index.js interpolate()` for other template files, and in the wizard testCommand default (`init-in-place.js`)

## Changes

- `claude-md.js`: added `NATIVE_CMD_DEFAULTS` map; `buildCommandsBlock()` uses stack-appropriate defaults before npm fallback
- `scaffold/index.js`: same `nativeCommandDefaults` map applied to `[TEST_COMMAND]`, `[INSTALL_COMMAND]`, `[BUILD_COMMAND]`, `[DEV_COMMAND]`, `[TYPE_CHECK_COMMAND]` interpolation
- `init-in-place.js`: wizard `testCommand` default uses native defaults (xcodebuild test, ./gradlew test, cargo test, dotnet test, mvn test) when detection returns empty

## Test plan

- [x] 233/233 integration checks pass (`node packages/cli/test/integration/run.js`)
- [x] New scenario `scenarioNativeStackCommandDefaults`: 5 native stacks × 3 assertions (no npm, correct test cmd, correct install cmd) = 15 new checks

Identified in round 4 scaffold audit (check 5.3) of mac-transcription-collector Swift project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)