### PR TITLE
fix(doctor,templates): Playwright false positive + skill-dev stack-agnostic regression risk

### DIFF
--- a/packages/cli/src/commands/doctor.js
+++ b/packages/cli/src/commands/doctor.js
@@ -233,7 +233,7 @@ const checks = [
           const skillFile = path.join(skillsDir, skill, 'SKILL.md');
           if (!fs.existsSync(skillFile)) continue;
           const content = fs.readFileSync(skillFile, 'utf8');
-          const usesPlaywright = content.includes('Playwright') || content.includes('browser_');
+          const usesPlaywright = content.includes('browser_');
           const hasAllowedTools = content.startsWith('---') && content.includes('allowed-tools');
           if (usesPlaywright && !hasAllowedTools) missingTools.push(skill);
         }

--- a/packages/cli/templates/tier-l/.claude/skills/skill-dev/SKILL.md
+++ b/packages/cli/templates/tier-l/.claude/skills/skill-dev/SKILL.md
@@ -282,7 +282,7 @@ Then write ONLY the approved entries to `docs/refactoring-backlog.md`.
 
 Each entry **must** include a `Regression risk` field:
 - **Behavior-preserving** (pure refactoring — no change to external contracts, UI, DB writes, emails, redirects): proceed at the assigned severity.
-- **Behavior-adjacent** (fix touches a path that could affect observable output): downgrade severity by one level AND add the note `"Requires dedicated pipeline block — not a fast-lane fix."`. List the existing Vitest/Playwright tests that cover the affected path — if none exist, add `"No coverage — regression risk is unverifiable without adding tests first."` and treat as Critical regardless of check category.
+- **Behavior-adjacent** (fix touches a path that could affect observable output): downgrade severity by one level AND add the note `"Requires dedicated pipeline block — not a fast-lane fix."`. List the existing automated tests that cover the affected path — if none exist, add `"No coverage — regression risk is unverifiable without adding tests first."` and treat as Critical regardless of check category.
 - If the fix cannot be proven behavior-preserving from static analysis alone: default to behavior-adjacent.
 
 ### Severity guide

--- a/packages/cli/templates/tier-m/.claude/skills/skill-dev/SKILL.md
+++ b/packages/cli/templates/tier-m/.claude/skills/skill-dev/SKILL.md
@@ -282,7 +282,7 @@ Then write ONLY the approved entries to `docs/refactoring-backlog.md`.
 
 Each entry **must** include a `Regression risk` field:
 - **Behavior-preserving** (pure refactoring — no change to external contracts, UI, DB writes, emails, redirects): proceed at the assigned severity.
-- **Behavior-adjacent** (fix touches a path that could affect observable output): downgrade severity by one level AND add the note `"Requires dedicated pipeline block — not a fast-lane fix."`. List the existing Vitest/Playwright tests that cover the affected path — if none exist, add `"No coverage — regression risk is unverifiable without adding tests first."` and treat as Critical regardless of check category.
+- **Behavior-adjacent** (fix touches a path that could affect observable output): downgrade severity by one level AND add the note `"Requires dedicated pipeline block — not a fast-lane fix."`. List the existing automated tests that cover the affected path — if none exist, add `"No coverage — regression risk is unverifiable without adding tests first."` and treat as Critical regardless of check category.
 - If the fix cannot be proven behavior-preserving from static analysis alone: default to behavior-adjacent.
 
 ### Severity guide


### PR DESCRIPTION
## Summary

**BUG-O — doctor.js**: `skill-allowed-tools` check used `content.includes('Playwright')` which flagged any skill mentioning "Playwright" as a test framework name in prose. The intent is to catch skills that invoke Playwright MCP tools (`browser_*`). Detection now checks only for `browser_` invocations.

**BUG-P — skill-dev SKILL.md**: regression risk field on line 285 cited `Vitest/Playwright` as example test frameworks — breaks stack-agnosticity on native projects (Swift, Kotlin, etc.). Replaced with `existing automated tests` in both tier M and tier L templates.

## Test plan

- [x] 233/233 integration checks pass
- [x] `doctor --report` no longer warns on skill-dev for native stack projects

Identified during Round 5 scaffold validation on mac-transcription-collector (Swift/macOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)