### PR TITLE
fix(templates): context-review C13 — replace literal ... in memory path

### DIFF
--- a/packages/cli/templates/common/context-review.md
+++ b/packages/cli/templates/common/context-review.md
@@ -148,7 +148,7 @@ Compare the filename with the "Last synced: migration `NNN_*.sql`" line at the t
 **Run**: `wc -l CLAUDE.md` to check line count first. If < 100 lines AND fewer than 4 blocks since last C13 ran → skip and mark ✅.
 
 **For each entry that fails the filter** (it's a schema fact, historical note, or something Claude would recover from reading the code):
-- Move the full content to an appropriate memory topic file in `~/.claude/projects/.../memory/`
+- Move the full content to an appropriate memory topic file in `~/.claude/projects/<project-path-hash>/memory/` (run `ls ~/.claude/projects/` to find your project hash)
 - Remove the entry from CLAUDE.md Known Patterns
 - Add or update a pointer in MEMORY.md if the topic file is new
 


### PR DESCRIPTION
## Summary

Third and final instance of `~/.claude/projects/.../memory/` with literal `...` in `context-review.md`.

- C2 (line 25): fixed in PR #32
- C4 (line 45): fixed in PR #35
- C13 (line 151): fixed here

Same pattern applied: `<project-path-hash>` placeholder + `ls ~/.claude/projects/` discovery hint.

## Test plan

- [x] 233/233 integration checks pass
- [x] `grep "projects/\.\.\." context-review.md` returns 0 matches

Identified in Round 5 scaffold audit (check 4.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)