### PR TITLE
chore(release): bump version to v1.6.1 + sync docs post round 5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,4 +71,4 @@ node packages/cli/test/integration/run.js
 - Both updated as mandatory final step after every round of changes (standing rule)
 
 ## Current Version
-`v1.6.0` — conditional docs scaffold (sitemap/db-map Tier M+L) + staff-manager→CDK skill sync (29 templates). `pruneConditionalDocs()` prunes sitemap/db-map when `hasFrontend`/`hasDatabase` false. 29 template files upgraded via 4-level agnosticity filter. 194 integration checks.
+`v1.6.1` — native stack polish pass (Swift/Kotlin/Rust/.NET/Java). Stop hook guard, arch-audit timer path, native command defaults, perf-audit/skill-dev applicability checks, dependency-scanner native patterns, context-review path fixes, doctor Playwright detection fix. 233 integration checks.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ npx mg-claude-dev-kit doctor --report # JSON output for CI pipelines
 npx mg-claude-dev-kit doctor --ci     # silent mode: exit 1 if any check fails
 ```
 
-19 checks: Claude CLI, CLAUDE.md present + size, settings.json, Stop hook configured + no unfilled placeholder, pipeline.md, security.md, .env in .gitignore, no secrets in CLAUDE.md, CODEOWNERS, output-style.md, claudemd-standards.md, pipeline-standards.md, commit skill, skills with allowed-tools frontmatter, context-review.md includes C12.
+17 checks: Claude CLI, CLAUDE.md present + size, settings.json, Stop hook configured + no unfilled placeholder, pipeline.md, security.md, .env in .gitignore, no secrets in CLAUDE.md, CODEOWNERS, output-style.md (tier M/L), docs/claudemd-standards.md (tier M/L), docs/pipeline-standards.md (tier M/L), commit skill (tier M/L), skills with allowed-tools frontmatter, context-review.md includes C12. Checks 12–16 are skipped (pass/skip) for Tier 0 projects.
 
 `--report` outputs machine-readable JSON — consumable by CI pipelines and external audit systems. Each check returns `id`, `status` (pass / warn / fail / skip), and `fix` message.
 
@@ -316,7 +316,9 @@ Full operational guide for your team: [`docs/operational-guide.docs`](docs/opera
 
 ## Status
 
-`v1.6.0` — conditional docs scaffold (sitemap/db-map) + staff-manager→CDK skill sync. Integration tests 186 → 194.
+`v1.6.1` — native stack polish pass (Swift/Kotlin/Rust/.NET/Java). Integration tests 194 → 233.
+
+**v1.6.1 changes**: native stack scaffold validated end-to-end via 5-round audit on a Swift/macOS project. Fixes: Stop hook `stop_hook_active` guard added to all tiers (PR#32); arch-audit timestamp moved from unreliable external path to `.claude/session/last-arch-audit` (PR#32/33); `perf-audit` applicability check added — exits cleanly for native apps instead of running web-only checks; `skill-dev` applicability check added — skips React/Next.js-specific checks (D9, J3) on non-web stacks; `dependency-scanner` Check 1 extended with Swift native navigation patterns (`NavigationLink`, `.sheet()`, `fullScreenCover()`); `CLAUDE.md` Key Commands no longer defaults to `npm test`/`npm install` for native stacks — uses platform-appropriate defaults (`xcodebuild test`, `cargo test`, `dotnet test`, etc.); `skill-dev` Severity guide made stack-agnostic (removed `useEffect`/`'use client'`/`'use server'` examples); `perf-audit` applicability check no longer interpolates `[HAS_FRONTEND]` as a boolean literal in narrative text; `context-review.md` all three `...` path instances replaced with `<project-path-hash>` + `ls ~/.claude/projects/` hint (C2, C4, C13); doctor Playwright detection narrowed to actual `browser_*` MCP tool invocations only. +39 integration checks (233 total).
 
 **v1.6.0 changes**: `docs/sitemap.md` and `docs/db-map.md` added as Tier M+L scaffold templates, pruned conditionally when `hasFrontend=false` / `hasDatabase=false` via new `pruneConditionalDocs()`; `printPlan` updated to show these files conditionally and remove phantom `docs/dependency-map.md`. 29 template files upgraded (common rules + 11 skills across Tier M/L, 2 skills in Tier S) via a 4-level agnosticity-filtered sync from an internal pilot project — L1 lexical, L2 structural, L3 CDK File/Placeholder Registry, L3b CDK Pattern Recognition, L4 conditional; domain tokens stripped, CDK Configuration placeholders preserved. +8 integration checks (194 total).
 

--- a/docs/operational-guide.docs
+++ b/docs/operational-guide.docs
@@ -1,7 +1,7 @@
 
 # claude-dev-kit — Operational Guide
 
-**Version**: 1.5.0
+**Version**: 1.6.1
 **Audience**: Builder PMs, tech leads, and development teams using Claude Code — from first exploration to structured, reviewable delivery
 **Format**: Reference + step-by-step. Read section 1 and your target tier section first, then use it as a lookup.
 
@@ -1463,7 +1463,7 @@ npx mg-claude-dev-kit doctor --report  # JSON compliance output for CI pipelines
 npx mg-claude-dev-kit doctor --ci      # silent mode: exit 1 if any check fails
 ```
 
-Runs 19 checks and reports pass/fail:
+Runs 17 checks and reports pass/fail:
 
 1. Claude Code CLI is installed and reachable
 2. `CLAUDE.md` is present
@@ -1474,16 +1474,16 @@ Runs 19 checks and reports pass/fail:
 7. `.env` files are covered by `.gitignore`
 8. No secrets (API keys, tokens) found in `CLAUDE.md`
 9. Stop hook is configured with a non-empty command
-10. `.github/CODEOWNERS` covers `.claude/`
-11. Stop hook command has no unfilled `[TEST_COMMAND]` placeholder
+10. Stop hook command has no unfilled `[TEST_COMMAND]` placeholder
+11. `.github/CODEOWNERS` covers `.claude/`
 12. `.claude/rules/output-style.md` present (tier M/L — warn if missing)
-13. `.claude/rules/claudemd-standards.md` present (tier M/L — warn if missing)
-14. `.claude/rules/pipeline-standards.md` present (tier M/L — warn if missing)
+13. `docs/claudemd-standards.md` present (tier M/L — warn if missing)
+14. `docs/pipeline-standards.md` present (tier M/L — warn if missing)
 15. `.claude/skills/commit/` present (tier M/L — warn if missing)
-16. Skills using Playwright declare `allowed-tools` frontmatter (warn if missing)
+16. Skills invoking Playwright `browser_*` tools declare `allowed-tools` frontmatter (warn if missing)
 17. `.claude/rules/context-review.md` includes C12 (warn if not present — upgrade needed)
-18. (checks 12–17 are skipped with `pass/skip` when the project has no `pipeline.md` — i.e. Tier 0)
-19. (reserved for future checks)
+
+Checks 12–17 are skipped (`pass/skip`) for Tier 0 projects (no `pipeline.md`).
 
 **`--report` output format** — machine-readable JSON consumed by CI systems or external audit tools:
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mg-claude-dev-kit",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Scaffold for legible, reviewable AI-assisted development",
   "type": "module",
   "bin": {

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -9,7 +9,7 @@ import chalk from 'chalk';
 program
   .name('claude-dev-kit')
   .description('Scaffold for legible, reviewable AI-assisted development')
-  .version('1.6.0');
+  .version('1.6.1');
 
 program
   .command('init')


### PR DESCRIPTION
## Summary

Version bump and doc sync following the 5-round native stack validation campaign (PRs #32–#39).

**Version**: `1.6.0` → `1.6.1` in `package.json`, `index.js`, `CLAUDE.md`

**README:**
- Doctor check count: 19 → 17 (accurate count with correct paths)
- Integration tests: 194 → 233
- Added `v1.6.1` Status entry documenting all native stack fixes

**operational-guide.docs:**
- Version header: 1.5.0 → 1.6.1
- Doctor check list updated: 17 checks, correct paths (`docs/claudemd-standards.md` not `.claude/rules/`), Playwright detection narrowed to `browser_*` MCP tools

**CLAUDE.md:**
- Current Version section updated with v1.6.1 summary and 233 integration checks

## Test plan

- [x] 233/233 integration checks pass
- [x] `npx /path/to/cli --version` returns `1.6.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)