### PR TITLE
fix(templates): perf-audit HAS_FRONTEND interpolation + BUNDLE_TOOL native + skill-dev severity guide

### DIFF
--- a/packages/cli/src/scaffold/index.js
+++ b/packages/cli/src/scaffold/index.js
@@ -317,5 +317,5 @@ function interpolate(content, config) {
     .replace(/\[FRAMEWORK\]/g, ['swift', 'kotlin', 'rust', 'dotnet'].includes(config.techStack) ? 'N/A — native app' : config.hasFrontend === false ? 'N/A — no web frontend' : 'your frontend framework')
     .replace(/\[SITEMAP_OR_ROUTE_LIST\]/g, config.hasFrontend === false ? 'N/A — no web frontend' : 'docs/sitemap.md')
     .replace(/\[API_ROUTES_PATH\]/g, config.hasApi === false ? 'N/A — no API routes' : 'src/app/api/')
-    .replace(/\[BUNDLE_TOOL\]/g, 'your build tool\'s bundle analyzer');
+    .replace(/\[BUNDLE_TOOL\]/g, ['swift', 'kotlin', 'rust', 'dotnet', 'java'].includes(config.techStack) ? 'N/A — native app' : 'your build tool\'s bundle analyzer');
 }

--- a/packages/cli/templates/tier-l/.claude/skills/perf-audit/SKILL.md
+++ b/packages/cli/templates/tier-l/.claude/skills/perf-audit/SKILL.md
@@ -23,7 +23,7 @@ Before any other step: read `CLAUDE.md` and check the Framework and Language fie
 
   > **perf-audit** targets web applications (Core Web Vitals, bundle composition, server/client boundaries). This project uses a native stack. Use platform-native profiling tools instead: Instruments (Swift/macOS/iOS), Android Studio Profiler (Kotlin/Android), Valgrind/perf (C/C++).
 
-- If `[HAS_FRONTEND]` is `false`: output the same message and stop.
+- If the CLAUDE.md Framework field is `N/A — no web frontend`: output the same message and stop.
 - If the project is a web application: proceed to Step 1.
 
 

--- a/packages/cli/templates/tier-l/.claude/skills/skill-dev/SKILL.md
+++ b/packages/cli/templates/tier-l/.claude/skills/skill-dev/SKILL.md
@@ -288,8 +288,8 @@ Each entry **must** include a `Regression risk` field:
 ### Severity guide
 
 - **Critical**: `@ts-ignore` on a security/data path; N+1 in a hot path (list page or dashboard); floating promise on an auth or data-write event handler
-- **High**: `any` in shared lib utilities; `useEffect` missing dependency array (D9C); dead export in shared lib; empty catch on DB write; missing `'use server'` on exported Server Action (J3)
-- **Medium**: `useEffect` derived-state antipattern (D9A); over-large component >300 lines with 4+ responsibilities (J1); `'use client'` at page level when only a subcomponent needs it (J3); magic business-rule numbers (D6); console.log in production (D10); data clumps >3 always-grouped props (J2)
+- **High**: `any` in shared lib utilities; dead export in shared lib; empty catch on DB write; unhandled error on async data-write path
+- **Medium**: over-large module >300 lines with 4+ responsibilities (J1); magic business-rule numbers (D6); console.log in production (D10); data clumps >3 always-grouped props (J2)
 - **Low**: TODO comments; minor coupling; consolidation opportunities; magic enum strings already covered by type definitions; D4 sampled dead exports
 
 ---

--- a/packages/cli/templates/tier-m/.claude/skills/perf-audit/SKILL.md
+++ b/packages/cli/templates/tier-m/.claude/skills/perf-audit/SKILL.md
@@ -23,7 +23,7 @@ Before any other step: read `CLAUDE.md` and check the Framework and Language fie
 
   > **perf-audit** targets web applications (Core Web Vitals, bundle composition, server/client boundaries). This project uses a native stack. Use platform-native profiling tools instead: Instruments (Swift/macOS/iOS), Android Studio Profiler (Kotlin/Android), Valgrind/perf (C/C++).
 
-- If `[HAS_FRONTEND]` is `false`: output the same message and stop.
+- If the CLAUDE.md Framework field is `N/A — no web frontend`: output the same message and stop.
 - If the project is a web application: proceed to Step 1.
 
 

--- a/packages/cli/templates/tier-m/.claude/skills/skill-dev/SKILL.md
+++ b/packages/cli/templates/tier-m/.claude/skills/skill-dev/SKILL.md
@@ -288,8 +288,8 @@ Each entry **must** include a `Regression risk` field:
 ### Severity guide
 
 - **Critical**: `@ts-ignore` on a security/data path; N+1 in a hot path (list page or dashboard); floating promise on an auth or data-write event handler
-- **High**: `any` in shared lib utilities; `useEffect` missing dependency array (D9C); dead export in shared lib; empty catch on DB write; missing `'use server'` on exported Server Action (J3)
-- **Medium**: `useEffect` derived-state antipattern (D9A); over-large component >300 lines with 4+ responsibilities (J1); `'use client'` at page level when only a subcomponent needs it (J3); magic business-rule numbers (D6); console.log in production (D10); data clumps >3 always-grouped props (J2)
+- **High**: `any` in shared lib utilities; dead export in shared lib; empty catch on DB write; unhandled error on async data-write path
+- **Medium**: over-large module >300 lines with 4+ responsibilities (J1); magic business-rule numbers (D6); console.log in production (D10); data clumps >3 always-grouped props (J2)
 - **Low**: TODO comments; minor coupling; consolidation opportunities; magic enum strings already covered by type definitions; D4 sampled dead exports
 
 ---


### PR DESCRIPTION
## Summary

**BUG-Q-a** — `perf-audit/SKILL.md` applicability check used `[HAS_FRONTEND]` as an interpolatable token inside narrative prose. After scaffold on a no-frontend project it produced `"If \`false\` is \`false\`"` — malformed and confusing. Replaced with an explicit check on the CLAUDE.md Framework field value (`N/A — no web frontend`), which is already set correctly by the wizard.

**BUG-Q-b** — `scaffold/index.js`: `[BUNDLE_TOOL]` resolved to `"your build tool's bundle analyzer"` for all stacks including native (Swift, Kotlin, Rust, .NET, Java). Now resolves to `"N/A — native app"` for those stacks, consistent with the existing `[FRAMEWORK]` treatment.

**BUG-R** — `skill-dev/SKILL.md` Severity guide (tier M + L): listed D9/J3 React/Next.js-specific examples (`useEffect`, `'use client'`, `'use server'`) under High and Medium severity. These checks are already excluded by the Applicability check, but remained visible as canonical severity references regardless of stack. Replaced with stack-agnostic examples.

## Test plan

- [x] 233/233 integration checks pass
- [x] Verified on scaffolded mac-transcription-collector (Swift/macOS) — perf-audit applicability text clean, no `false is false`

Identified in Round 5 scaffold audit (checks 2.3 PARTIAL and 2.7 FAIL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)