### PR TITLE
feat(scaffold): stack-aware content specialization v1.7.0

### DIFF
--- a/.claude/initiatives/workspace-quality-rubric.md
+++ b/.claude/initiatives/workspace-quality-rubric.md
@@ -1,0 +1,172 @@
+# Workspace Quality Rubric — Session File
+
+**Branch**: `feat/workspace-quality-rubric`
+**Started**: 2026-04-03
+**Status**: Phase 1 - Research in progress
+**Model**: Opus 4.6 (research + rubric definition phases)
+
+---
+
+## Obiettivo
+
+Definire un rubric riutilizzabile per valutare la qualità di qualsiasi workspace AI scaffoldato (indipendente dallo stack), con le seguenti proprietà:
+
+- Applicabile a qualsiasi progetto (non CDK-specific)
+- Basato su criteri oggettivi e misurabili
+- Usabile come baseline per validazioni ripetute (ogni round di scaffolding)
+- Prima applicazione: mac-transcription-collector (Swift/macOS, Tier M, CDK v1.6.1)
+
+**Scope**: Qualità strutturale + qualità del contenuto dei file workspace AI. Non solo "i file ci sono" (quello lo fa già doctor + audit-22check) ma "i file danno a Claude le informazioni giuste per lavorare efficacemente sul progetto".
+
+---
+
+## Valutazione Iniziale (2026-04-03)
+
+### Cosa regge nell'impostazione
+
+Il bisogno è reale. Il ciclo audit attuale (25 check) è autoreferenziale: CDK valida i propri template contro i propri test. Un metro esterno è più obiettivo. La sequenza "prima criteri, poi validazione" è corretta.
+
+### Tre problemi identificati nell'impostazione originale
+
+**1. "Progetti simili" come fonte di criteri - bassa resa.**
+CDK è inusuale: multi-tier governance scaffold su Claude Code. Sul web si trovano cursor rules repos, CLAUDE.md community examples, blog posts Anthropic. Nessuno copre governance pipelines, STOP gates, skills-as-files. La ricerca esterna darebbe criteri generici.
+
+Fonti più utili:
+- Anthropic documentation ufficiale su CLAUDE.md e Claude Code
+- Principi di design già incorporati in CDK (decisioni prese e perché)
+- Analisi di cosa serve effettivamente a Claude per lavorare su un progetto
+
+**2. Target ambiguo - due oggetti distinti:**
+- Output su mac-transcription-collector: i file scaffoldati sono utili e corretti per quel progetto specifico?
+- Template CDK: i template producono output di qualità per qualsiasi stack?
+
+Round 5 ha validato l'integrità strutturale (file presenti, placeholder risolti). Manca la valutazione del contenuto.
+
+**3. "Miglioramento incrementale continuo" = framework vivo, non deliverable di sessione.**
+Separare: prima rubric usabile ora, poi decidere se diventa processo ricorrente.
+
+---
+
+## Informazioni Acquisite
+
+### Stato corrente CDK (v1.6.1)
+
+- 4 tier: 0 (Discovery), S (Fast Lane), M (Standard), L (Full)
+- Doctor: 17 check di integrità strutturale
+- Audit 25 check: valida template resolution, stop hooks, pipeline gates, placeholder risolti
+- Integration tests: 233 check
+- Round 5 su mac-transcription-collector: 24/25 PASS (check 5.2 e 6.3 sono user-side, non CDK bugs)
+
+### Copertura attuale degli audit (cosa già misuriamo)
+
+| Categoria | Coverage attuale |
+|-----------|-----------------|
+| File presenti (struttura) | PASS - doctor + audit |
+| Placeholder risolti | PASS - audit check 2.x |
+| Stop hook presente e funzionale | PASS - audit check 3.x |
+| Pipeline gate count | PASS - audit check 1.x |
+| Comandi nativi corretti (no npm fallback) | PASS - integration tests v1.6.1 |
+| Playwright detection false positive | FIXED - v1.6.1 |
+| Contenuto CLAUDE.md (qualità informativa) | NON MISURATO |
+| Qualità skills (usabilità, completezza) | NON MISURATO |
+| Qualità rules (efficacia, specificità) | NON MISURATO |
+| Pipeline steps (chiarezza, actionability) | NON MISURATO |
+| Coerenza cross-file | NON MISURATO |
+
+### Gap identificato
+
+L'audit corrente è **strutturale e meccanico**. Manca una dimensione **qualitativa e semantica**: i file non solo ci sono e hanno i placeholder risolti, ma *funzionano* come workspace AI?
+
+---
+
+## Piano Esecutivo — Opzione A: Rubric Riutilizzabile
+
+### Fase 1 - Research (Opus 4.6)
+
+**Obiettivo**: raccogliere fonti esterne autorevoli per ancorare il rubric
+
+Fonti da esaminare:
+1. Anthropic official docs su CLAUDE.md best practices
+2. Claude Code documentation su memory, commands, hooks
+3. Community patterns (cursor.directory, GitHub Copilot workspace conventions)
+4. Analisi dei principi CDK già documentati in README + operational-guide
+
+**Deliverable**: lista annotata di fonti + principi estratti, salvata in questo file (sezione "Research Output")
+
+### Fase 2 - Definizione Dimensioni (Opus 4.6)
+
+Identificare le dimensioni di valutazione. Draft iniziale:
+
+| Dimensione | Descrizione |
+|-----------|-------------|
+| **D1 - Project Identity** | CLAUDE.md descrive il progetto in modo che Claude possa rispondere a "chi sono, cosa faccio, per chi" |
+| **D2 - Tech Grounding** | Stack, comandi, framework specificati e corretti per il progetto reale |
+| **D3 - Workflow Clarity** | Pipeline/processo di sviluppo definito, con gate e checkpoint chiari |
+| **D4 - Rules Effectiveness** | Rules sono specifiche, actionable, non generiche |
+| **D5 - Skills Completeness** | Skills coprono i task ripetitivi rilevanti per lo stack |
+| **D6 - Context Hygiene** | Memory, context-review, files-guide permettono a Claude di avere contesto aggiornato |
+| **D7 - Safety Guards** | Stop hooks, STOP gates, review points proteggono da azioni irreversibili |
+| **D8 - Cross-file Coherence** | I file si riferiscono l'uno all'altro in modo consistente (no path broken, no contradictions) |
+
+**Deliverable**: dimensioni finalizzate con descrizione e criteri di scoring
+
+### Fase 3 - Scoring System (Opus 4.6)
+
+Per ogni dimensione, definire:
+- Criteri di valutazione (cosa osservare)
+- Scala: 0 (assente/inutilizzabile), 1 (parziale), 2 (adeguato), 3 (eccellente)
+- Esempi concreti per ogni livello (basati su CDK output reale)
+
+**Deliverable**: rubric completo come documento standalone (`docs/workspace-quality-rubric.md`)
+
+### Fase 4 - Validazione del Rubric (Opus 4.6)
+
+Prima di applicarlo a mac-transcription-collector:
+- Il rubric è applicabile a uno stack non-Swift (test su progetto noto)?
+- I criteri sono oggettivi (stesso valutatore, stesso score)?
+- Le dimensioni coprono tutto il gap identificato nella tabella sopra?
+
+### Fase 5 - Prima Run (→ Opzione B)
+
+Applicare il rubric a mac-transcription-collector come first run ufficiale.
+Output: gap list + piano azioni prioritizzato (vedere sezione Opzione B).
+
+---
+
+## Opzione B — Validazione mac-transcription-collector (To Be)
+
+**Prerequisito**: Rubric Opzione A completato e validato.
+
+**Oggetto**: scaffold CDK v1.6.1, Tier M, Swift/macOS, in-place init su progetto esistente
+
+**Output atteso**:
+- Score per ogni dimensione D1-D8
+- Gap list: cosa manca, cosa è generico, cosa è errato per il progetto specifico
+- Action plan prioritizzato: P1 (blocca l'utilità), P2 (riduce qualità), P3 (nice-to-have)
+- Delta: cosa deve cambiare nel progetto vs cosa deve cambiare nei template CDK
+
+**Nota**: alcune gap saranno user-side (Discovery pass non completato, CLAUDE.md Tech Stack vuoto — check 5.2 Round 5). Il rubric deve distinguere gap CDK da gap user.
+
+---
+
+## Research Output
+
+*(da compilare in Fase 1)*
+
+---
+
+## Rubric Draft
+
+*(da compilare in Fase 3)*
+
+---
+
+## Checkpoint Corrente
+
+- [x] Branch `feat/workspace-quality-rubric` creato
+- [x] File di sessione creato con struttura completa
+- [ ] Fase 1: Research - da eseguire con Opus 4.6
+- [ ] Fase 2: Dimensioni finalizzate
+- [ ] Fase 3: Rubric completo
+- [ ] Fase 4: Validazione rubric
+- [ ] Fase 5: Prima run su mac-transcription-collector (Opzione B)

--- a/.claude/initiatives/workspace-quality-rubric.md
+++ b/.claude/initiatives/workspace-quality-rubric.md
@@ -151,13 +151,435 @@ Output: gap list + piano azioni prioritizzato (vedere sezione Opzione B).
 
 ## Research Output
 
-*(da compilare in Fase 1)*
+### Fonte 1: Anthropic Official Documentation
+
+**URLs verificate**:
+- `code.claude.com/docs/en/memory` - CLAUDE.md reference page
+- `code.claude.com/docs/en/best-practices` - workspace best practices
+- `code.claude.com/docs/en/context-window` - context budget visualization
+- `code.claude.com/docs/en/hooks` - hooks vs CLAUDE.md distinction
+- `code.claude.com/docs/en/skills` - skills as demand-loaded context
+
+**Principi estratti**:
+
+| ID | Principio | Fonte |
+|----|-----------|-------|
+| A1 | **Size discipline**: CLAUDE.md ≤ 200 righe. File più lunghi causano istruzioni ignorate - l'aderenza degrada con la dimensione | memory docs + best-practices |
+| A2 | **Specificity over vagueness**: istruzioni concrete e verificabili ("Use 2-space indentation" non "Format code properly") | memory docs |
+| A3 | **Signal-to-noise**: includere solo ciò che Claude non può inferire dal codice. Se Claude fa già la cosa giusta senza l'istruzione, rimuoverla | best-practices |
+| A4 | **No contradictions**: regole in conflitto tra file causano comportamento arbitrario. Review periodica obbligatoria | memory docs |
+| A5 | **Separation of concerns**: CLAUDE.md = contesto persistente, rules/ = istruzioni path-scoped, skills = workflow on-demand, hooks = enforcement deterministico | hooks docs + skills docs |
+| A6 | **Emphasis tuning**: "IMPORTANT" o "YOU MUST" migliora l'aderenza su regole critiche | best-practices |
+| A7 | **Verification is highest-leverage**: includere test, screenshot, output atteso per auto-verifica di Claude | best-practices |
+| A8 | **Treat it like code**: versionare, revieware quando le cose vanno male, potare regolarmente, testare osservando se il comportamento cambia | best-practices |
+| A9 | **Context is the constraint**: ogni token in CLAUDE.md compete con file reads, tool outputs e conversazione. CLAUDE.md caricato come user message a bassa priorità | context-window docs |
+| A10 | **Import for scale**: usare `@path` imports per mantenere CLAUDE.md conciso referenziando docs dettagliati | memory docs |
+
+### Fonte 2: Anthropic Engineering Blog
+
+**URL**: `anthropic.com/engineering/effective-context-engineering-for-ai-agents`
+
+| ID | Principio | Dettaglio |
+|----|-----------|-----------|
+| B1 | **Goldilocks zone**: istruzioni specifiche abbastanza da guidare, flessibili abbastanza da fornire euristiche. No logica if-else rigida, no guidance vaga | Blog post |
+| B2 | **Examples over exhaustive rules**: esempi canonici e diversificati valgono più di mille parole di regole | Blog post |
+| B3 | **Context rot**: l'accuratezza decresce con l'aumento dei token per limiti dell'architettura transformer | Blog post |
+| B4 | **Structure with markup**: sezioni distinte con XML/Markdown headers per leggibilità | Blog post |
+
+### Fonte 3: Community Patterns (cross-tool)
+
+**Strumenti confrontati**: Cursor (.cursorrules), GitHub Copilot (.github/copilot-instructions.md), Claude Code (CLAUDE.md), Windsurf, Cline, Aider
+
+| ID | Principio | Convergenza |
+|----|-----------|-------------|
+| C1 | **Tech stack declaration**: tutti i tool beneficiano di stack + versioni esplicite | Tutti i tool |
+| C2 | **Actionable over aspirational**: "be specific" è il consiglio più comune cross-tool | Cursor + Copilot + Claude Code |
+| C3 | **File path conventions**: definire dove vanno i file, come si chiamano | Cursor (forte), Claude Code (files-guide) |
+| C4 | **Anti-patterns explicit**: dire cosa NON fare è efficace quanto dire cosa fare | Cursor community, CDK output-style |
+| C5 | **Size budget per tool**: ogni tool ha un context budget - le istruzioni devono starci dentro | Tutti i tool |
+| C6 | **Version control the config**: AI workspace files = codice, committati nel repo | Tutti i tool |
+
+### Fonte 4: Principi CDK interni (README + operational-guide + templates)
+
+**Principi di qualità già codificati in CDK**:
+
+| ID | Principio | Dove codificato |
+|----|-----------|-----------------|
+| D1 | **Legibility**: lavoro visibile, auditabile, reviewable | README core statement |
+| D2 | **Reversibility**: ogni azione significativa reversibile in minuti | README + STOP gates |
+| D3 | **Traceability**: decisioni AI discoverable nella git history con attribution | README + commit skill |
+| D4 | **Specification before code**: docs-first (Phase 1 → Phase 2) | pipeline.md Tier M/L |
+| D5 | **Tiered complexity**: overhead di processo scala con blast radius | 4-tier architecture |
+| D6 | **Mechanical → Structured → Judgment**: tre livelli di qualità verificabili | doctor → context-review → STOP gates |
+| D7 | **13 context-review checks (C1-C13)**: secret hygiene, schema currency, path accuracy, duplication, canonical docs sync | context-review.md |
+| D8 | **9 CLAUDE.md standards (S1-S9)**: density ≤200, content filter, specific language, progressive disclosure, hook enforcement | claudemd-standards.md |
+| D9 | **9 pipeline standards (S1-S9)**: phase gates, testing pyramid, security checklist, docs-first, conventional commits | pipeline-standards.md |
+| D10 | **Information hierarchy**: file diversi caricati in momenti diversi (session start vs Phase 0 vs Phase 1 vs on-demand) | files-guide.md |
+
+### Sintesi: 5 meta-principi convergenti
+
+Dalla ricerca emergono 5 principi trasversali a tutte le fonti:
+
+1. **Context economy** (A1, A3, A9, B3, C5): lo spazio è finito - ogni token deve guadagnarsi il posto
+2. **Specificity** (A2, A6, B1, C2, C4): istruzioni concrete, verificabili, con esempi - mai vaghe
+3. **Separation of concerns** (A5, A10, C3, D5, D10): informazione giusta nel posto giusto, caricata al momento giusto
+4. **Verifiability** (A7, A8, D6, D7): regole che possono essere testate, non solo dichiarate
+5. **Coherence** (A4, B4, D7-D9): nessuna contraddizione cross-file, struttura consistente
 
 ---
 
-## Rubric Draft
+## Azioni Future (fuori scope rubric)
 
-*(da compilare in Fase 3)*
+- **Scaffoldare `.claude/commands/README.md`** in Tier M/L: spiega cosa sono i commands, quando usarli vs skills, come crearne uno. No file di esempio finti.
+- **Non scaffoldare `agents/`**: pattern non documentato ufficialmente da Anthropic. Monitorare.
+- **Menzionare `agents/` in files-guide.md** (Tier M/L): una riga come pattern emergente.
+
+---
+
+## Dimensioni Confermate (Fase 2)
+
+| Dim | Nome | Cosa valuta | Meta-principio |
+|-----|------|-------------|----------------|
+| **D1** | Project Identity | CLAUDE.md risponde a "cos'è, cosa fa, per chi" - Claude può navigare il progetto senza chiedere | Specificity |
+| **D2** | Tech Grounding | Stack, comandi build/test/lint, dipendenze chiave - corretti per il progetto reale | Specificity |
+| **D3** | Workflow Clarity | Pipeline/fasi con gate espliciti. Claude sa cosa fare a ogni step e quando fermarsi | Verifiability |
+| **D4** | Rules Effectiveness | Rules specifiche, actionable, no vagueness. Sicurezza, output-style, project-specific | Specificity + Verifiability |
+| **D5** | Skills Completeness | Skills coprono task ripetitivi per lo stack. Frontmatter corretto, allowed-tools dichiarati. Meccanismo giusto per ogni tipo di automazione | Separation of concerns |
+| **D6** | Context Economy | CLAUDE.md ≤ 200 righe. No duplicazione. Info nel file giusto (CLAUDE.md vs rules vs skills vs commands vs memory). Imports usati dove serve | Context economy |
+| **D7** | Safety Guards | Stop hooks configurati e funzionali. STOP gates nel pipeline. Review points per azioni irreversibili | Verifiability |
+| **D8** | Cross-file Coherence | Path references validi, nessuna contraddizione, nomi consistenti, tier boundaries rispettate | Coherence |
+
+---
+
+## Rubric v1.0
+
+**Documento completo**: `docs/workspace-quality-rubric.md`
+
+Struttura del rubric:
+- 8 dimensioni (D1-D8) con pesi differenziati (1x-2x)
+- Scala 0-3 per dimensione con definizioni precise ed esempi concreti
+- Score normalizzato 0-100 (weighted sum / 30 x 100)
+- Gap attribution: Tool-side (T), User-side (U), Design-side (D)
+- Red flags per dimensione
+- Score sheet template compilabile
+- Interpretation guide (5 fasce: Unusable → Excellent)
+- Action priority (P1 blocks utility → P3 optimization)
+
+Ancoraggi:
+- Anthropic official docs (A1-A10)
+- Context engineering blog (B1-B4)
+- Community cross-tool patterns (C1-C6)
+- CDK internal principles (D1-D10)
+
+---
+
+## Fase 4 - Validazione
+
+### Test 1: Applicabilità non-CDK
+**Risultato**: PASS con riserva. Il rubric è applicabile a qualsiasi workspace ma D4/D5/D6/D7 hanno un ceiling implicito a score 2 per tool senza skills/hooks/path-scoped rules. Aggiunta nota "Tool ceiling" al rubric.
+
+### Test 2: Oggettività criteri
+**Risultato**: PASS con 2 fix applicati.
+- D6.2 (removal test): reso meccanico con test a due step (1. info reperibile da file standard? 2. rimozione causa errore specifico e nominabile?)
+- D4.5 (self-evident rules): annotato che la baseline dipende dal modello AI
+
+Criteri residui con margine interpretativo accettabile: D3.5 (scales), D8.3 (contradictions). Non risolvibili completamente senza over-engineering.
+
+### Test 3: Copertura gap
+**Risultato**: PASS completo. 5/5 gap "NON MISURATO" dalla tabella Coverage sono coperti:
+- Contenuto CLAUDE.md → D1 + D2
+- Qualità skills → D5
+- Qualità rules → D4
+- Pipeline steps → D3
+- Coerenza cross-file → D8
+
+---
+
+## Fase 5 — Prima Run: mac-transcription-collector
+
+**Project**: mac-transcription-collector
+**Date**: 2026-04-03
+**Evaluator**: Claude Opus 4.6
+**Workspace tool**: CDK v1.6.1
+**Tier**: M (Standard)
+**Stack**: Swift/macOS (Xcode project)
+
+---
+
+### D1 — Project Identity | Score: 0 | Weight: 1.0 | Weighted: 0.0
+
+**Evidence**:
+- CLAUDE.md line 4: `[One paragraph: what the product does, who uses it, what problem it solves.]` - placeholder, never filled
+- No project purpose, no target user, no domain terminology
+- Project name is the only identity signal
+
+**Criteria breakdown**:
+- 1.1 Project purpose: FAIL - placeholder
+- 1.2 Target user: FAIL - not stated
+- 1.3 Scope boundaries: FAIL - not stated
+- 1.4 Domain terminology: FAIL - not applicable content to evaluate
+
+**Red flags triggered**: Placeholder text present. No mention of what the project does.
+
+**Attribution**: **User-side (U)** - CDK produced the template correctly, user did not fill it in.
+
+---
+
+### D2 — Tech Grounding | Score: 1 | Weight: 1.0 | Weighted: 1.0
+
+**Evidence**:
+- CLAUDE.md Tech Stack (lines 7-14): all fields are placeholders (`[e.g. Next.js 15, Express...]`)
+- Key Commands (lines 30-37): partially filled - `swift run`, `xcodebuild build`, `xcodebuild test` are correct. But line 36 has `N` (literal placeholder for E2E) which is the correct CDK sentinel value
+- Pipeline Phase 3 (lines 130-132): correctly uses `xcodebuild build` and `xcodebuild test` - matches CLAUDE.md
+- Stop hook in settings.json: `xcodebuild test` - correct, matches
+
+**Criteria breakdown**:
+- 2.1 Tech stack: FAIL - all placeholder except commands
+- 2.2 Commands runnable: PARTIAL - swift/xcodebuild commands are correct but Tech Stack section empty
+- 2.3 Stack-specific conventions: FAIL - line 40-43 still has `[Italian / English / other]` and `[Other non-obvious conventions.]`
+- 2.4 Dependencies match: CANNOT VERIFY - no tech stack declared to compare against
+
+**Attribution**: Mixed - **User-side (U)** for unfilled Tech Stack section. **Tool-side (T, minor)** for the Key Commands section having an unexplained `N` sentinel that reads like a broken value to a new user.
+
+---
+
+### D3 — Workflow Clarity | Score: 3 | Weight: 1.5 | Weighted: 4.5
+
+**Evidence**:
+- pipeline.md: 282 lines, 8 phases + cross-cutting rules
+- Phase 0 (session orientation) with CONTEXT_IMPORT check
+- Phase 1 STOP gate with Mode A/B auto-selection
+- Phase 1.5 conditional design review
+- Phase 6 STOP gate with outcome checklist
+- Phase 8.5 context review (C1-C12)
+- Fast lane routing (Tier S for low blast radius)
+- Tier 1/Tier 2 scope sweep with concrete dimension checklists
+- Execution keywords defined and enforced
+- Cross-cutting rules: never commit to main, green before commit, conventional commits
+
+**Criteria breakdown**:
+- 3.1 Phases defined: PASS - 8 phases with clear entry/exit criteria
+- 3.2 Human review points: PASS - 2 STOP gates + Phase 1.5 conditional + Phase 8.5
+- 3.3 Scope before implementation: PASS - Phase 1 mandatory scope sweep
+- 3.4 Completion criteria: PASS - Phase 6 checklist with actual results
+- 3.5 Complexity scaling: PASS - Tier S/M/L routing, Mode A/B auto-selection
+
+**Red flags triggered**: none.
+
+**Attribution**: **Tool-side positive** - CDK template produces an excellent pipeline for Tier M.
+
+---
+
+### D4 — Rules Effectiveness | Score: 2 | Weight: 1.0 | Weighted: 2.0
+
+**Evidence**:
+- 5 rules files (619 lines total): pipeline.md, security.md, output-style.md, git.md, context-review.md
+- security.md: 6-point checklist, specific to API/auth/DB code, verifiable pass/fail
+- output-style.md: 74 lines, concrete forbidden patterns with replacements
+- git.md: branch naming, commit format, never-commit list
+- context-review.md: 13 checks (C1-C13) with explicit pass/fail criteria
+
+**Criteria breakdown**:
+- 4.1 Specific and verifiable: PASS - "Auth check must be first operation" is verifiable
+- 4.2 Security coverage: PARTIAL - security.md covers web API patterns (auth, SQL injection, RLS). For a Swift/macOS app without web APIs, some rules are inapplicable (RLS, API routes). No macOS-specific security rules (sandbox entitlements, keychain, TCC permissions)
+- 4.3 Organized by concern: PASS - 5 separate files
+- 4.4 Critical rules use emphasis: PASS - "never", "must be the first", bolded constraints
+- 4.5 No self-evident rules: PASS - no "write clean code" type rules found
+
+**Deduction rationale**: security.md assumes a web API stack. A Swift/macOS desktop app has a different attack surface (entitlements, local file access, App Sandbox, keychain). The rules are high quality but partially mismatched to the stack.
+
+**Attribution**: **Tool-side (T)** - CDK's security.md template is web-oriented. Missing: stack-specific security rule generation for native apps.
+
+---
+
+### D5 — Skills Completeness | Score: 2 | Weight: 1.0 | Weighted: 2.0
+
+**Evidence**:
+- 5 skills: arch-audit, commit, perf-audit, security-audit, skill-dev
+- 1 agent: dependency-scanner (correctly placed in agents/)
+- commit skill: correctly configured, no placeholders, model: haiku
+- arch-audit: correctly configured, fetches Anthropic docs
+- perf-audit: has applicability check for native apps - will correctly bail out with "use Instruments instead" message
+- security-audit: references `docs/sitemap.md` for target resolution - sitemap doesn't exist in this project (was scaffolded empty in docs/ but not created)
+- skill-dev: correctly configured, generic (stack-agnostic)
+
+**Criteria breakdown**:
+- 5.1 Repetitive tasks automated: PASS - commit, audit suite present
+- 5.2 Configured for stack: PARTIAL - perf-audit correctly handles native bail-out. security-audit assumes web routes. No Swift-specific skills (Instruments profiling, xctest patterns)
+- 5.3 Right mechanism: PASS - skills for auto-triggered, agent for dependency scan
+- 5.4 Dependencies declared: PASS - skills declare model, context, effort
+
+**Deduction rationale**: skills are well-structured but web-centric. perf-audit handles the mismatch gracefully (bail-out). security-audit does not - it will try to audit "API routes" on a macOS desktop app.
+
+**Attribution**: **Tool-side (T)** - CDK scaffolds web-oriented audit skills without stack-aware filtering (except perf-audit which was fixed in v1.6.1).
+
+---
+
+### D6 — Context Economy | Score: 2 | Weight: 1.5 | Weighted: 3.0
+
+**Evidence**:
+- CLAUDE.md: 74 lines (under 200 hard limit, under 100 optimal - PASS)
+- Rules separated by concern (5 files in rules/)
+- Skills demand-loaded (5 skills, not in CLAUDE.md)
+- Agent persona in agents/ (not loaded at startup)
+- No @-imports used (none needed at current size)
+- files-guide.md: 11,471 bytes - reference doc explaining file hierarchy
+
+**Criteria breakdown**:
+- 6.1 Size budget: PASS - 74 lines, well under both thresholds
+- 6.2 Removal test: PARTIAL - the unfilled placeholder sections in CLAUDE.md (Overview, Tech Stack, RBAC, Workflows, Known Patterns, Environment) consume ~40 lines of pure noise. Claude reads template comments and placeholders every session for zero benefit
+- 6.3 Right file type: PASS - good separation between CLAUDE.md / rules / skills / agents
+- 6.4 No duplication: PASS - no duplicate content found across files
+- 6.5 Progressive disclosure: PARTIAL - no @-imports used, but not needed at current scale. Path-scoped rules not used (output-style.md has `description:` frontmatter but no `paths:` - loads every session even for non-prose tasks)
+
+**Deduction rationale**: the unfilled placeholders are negative-value content. 40+ lines of `[placeholder]` text loaded every session. Until filled, these sections should ideally not exist.
+
+**Attribution**: Mixed - **User-side (U)** for not filling placeholders. **Design-side (D)** - CDK could generate CLAUDE.md with placeholder sections commented out or excluded until user fills them, rather than shipping visible placeholders that consume context budget.
+
+---
+
+### D7 — Safety Guards | Score: 3 | Weight: 2.0 | Weighted: 6.0
+
+**Evidence**:
+- Stop hook: `xcodebuild test` - correct command, not a placeholder, 300s timeout
+- `stop_hook_active` guard present (conditional bypass for non-test phases)
+- permissions.deny: force push, push to main, rm -rf, DROP TABLE, TRUNCATE
+- .gitignore: `.env`, `.env.local`, `.env.*.local`, `.env.production`, `*.pem`, `*.key`, `secrets/`, `credentials/`
+- PostToolUse audit hook: logs Write/Edit/Bash calls to `~/.claude/audit/`
+- SessionStart: audit logging + arch-audit overdue check
+- StopFailure: logged to audit
+- Pipeline: 2 STOP gates (Phase 1, Phase 6) + Phase 1.5 conditional
+- context-review.md C1: grep for token patterns (sk_live_, sbp_, re_)
+- Cross-cutting rule: "Never commit to main or staging directly"
+
+**Criteria breakdown**:
+- 7.1 Test enforcement: PASS - stop hook with real command
+- 7.2 Destructive ops blocked: PASS - deny list covers force push, DB drops
+- 7.3 Secrets protected: PASS - comprehensive .gitignore, C1 check
+- 7.4 Human review for shared-state: PASS - push to main denied, STOP gates
+- 7.5 Correct test command: PASS - `xcodebuild test` matches stack
+
+**Red flags triggered**: none.
+
+**Attribution**: **Tool-side positive** - CDK produces excellent safety configuration. Native command (`xcodebuild test`) correctly resolved.
+
+---
+
+### D8 — Cross-file Coherence | Score: 2 | Weight: 1.0 | Weighted: 2.0
+
+**Evidence**:
+- Test command consistency: `xcodebuild test` in CLAUDE.md (line 34), settings.json (stop hook), pipeline.md (Phase 3 line 132) - all match
+- Build command consistency: `xcodebuild build` in CLAUDE.md (line 33), pipeline.md (line 131) - match
+- Dev command: `swift run` in CLAUDE.md (line 32), pipeline.md Phase 5c (line 170) - match
+- Reference docs: CLAUDE.md references `docs/requirements.md`, `docs/implementation-checklist.md`, `docs/refactoring-backlog.md`, `docs/adr/` - all exist on disk
+- Pipeline references `docs/specs/` - exists (with archive/ subdir)
+- Pipeline Phase 3b references `[API_TESTS_PATH]` - unresolved placeholder
+- Pipeline Phase 4 references `N` as E2E command - correct sentinel for "not configured"
+- permissions.allow includes `Bash(node:*)`, `Bash(npm:*)`, `Bash(npx:*)` - irrelevant for a Swift project (no node/npm in this project)
+- security-audit skill references `docs/sitemap.md` - file does not exist
+
+**Criteria breakdown**:
+- 8.1 Path references valid: PARTIAL - most valid, security-audit → sitemap.md broken
+- 8.2 Commands consistent: PASS - xcodebuild test/build/swift run match everywhere
+- 8.3 No contradictions: PASS - no conflicting rules found
+- 8.4 Tier-appropriate: PASS - Tier M features only
+- 8.5 Skill/doc references: PARTIAL - `[API_TESTS_PATH]` unresolved in pipeline, permissions.allow has node/npm for a Swift project
+
+**Deduction rationale**: minor coherence issues. The node/npm permissions are harmless but signal that the workspace wasn't fully adapted to the native stack. The `[API_TESTS_PATH]` placeholder in pipeline Phase 3b is an unresolved artifact.
+
+**Attribution**: **Tool-side (T)** - CDK scaffolds node/npm permissions by default even for Swift projects. `[API_TESTS_PATH]` should be resolved or the Phase 3b section should be conditional.
+
+---
+
+### Score Summary
+
+```
+Project: mac-transcription-collector
+Date: 2026-04-03
+Evaluator: Claude Opus 4.6
+Workspace tool: CDK v1.6.1
+Tier: M (Standard)
+
+| Dim | Score (0-3) | Weight | Weighted | Key gaps                              | Attribution |
+|-----|-------------|--------|----------|---------------------------------------|-------------|
+| D1  | 0           | 1.0    | 0.0      | All placeholder, no project identity  | U           |
+| D2  | 1           | 1.0    | 1.0      | Tech Stack empty, conventions empty   | U + T minor |
+| D3  | 3           | 1.5    | 4.5      | None                                  | —           |
+| D4  | 2           | 1.0    | 2.0      | Security rules web-oriented           | T           |
+| D5  | 2           | 1.0    | 2.0      | Skills web-oriented                   | T           |
+| D6  | 2           | 1.5    | 3.0      | Placeholder noise in CLAUDE.md        | U + D       |
+| D7  | 3           | 2.0    | 6.0      | None                                  | —           |
+| D8  | 2           | 1.0    | 2.0      | node/npm perms, API_TESTS_PATH        | T           |
+|-----|-------------|--------|----------|---------------------------------------|-------------|
+| TOT |             | 10.0   | 20.5/30  |                                       | 68%         |
+
+Final score: (20.5 / 30) x 100 = 68% — Functional
+```
+
+**Interpretation**: workspace works for routine tasks. Gaps in project identity (user-side: unfilled), stack-specific adaptation (tool-side: web-oriented defaults), and minor cross-file coherence issues.
+
+---
+
+### Gap List — Prioritized Actions
+
+#### P1 — Blocks utility (fix immediately)
+
+| # | Gap | Attribution | Action |
+|---|-----|-------------|--------|
+| P1.1 | CLAUDE.md Overview is placeholder | U | Fill: what mac-transcription-collector does, who uses it, what problem it solves |
+| P1.2 | CLAUDE.md Tech Stack all placeholder | U | Fill: Swift, macOS, Xcode, any frameworks (SwiftUI/AppKit), data persistence layer |
+
+#### P2 — Reduces quality (fix soon)
+
+| # | Gap | Attribution | Action |
+|---|-----|-------------|--------|
+| P2.1 | security.md assumes web API stack | T | Create macOS-specific security rules: App Sandbox entitlements, keychain access patterns, TCC permissions, local file access validation |
+| P2.2 | Placeholder noise in CLAUDE.md (~40 lines) | U + D | Fill remaining sections or remove unfilled placeholder sections to save context budget |
+| P2.3 | Coding Conventions still placeholder | U | Fill: Swift naming conventions, UI language, project-specific rules |
+| P2.4 | security-audit skill assumes web routes | T | Add applicability check for native apps (similar to perf-audit's bail-out) |
+
+#### P3 — Optimization (nice-to-have)
+
+| # | Gap | Attribution | Action |
+|---|-----|-------------|--------|
+| P3.1 | permissions.allow includes node/npm/npx | T | Replace with Swift-native: `Bash(swift:*)`, `Bash(xcodebuild:*)`, `Bash(xcrun:*)` |
+| P3.2 | `[API_TESTS_PATH]` unresolved in pipeline Phase 3b | T | Resolve or make Phase 3b conditional on API presence |
+| P3.3 | security-audit references non-existent docs/sitemap.md | T | Make sitemap.md reference conditional |
+| P3.4 | No Swift-specific skills (Instruments, xctest patterns) | D | Consider adding native-stack skills in future CDK version |
+
+#### Delta: CDK template changes vs user actions
+
+| Action | Owner | Scope |
+|--------|-------|-------|
+| Fill CLAUDE.md placeholder sections | User | P1.1, P1.2, P2.2, P2.3 |
+| Stack-aware permissions.allow (no node/npm for Swift) | CDK | P3.1 |
+| security-audit applicability check for native apps | CDK | P2.4 |
+| security.md native-stack variant | CDK | P2.1 |
+| Conditional API_TESTS_PATH / Phase 3b | CDK | P3.2 |
+| Conditional sitemap.md references in skills | CDK | P3.3 |
+
+---
+
+## Fase 6 — Stack-aware Content Specialization (Completata)
+
+**Origine**: riflessione post-rubric. Il wizard rileva lo stack, ma il dato veniva usato solo per i comandi (livello 2). I file di governance restavano web-oriented nel contenuto semantico (livello 3). Il rubric ha quantificato il gap: D4 e D5 perdevano un punto su stack nativi.
+
+**Principio applicato**: CDK resta stack-agnostic nella struttura e nel workflow. Content specialization aggiunta nei file dove lo stack determina il contenuto.
+
+**Implementato**:
+
+| Intervento | File modificati | Dettaglio |
+|-----------|-----------------|-----------|
+| security.md varianti | `templates/common/rules/security-native-apple.md`, `security-native-android.md`, `security-systems.md` + `security.md` (web, invariato) | 4 varianti: web (default), native-apple (Swift), native-android (Kotlin), systems (Rust/Go/.NET/Java senza API) |
+| Selezione variante | `scaffold/index.js` → `securityRuleVariant()` | Seleziona in base a `techStack` + `hasApi`. Output sempre come `security.md` |
+| permissions.deny | `scaffold/index.js` → `patchSettingsPermissions()` | Deny stack-specific: xcodebuild archive, cargo publish, gradlew publish, mvn deploy, gem push, twine upload, dotnet nuget push |
+| CLAUDE.md auto-population | `scaffold/index.js` + `generators/claude-md.js` | `[FRAMEWORK_VALUE]` e `[LANGUAGE_VALUE]` risolti automaticamente da wizard data |
+| security-audit applicability | `templates/tier-m/.claude/skills/security-audit/SKILL.md` + tier-l | Bail-out per native apps senza API (completato in P2) |
+
+**Non implementato (fuori scope, come pianificato)**:
+- Nuovi skill stack-specific (Instruments, Android Profiler)
+- Pipeline varianti per stack (workflow correttamente agnostico)
+- detect-stack.js stack family export (non necessario: logica diretta in securityRuleVariant)
 
 ---
 
@@ -165,8 +587,18 @@ Output: gap list + piano azioni prioritizzato (vedere sezione Opzione B).
 
 - [x] Branch `feat/workspace-quality-rubric` creato
 - [x] File di sessione creato con struttura completa
-- [ ] Fase 1: Research - da eseguire con Opus 4.6
-- [ ] Fase 2: Dimensioni finalizzate
-- [ ] Fase 3: Rubric completo
-- [ ] Fase 4: Validazione rubric
-- [ ] Fase 5: Prima run su mac-transcription-collector (Opzione B)
+- [x] Fase 1: Research completata
+- [x] Fase 2: Dimensioni confermate (D1-D8)
+- [x] Fase 3: Rubric v1.0 completato (`docs/workspace-quality-rubric.md`)
+- [x] Fase 4: Validazione rubric (3/3 test passed, 3 fix applicati)
+- [x] Fase 5: Prima run su mac-transcription-collector — score 68% (Functional)
+- [x] Fase 5b: P1-P3 completati — integration tests 233/233 PASS
+  - P1: CLAUDE.md mac-transcription-collector compilato (Overview, Tech Stack, Conventions, Environment)
+  - P2: security-audit applicability check aggiunto (tier-m + tier-l) — bail-out per stack nativi senza API
+  - P3: stack-aware permissions.allow via patchSettingsPermissions() — 8 stack mappati (swift, kotlin, rust, dotnet, java, ruby, go, python)
+- [x] Fix: CLAUDE.md auto-population — Framework e Language risolti automaticamente da wizard data (interpolate + generateClaudeMd). Fallback per framework non rilevato: italic hint. Native stacks: "N/A — native app". 233/233 tests PASS.
+- [x] Fase 6: Stack-aware Content Specialization — completata
+  - security.md: 4 varianti (web default, native-apple, native-android, systems) selezionate da securityRuleVariant() in base a techStack + hasApi
+  - permissions.deny: stack-specific deny entries aggiunti (xcodebuild archive, cargo publish, gradlew publish, mvn deploy, gem push, twine upload, dotnet nuget push)
+  - CLAUDE.md auto-population: Framework e Language risolti da wizard data
+  - Integration tests: 249/249 PASS (16 nuovi check: 12 security variant selection + 4 deny verification)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Run before every release to validate all tier/mode combinations:
 node packages/cli/test/integration/run.js
 # Add --verbose for per-check output
 ```
-194 checks: file structure per tier, Stop hook presence and resolution, pipeline gate counts, wizard placeholder resolution, safe-mode preservation, new named stacks (swift/kotlin/rust/dotnet/ruby/java), conditional docs pruning (sitemap.md, db-map.md), full CLI execution via `--answers` fixtures (9 scenarios). Output is gitignored (`packages/cli/test/integration/output/`).
+249 checks: file structure per tier, Stop hook presence and resolution, pipeline gate counts, wizard placeholder resolution, safe-mode preservation, new named stacks (swift/kotlin/rust/dotnet/ruby/java), conditional docs pruning (sitemap.md, db-map.md), security rule variant selection (6 stack/API combinations + leak check + deny verification), full CLI execution via `--answers` fixtures (9 scenarios). Output is gitignored (`packages/cli/test/integration/output/`).
 
 ## Interaction Protocol
 **Perimeter questions** (scope, vision, user, future): always use the `AskUserQuestion` tool — never present as inline text. Max 4 questions per call, each with 2–4 options. Open-ended questions get representative options + "Other" for custom input.
@@ -71,4 +71,4 @@ node packages/cli/test/integration/run.js
 - Both updated as mandatory final step after every round of changes (standing rule)
 
 ## Current Version
-`v1.6.1` — native stack polish pass (Swift/Kotlin/Rust/.NET/Java). Stop hook guard, arch-audit timer path, native command defaults, perf-audit/skill-dev applicability checks, dependency-scanner native patterns, context-review path fixes, doctor Playwright detection fix. 233 integration checks.
+`v1.7.0` — stack-aware content specialization. Security rule variants (web/native-apple/native-android/systems), stack-specific permissions.deny, CLAUDE.md Framework/Language auto-population, security-audit applicability check, workspace quality rubric. 249 integration checks.

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ your-project/
 │   ├── rules/
 │   │   ├── pipeline.md             ← development workflow (tier-appropriate)
 │   │   ├── context-review.md       ← end-of-block compliance checklist (C1–C12)
-│   │   ├── security.md             ← path-scoped: API/auth files only
+│   │   ├── security.md             ← stack-aware: web / native-apple / native-android / systems
 │   │   ├── git.md                  ← commit format, branch rules
 │   │   ├── output-style.md         ← communication rules (no openers, plain vocabulary)
 │   │   ├── claudemd-standards.md   ← CLAUDE.md hygiene standards (S1–S9)
@@ -255,15 +255,20 @@ This is present in **every tier**, including Tier 0. It is the only mechanically
 
 **AI commit attribution** — every Claude-assisted commit tagged: `Co-authored-by: Claude <noreply@anthropic.com>`
 
-### Path-scoped rules
+### Stack-aware security rules
 
-Security rules load only when Claude works on API/auth files — zero context cost during UI work:
-```yaml
----
-paths: ["src/api/**", "lib/auth*"]
----
-# These rules are invisible when not relevant
-```
+The scaffold selects a security.md variant matched to your tech stack:
+
+| Variant | Stacks | Focus |
+|---|---|---|
+| Web (default) | Node.js, Python, Ruby, Go/Java/.NET with API | Auth, SQL injection, RLS, API responses |
+| Native Apple | Swift | App Sandbox, Keychain, TCC permissions, code signing |
+| Native Android | Kotlin | Manifest permissions, Keystore, network security, ProGuard |
+| Systems | Rust, Go, .NET, Java (no API) | Memory safety, process exec, file permissions |
+
+### Stack-aware permissions
+
+`permissions.allow` maps CLI tools to your stack (e.g. Swift gets `xcodebuild`, `xcrun`; Rust gets `cargo`). `permissions.deny` adds stack-specific release guards (e.g. `cargo publish`, `xcodebuild archive`, `gem push`) on top of the base protections (force push, `rm -rf /`, `DROP TABLE`).
 
 ---
 
@@ -299,6 +304,29 @@ Architectural decisions become persistent constraints Claude respects across ses
 
 ---
 
+## Supported stacks
+
+CDK auto-detects your tech stack and adapts the scaffold: commands, security rules, permissions, and CLAUDE.md fields are all stack-aware.
+
+| Stack | Detection | Security variant | CLAUDE.md Language |
+|---|---|---|---|
+| Node.js + TypeScript | `tsconfig.json` or `typescript` dep | Web | TypeScript |
+| Node.js + JavaScript | `package.json` without TS | Web | JavaScript |
+| Python | `pyproject.toml`, `requirements.txt`, `setup.py` | Web | Python |
+| Go | `go.mod` | Web or Systems | Go |
+| Swift | `Package.swift`, `.xcodeproj`, `.xcworkspace` | Native Apple | Swift |
+| Kotlin | `build.gradle.kts`, `build.gradle` (Android) | Native Android | Kotlin |
+| Rust | `Cargo.toml` | Web or Systems | Rust |
+| .NET / C# | `*.csproj`, `*.sln` | Web or Systems | C# |
+| Ruby | `Gemfile` | Web | Ruby |
+| Java | `pom.xml`, `build.gradle` | Web or Systems | Java |
+
+"Web or Systems" stacks use the web variant when `hasApi=true` and the systems variant when `hasApi=false`.
+
+Framework is auto-detected from dependencies (Next.js, Remix, SvelteKit, Vite, Express, Fastify, Hono, Django, FastAPI/Flask, Rails). When detected, it is auto-populated in CLAUDE.md. Native stacks show "N/A - native app".
+
+---
+
 ## Requirements
 
 - Node.js ≥ 18
@@ -316,7 +344,9 @@ Full operational guide for your team: [`docs/operational-guide.docs`](docs/opera
 
 ## Status
 
-`v1.6.1` — native stack polish pass (Swift/Kotlin/Rust/.NET/Java). Integration tests 194 → 233.
+`v1.7.0` — stack-aware content specialization. Security rules, permissions, and CLAUDE.md fields adapt to your tech stack. Integration tests 233 → 249.
+
+**v1.7.0 changes**: security.md now selects from 4 variants based on tech stack: web (default), native-apple (Swift - App Sandbox, Keychain, TCC), native-android (Kotlin - Manifest, Keystore, network security), systems (Rust/Go/.NET/Java without API - memory safety, process execution, file permissions). `permissions.deny` adds stack-specific release guards: `xcodebuild archive`, `cargo publish`, `gradlew publish`, `mvn deploy`, `gem push`, `twine upload`, `dotnet nuget push`. CLAUDE.md `Framework` and `Language` fields auto-populated from wizard data - no more placeholder text for fields CDK can resolve. `security-audit` skill has applicability check for native apps: bail-out with native-specific guidance when project has no API routes. New `docs/workspace-quality-rubric.md` - reusable 8-dimension rubric for evaluating AI workspace quality (D1-D8, weighted scoring 0-100%). +16 integration checks (249 total).
 
 **v1.6.1 changes**: native stack scaffold validated end-to-end via 5-round audit on a Swift/macOS project. Fixes: Stop hook `stop_hook_active` guard added to all tiers (PR#32); arch-audit timestamp moved from unreliable external path to `.claude/session/last-arch-audit` (PR#32/33); `perf-audit` applicability check added — exits cleanly for native apps instead of running web-only checks; `skill-dev` applicability check added — skips React/Next.js-specific checks (D9, J3) on non-web stacks; `dependency-scanner` Check 1 extended with Swift native navigation patterns (`NavigationLink`, `.sheet()`, `fullScreenCover()`); `CLAUDE.md` Key Commands no longer defaults to `npm test`/`npm install` for native stacks — uses platform-appropriate defaults (`xcodebuild test`, `cargo test`, `dotnet test`, etc.); `skill-dev` Severity guide made stack-agnostic (removed `useEffect`/`'use client'`/`'use server'` examples); `perf-audit` applicability check no longer interpolates `[HAS_FRONTEND]` as a boolean literal in narrative text; `context-review.md` all three `...` path instances replaced with `<project-path-hash>` + `ls ~/.claude/projects/` hint (C2, C4, C13); doctor Playwright detection narrowed to actual `browser_*` MCP tool invocations only. +39 integration checks (233 total).
 

--- a/docs/operational-guide.docs
+++ b/docs/operational-guide.docs
@@ -528,10 +528,16 @@ Scaffolded by the CLI for Tier M and Tier L. A practical guide to the first bloc
 
 The primary project context file. Claude reads it at the start of every session.
 
-**What to put in it:**
+**Auto-populated fields** (filled by the scaffold from wizard/detection data):
+- **Project name** — from wizard input
+- **Tech Stack Summary** — from detected stack (e.g. "Node.js + TypeScript", "Swift / macOS")
+- **Framework** — auto-detected from dependencies (e.g. "Next.js", "Django"). Shows "N/A - native app" for Swift/Kotlin/Rust/.NET/Java. Shows an italic hint when not detected.
+- **Language** — derived from tech stack (e.g. "TypeScript", "Python", "Swift", "C#")
+- **Key Commands** — from wizard input or native defaults (e.g. `xcodebuild test` for Swift)
+
+**What to fill in manually:**
 - Project overview (2–4 sentences)
-- Tech stack with specific versions
-- Key commands: install, dev, build, test, type check, migration (if applicable), E2E (if applicable — `# not configured` if none)
+- Database, Auth, Storage, Email, Deploy fields
 - Folder conventions (where routes live, where utilities live)
 - Naming conventions (casing, file naming)
 - Known non-obvious patterns (things Claude would get wrong without being told)
@@ -576,6 +582,20 @@ Permissions and hooks. Five hooks are pre-configured in Tier M/L (three in Tier 
 
 **Do not disable the Stop hook** unless running a dry-run or documentation-only task.
 
+**Stack-aware permissions**: `permissions.allow` is set to stack-appropriate CLI tools at scaffold time. `permissions.deny` includes base protections (force push, `rm -rf /`, `DROP TABLE`, `TRUNCATE`) plus stack-specific release/publish commands:
+
+| Stack | Allow | Deny (additions) |
+|---|---|---|
+| Node.js (default) | git, node, npm, npx, curl | — |
+| Swift | git, swift, xcodebuild, xcrun, curl | xcodebuild archive, xcrun altool --upload-app |
+| Kotlin | git, gradlew, gradle, curl | gradlew publish |
+| Rust | git, cargo, rustc, curl | cargo publish |
+| .NET | git, dotnet, curl | dotnet nuget push |
+| Java | git, mvn, gradlew, gradle, curl | mvn deploy, gradlew publish |
+| Ruby | git, bundle, rails, rake, curl | gem push |
+| Python | git, python, pip, uv, curl | twine upload |
+| Go | git, go, curl | — |
+
 **`includeGitInstructions: false`** — the built-in Claude Code git instructions are suppressed in Tier M/L. `pipeline.md` and `git.md` cover this more precisely for your project.
 
 ---
@@ -596,9 +616,18 @@ You can add project-specific overrides at the bottom of this file. Example:
 
 ### .claude/rules/security.md
 
-Path-scoped security rules. These load only when Claude works on files matching `src/api/**` or `lib/auth*`. Zero context cost during UI work.
+Stack-aware security rules. The scaffold selects the appropriate variant based on your tech stack:
 
-Contains: auth check requirements, input validation rules, RLS/ACL checklist, headers to include.
+| Variant | Stacks | Focus areas |
+|---|---|---|
+| **Web** (default) | Node.js, Python, Ruby, Go/Java/.NET with API | Auth checks, input validation, SQL injection, RLS/ACL, API response security, HTTP headers |
+| **Native Apple** | Swift | App Sandbox entitlements, Keychain access, TCC permissions (camera, mic, files), Data Protection, code signing |
+| **Native Android** | Kotlin | Manifest permissions, Android Keystore, EncryptedSharedPreferences, network security config, ProGuard |
+| **Systems** | Rust, Go, .NET, Java (without API) | Memory safety, process execution, file permissions, input validation at system boundaries, dependency auditing |
+
+Selection logic: Swift always gets native-apple, Kotlin always gets native-android. Rust/Go/.NET/Java get the systems variant when `hasApi=false`, otherwise the web variant. All other stacks get the web variant.
+
+The output file is always named `security.md` regardless of which variant was selected.
 
 ---
 
@@ -759,6 +788,8 @@ Add to `.claude/settings.json`:
 **File**: `.claude/skills/security-audit/SKILL.md`
 **Backlog prefix**: `SEC-n`
 **Run when**: shipping a new API route, after an auth refactor, or as a quarterly hygiene check.
+
+**Applicability check**: before starting, the skill reads CLAUDE.md and checks the Framework and Language fields. If the project is a native application (Swift, Kotlin, Objective-C, C++, desktop GUI) with no API routes (`[HAS_API]` is `false`), it outputs a native-specific guidance message and stops. Projects with API routes proceed normally regardless of stack.
 
 #### Placeholders to configure
 

--- a/docs/workspace-quality-rubric.md
+++ b/docs/workspace-quality-rubric.md
@@ -1,0 +1,355 @@
+# Workspace Quality Rubric v1.0
+
+A reusable rubric for evaluating the quality of any AI-assisted development workspace - the set of files that give an AI coding assistant (Claude Code, Cursor, Copilot, etc.) the context it needs to work effectively on a project.
+
+## How to use this rubric
+
+**Scope**: evaluate the workspace configuration files (CLAUDE.md, rules, skills, settings, pipeline definitions, context files). Not the application code itself.
+
+**Scale**: each dimension is scored 0-3.
+
+| Score | Meaning |
+|-------|---------|
+| 0 | Absent or unusable - the dimension is not addressed |
+| 1 | Partial - some coverage but with significant gaps or generic content |
+| 2 | Adequate - functional, project-specific, minor gaps |
+| 3 | Excellent - specific, verified, no wasted tokens, actively maintained |
+
+**Weights**: not all dimensions matter equally.
+
+| Dimension | Weight | Rationale |
+|-----------|--------|-----------|
+| D1 Project Identity | 1x | Foundational but easy to achieve |
+| D2 Tech Grounding | 1x | Correct commands = minimum viable workspace |
+| D3 Workflow Clarity | 1.5x | Process definition is the core governance value |
+| D4 Rules Effectiveness | 1x | Rule quality drives behavior quality |
+| D5 Skills Completeness | 1x | Stack-dependent, not always applicable |
+| D6 Context Economy | 1.5x | Context budget is the #1 constraint (Anthropic docs) |
+| D7 Safety Guards | 2x | Mistakes here cause irreversible damage |
+| D8 Cross-file Coherence | 1x | Structural integrity of the workspace |
+
+**Total score**: sum of (dimension score x weight) / (3 x sum of weights) x 100 = percentage.
+
+With these weights: max raw = 3 x (1+1+1.5+1+1+1.5+2+1) = 3 x 10 = 30. Score = (raw / 30) x 100.
+
+**Tool ceiling note**: score 3 on D4, D5, D6, and D7 requires Claude Code-specific features (skills/, hooks, path-scoped rules). Workspaces using other tools (Cursor, Copilot, Windsurf) have an effective ceiling of 2 on these dimensions. Maximum achievable score for non-Claude-Code workspaces is ~77%.
+
+**Gap attribution**: for each gap found, mark whether it is:
+- **Tool-side** (T) - the scaffolding tool produced incorrect or generic output
+- **User-side** (U) - the user has not completed required customization (e.g., placeholders unfilled)
+- **Design-side** (D) - the workspace design is missing a capability
+
+---
+
+## D1 - Project Identity
+
+**Weight**: 1x
+
+**What it measures**: can the AI assistant answer "what is this project, what does it do, who is it for" without asking the user?
+
+### Criteria
+
+| # | Criterion | How to verify |
+|---|-----------|---------------|
+| 1.1 | Project purpose stated in 1-2 sentences | Read CLAUDE.md opening section. Is there a concrete description or a placeholder? |
+| 1.2 | Target user or audience identified | Stated explicitly or inferable from context |
+| 1.3 | Project scope boundaries clear | The AI can determine what is in-scope vs out-of-scope for this project |
+| 1.4 | Domain terminology defined (if applicable) | Non-obvious terms explained, or pointer to glossary |
+
+### Scoring
+
+| Score | Definition | Example |
+|-------|------------|---------|
+| 0 | No project description, or only the project name | `# my-app` with no further context |
+| 1 | Generic description that could apply to many projects | "A web application built with modern technologies" |
+| 2 | Specific description with purpose, audience, and key domain concepts | "Invoice management SaaS for freelancers. Core entities: invoice, client, payment. Multi-currency support via Stripe." |
+| 3 | Score 2 + scope boundaries + non-obvious domain rules stated | Score 2 plus "Out of scope: tax calculation (handled by external service). Key constraint: invoices are immutable after send." |
+
+### Red flags
+- Placeholder text still present (`[PROJECT_NAME]`, `[describe your project]`)
+- Description copied from package.json or README without adaptation
+- No mention of what the project actually does (only tech stack listed)
+
+---
+
+## D2 - Tech Grounding
+
+**Weight**: 1x
+
+**What it measures**: are the technology stack, build commands, and development workflow correctly specified for the actual project?
+
+### Criteria
+
+| # | Criterion | How to verify |
+|---|-----------|---------------|
+| 2.1 | Tech stack listed with specific technologies (not just categories) | "Next.js 14 + TypeScript" not "frontend framework" |
+| 2.2 | Key commands are runnable | Execute install, dev, build, test commands - do they work? |
+| 2.3 | Stack-specific conventions stated | Naming conventions, file structure patterns, framework idioms relevant to this stack |
+| 2.4 | Dependencies and tools mentioned match what is actually installed | package.json / Podfile / Cargo.toml matches CLAUDE.md claims |
+
+### Scoring
+
+| Score | Definition | Example |
+|-------|------------|---------|
+| 0 | No tech stack information, or commands are placeholders | `[INSTALL_COMMAND]` still present |
+| 1 | Tech stack listed but commands are wrong, generic, or incomplete | Lists "React" but test command runs `npm test` when project uses `vitest` |
+| 2 | Tech stack correct, commands work, basic conventions stated | Stack, commands, and "use functional components, prefer server components" all accurate |
+| 3 | Score 2 + stack-specific gotchas documented + native tooling commands (not generic fallbacks) | Score 2 plus "SwiftUI previews require macOS 14+. Use `swift test --filter` for targeted runs. XCTest assertions, not third-party." |
+
+### Red flags
+- npm commands in a Swift/Rust/Go project (wrong ecosystem)
+- Commands that fail when executed
+- Framework version mismatch between CLAUDE.md and actual project
+- Generic "run tests" without the actual command
+
+---
+
+## D3 - Workflow Clarity
+
+**Weight**: 1.5x
+
+**What it measures**: does the workspace define a development process with clear phases, gates, and stopping points so the AI knows what to do at each step and when to pause for human review?
+
+### Criteria
+
+| # | Criterion | How to verify |
+|---|-----------|---------------|
+| 3.1 | Development phases are defined (not just "write code and test") | A pipeline, checklist, or phase sequence exists |
+| 3.2 | Human review points are explicit | STOP gates, confirmation keywords, or equivalent pause mechanisms |
+| 3.3 | Scope definition happens before implementation | Some form of "agree on what to build before building it" |
+| 3.4 | Completion criteria are stated | How does the AI (and user) know when a task is done? |
+| 3.5 | Process scales to task complexity | Different workflows for trivial fixes vs complex features, or clear escalation rules |
+
+### Scoring
+
+| Score | Definition | Example |
+|-------|------------|---------|
+| 0 | No workflow defined - the AI operates in freeform mode | No pipeline, no rules about process, no review points |
+| 1 | Basic workflow exists but lacks gates or completion criteria | "Plan, implement, test" without stopping points or scope confirmation |
+| 2 | Multi-phase workflow with at least 1 explicit human review gate and clear completion criteria | 4+ phases with scope confirmation before coding, test gate before done, outcome checklist |
+| 3 | Score 2 + complexity-based routing + intermediate checkpoints + documentation gates | Full pipeline with fast-lane for small changes, STOP gates at scope + outcome, intermediate commits, docs updated before closure |
+
+### Red flags
+- No mention of when to stop and ask the user
+- "Just do it" workflow with no review points
+- Pipeline exists but has no enforcement mechanism (no hooks, no keywords)
+- All tasks follow the same heavyweight process (no fast lane)
+
+---
+
+## D4 - Rules Effectiveness
+
+**Weight**: 1x
+
+**What it measures**: are the rules (instructions, constraints, conventions) specific enough to change the AI's behavior, and do they cover the project's actual risk areas?
+
+### Criteria
+
+| # | Criterion | How to verify |
+|---|-----------|---------------|
+| 4.1 | Rules are specific and verifiable | Each rule can be checked pass/fail (not "write good code") |
+| 4.2 | Security rules cover the project's attack surface | Auth, input validation, secrets, data exposure - appropriate to the stack |
+| 4.3 | Rules are organized by concern (not one giant file) | Separate files for security, style, git conventions, etc. |
+| 4.4 | Critical rules use emphasis markers | MUST, NEVER, IMPORTANT on rules where violation causes real damage |
+| 4.5 | No self-evident rules that waste context budget | "Write clean code", "follow best practices", "use descriptive variable names" are absent. Note: what is "self-evident" depends on the AI model's baseline behavior - evaluate against current frontier models. |
+
+### Scoring
+
+| Score | Definition | Example |
+|-------|------------|---------|
+| 0 | No rules, or only the default CLAUDE.md with no project-specific rules | Empty `.claude/rules/` or no rules directory |
+| 1 | Some rules exist but are vague, generic, or not organized | Single file mixing security, style, and process rules. "Always test your code." |
+| 2 | Rules are specific, organized by concern, cover security basics | Separate security.md with auth-first rule, input validation requirement. output-style.md with concrete constraints. |
+| 3 | Score 2 + rules are verifiable with examples + critical rules use emphasis + no wasted rules | Security checklist with 5 concrete checks per API route. Style rules with specific forbidden patterns and replacements. Zero "write clean code" type rules. |
+
+### Red flags
+- "Be careful with security" (vague)
+- Rules that Claude already follows by default (wasted tokens)
+- Contradictory rules across files
+- Security rules missing for a project that handles auth, payments, or PII
+
+---
+
+## D5 - Skills Completeness
+
+**Weight**: 1x
+
+**What it measures**: does the workspace provide reusable workflows (skills, commands, or equivalent) for the project's repetitive tasks, and are they correctly configured for the stack?
+
+### Criteria
+
+| # | Criterion | How to verify |
+|---|-----------|---------------|
+| 5.1 | Repetitive tasks have defined automation | Commit workflow, audit checks, deployment - appropriate to the project's complexity |
+| 5.2 | Skills/commands are configured for the actual stack | No placeholder configuration values, correct tool references |
+| 5.3 | The right mechanism is used for each type of automation | Skills for auto-triggered workflows, commands for user-invoked actions, rules for always-on instructions |
+| 5.4 | Skills that use external tools declare their dependencies | Allowed tools, required MCP servers, or equivalent declarations |
+
+### Scoring
+
+| Score | Definition | Example |
+|-------|------------|---------|
+| 0 | No skills, commands, or reusable workflows defined | Empty or absent `.claude/skills/` and `.claude/commands/` |
+| 1 | Some skills exist but unconfigured or wrong for the stack | Commit skill present but with placeholder test command. Security audit referencing npm when project uses Swift. |
+| 2 | Skills cover key workflows, configured for the stack, dependencies declared | Commit skill with real test command. Security audit with correct paths. Arch-audit configured. |
+| 3 | Score 2 + skills cover project-specific workflows (not just generic audit) + mechanism selection is correct | Score 2 plus project-specific skills (e.g., migration runner, API contract validator). Commands for user-invoked actions. No misuse of skills where a rule would suffice. |
+
+### Red flags
+- Skills referencing tools or paths that don't exist in the project
+- Placeholder values in skill configuration (`[DB_SYSTEM]`, `[API_ROUTES_PATH]`)
+- All skills are generic - none address project-specific repetitive tasks
+- Skills that duplicate what a rule already handles
+
+---
+
+## D6 - Context Economy
+
+**Weight**: 1.5x
+
+**What it measures**: does the workspace respect the AI's context budget? Is information placed in the right file type, loaded at the right time, and free of duplication?
+
+### Criteria
+
+| # | Criterion | How to verify |
+|---|-----------|---------------|
+| 6.1 | CLAUDE.md is within size budget | Count lines: target < 200 (hard limit), optimal < 100 |
+| 6.2 | Content passes the removal test | For each CLAUDE.md section: can you find the same information by running a command or reading a standard project file (package.json, README, source code)? If yes, the section is redundant and should be removed. For remaining sections: would removing this cause Claude to make a specific, nameable mistake? |
+| 6.3 | Information is in the right file type | Persistent context in CLAUDE.md, path-scoped rules in rules/, on-demand workflows in skills/, enforcement in hooks |
+| 6.4 | No duplication across files | Same information not repeated in CLAUDE.md and rules and memory |
+| 6.5 | Progressive disclosure used where available | @-imports, path-scoped rules with `paths:` frontmatter, skills loaded on demand |
+
+### Scoring
+
+| Score | Definition | Example |
+|-------|------------|---------|
+| 0 | No awareness of context constraints - everything dumped in one file or files are bloated | CLAUDE.md is 500+ lines. Or all instructions in a single rules file. |
+| 1 | Some separation exists but CLAUDE.md is oversized or contains removable content | CLAUDE.md at 250 lines. Contains code style rules that Claude follows by default. Some rules separated but most in CLAUDE.md. |
+| 2 | CLAUDE.md under 200 lines. Rules, skills, and context separated by concern. Minor duplication. | Clear separation: CLAUDE.md for project identity + tech stack + conventions. Rules for pipeline, security, style. Skills for workflows. |
+| 3 | Score 2 + CLAUDE.md under 100 lines + removal test passed + @-imports used + zero duplication + path-scoped rules | Lean CLAUDE.md with only what Claude needs every session. Path-scoped rules load only for relevant files. Skills demand-loaded. No information repeated across files. |
+
+### Red flags
+- CLAUDE.md over 200 lines (Anthropic-documented degradation threshold)
+- README content copy-pasted into CLAUDE.md
+- Same rules in both CLAUDE.md and a rules file
+- Tutorials, code snippets, or API docs inlined instead of referenced
+- Information that Claude can discover by reading the codebase
+
+---
+
+## D7 - Safety Guards
+
+**Weight**: 2x
+
+**What it measures**: does the workspace prevent the AI from taking irreversible actions without human confirmation? Are tests enforced, not just recommended?
+
+### Criteria
+
+| # | Criterion | How to verify |
+|---|-----------|---------------|
+| 7.1 | Test execution is enforced (not optional) | A stop hook, pre-commit hook, or equivalent blocks completion if tests fail |
+| 7.2 | Destructive operations are blocked or require confirmation | Force push, database drops, production deploys have explicit guards |
+| 7.3 | Secrets are protected | `.env*` in .gitignore, no token patterns in committed files, no credentials in AI memory |
+| 7.4 | Human review is required before shared-state actions | Push, PR creation, deployment require explicit user confirmation |
+| 7.5 | The stop hook runs the correct test command | Not a placeholder, not a generic `npm test` when the project uses something else |
+
+### Scoring
+
+| Score | Definition | Example |
+|-------|------------|---------|
+| 0 | No safety guards - the AI can push, delete, and deploy without any gate | No stop hook, no permission deny list, no gitignore for secrets |
+| 1 | Basic guards exist but are incomplete or misconfigured | Stop hook present but test command is a placeholder. `.env` in gitignore but no deny list for destructive commands. |
+| 2 | Tests enforced via hook, destructive operations denied, secrets protected | Working stop hook with real test command. `permissions.deny` blocks force push and DB drops. `.env*` gitignored. No secrets in CLAUDE.md. |
+| 3 | Score 2 + audit logging of tool use + STOP gates in pipeline + secret patterns checked in pre-commit | Score 2 plus PostToolUse audit hook. Pipeline STOP gates at scope and outcome. Pre-commit or context-review checks for token patterns in committed files. |
+
+### Red flags
+- No stop hook configured
+- Stop hook command is `[TEST_COMMAND]` (unresolved placeholder)
+- `permissions.deny` is empty or absent
+- `.env` files not in `.gitignore`
+- The AI can push to main without confirmation
+
+---
+
+## D8 - Cross-file Coherence
+
+**Weight**: 1x
+
+**What it measures**: do all workspace files reference each other consistently? No broken paths, no contradictions, no orphaned references.
+
+### Criteria
+
+| # | Criterion | How to verify |
+|---|-----------|---------------|
+| 8.1 | File paths referenced in CLAUDE.md and rules exist on disk | Grep for path references, check each one |
+| 8.2 | Commands are consistent across files | The test command in CLAUDE.md matches the stop hook matches the pipeline |
+| 8.3 | No contradictory instructions across files | Rules in one file don't conflict with rules in another |
+| 8.4 | Tier-appropriate content only | No Tier L features (design review, UAT scenarios) in a Tier M workspace, no Tier M overhead in Tier S |
+| 8.5 | File references in docs and skills point to real project paths | Skill configurations reference paths that exist, doc templates reference real files |
+
+### Scoring
+
+| Score | Definition | Example |
+|-------|------------|---------|
+| 0 | Files are disconnected - references are broken, commands contradict each other | Pipeline references `docs/sitemap.md` but the file doesn't exist. Stop hook runs `npm test` but CLAUDE.md says `swift test`. |
+| 1 | Most references work but some inconsistencies exist | Test command matches in 3 of 4 locations. One broken doc reference. |
+| 2 | All path references valid, commands consistent, no contradictions | Every referenced file exists. Same test command everywhere. No conflicting rules. |
+| 3 | Score 2 + an automated check exists for coherence + tier boundaries respected | Score 2 plus context-review checks (C8, C10) or equivalent. Workspace uses only features appropriate to its governance tier. |
+
+### Red flags
+- Test command differs between CLAUDE.md, stop hook, and pipeline
+- References to files from a different tier or a different project
+- Skills configured for a different stack than the project uses
+- Memory files reference docs that were deleted or renamed
+
+---
+
+## Score Sheet
+
+Copy and fill for each evaluation run.
+
+```
+Project: _______________
+Date: _______________
+Evaluator: _______________
+Workspace tool: _______________ (CDK / manual / other)
+Tier (if applicable): _______________
+
+| Dim | Score (0-3) | Weight | Weighted | Key gaps | Attribution (T/U/D) |
+|-----|-------------|--------|----------|----------|---------------------|
+| D1  |             | 1.0    |          |          |                     |
+| D2  |             | 1.0    |          |          |                     |
+| D3  |             | 1.5    |          |          |                     |
+| D4  |             | 1.0    |          |          |                     |
+| D5  |             | 1.0    |          |          |                     |
+| D6  |             | 1.5    |          |          |                     |
+| D7  |             | 2.0    |          |          |                     |
+| D8  |             | 1.0    |          |          |                     |
+|-----|-------------|--------|----------|----------|---------------------|
+| TOT |             |  10.0  |    /30   |          |   ___%              |
+
+Final score: (weighted total / 30) x 100 = ___%
+```
+
+## Interpretation Guide
+
+| Range | Rating | Meaning |
+|-------|--------|---------|
+| 0-30% | Unusable | Workspace does not provide meaningful AI guidance. Rebuild from scratch. |
+| 31-50% | Minimal | Basic structure exists but significant gaps reduce AI effectiveness. Priority: fill placeholders, add safety guards. |
+| 51-70% | Functional | Workspace works for routine tasks. Gaps in edge cases, context economy, or cross-file coherence. |
+| 71-85% | Good | Workspace actively improves AI output quality. Minor optimization opportunities remain. |
+| 86-100% | Excellent | Workspace is a force multiplier. AI operates with high autonomy and low error rate. Maintain through regular review. |
+
+## Action Priority
+
+When gaps are found, prioritize fixes in this order:
+
+1. **P1 - Blocks utility**: Score 0 on D7 (Safety) or D2 (Tech Grounding). Fix immediately - the workspace is actively dangerous or non-functional.
+2. **P2 - Reduces quality**: Score 0-1 on D1 (Identity), D3 (Workflow), D6 (Economy). The AI works but makes avoidable mistakes or wastes context.
+3. **P3 - Optimization**: Score 1-2 on D4, D5, D8. The workspace functions but could be tighter.
+
+---
+
+## Changelog
+
+- **v1.0** (2026-04-03): Initial version. 8 dimensions, weighted scoring, gap attribution model. Anchored to Anthropic official documentation (code.claude.com/docs), context engineering blog, CDK v1.6.1 template analysis, and cross-tool community patterns.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mg-claude-dev-kit",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Scaffold for legible, reviewable AI-assisted development",
   "type": "module",
   "bin": {

--- a/packages/cli/src/generators/claude-md.js
+++ b/packages/cli/src/generators/claude-md.js
@@ -23,7 +23,9 @@ export async function generateClaudeMd(config, targetDir) {
   // Apply known values from wizard answers
   content = content
     .replace(/\[PROJECT_NAME\]/g, config.projectName)
-    .replace(/\[TECH_STACK_SUMMARY\]/g, techStackSummary(config.techStack));
+    .replace(/\[TECH_STACK_SUMMARY\]/g, techStackSummary(config.techStack))
+    .replace(/\[FRAMEWORK_VALUE\]/g, frameworkValue(config))
+    .replace(/\[LANGUAGE_VALUE\]/g, languageFromStack(config.techStack));
 
   // Inject commands
   const commands = buildCommandsBlock(config);
@@ -36,6 +38,29 @@ export async function generateClaudeMd(config, targetDir) {
   }
 
   await fs.writeFile(path.join(targetDir, 'CLAUDE.md'), content);
+}
+
+function frameworkValue(config) {
+  if (config.framework) return config.framework;
+  const nativeStacks = ['swift', 'kotlin', 'rust', 'dotnet', 'java'];
+  if (nativeStacks.includes(config.techStack)) return 'N/A — native app';
+  return '_fill in: e.g. Next.js 15, Express, Django, Rails_';
+}
+
+function languageFromStack(techStack) {
+  const map = {
+    'node-ts': 'TypeScript',
+    'node-js': 'JavaScript',
+    python: 'Python',
+    go: 'Go',
+    swift: 'Swift',
+    kotlin: 'Kotlin',
+    rust: 'Rust',
+    dotnet: 'C#',
+    ruby: 'Ruby',
+    java: 'Java',
+  };
+  return map[techStack] || '_fill in: TypeScript / Python / Go / etc._';
 }
 
 function techStackSummary(stack) {

--- a/packages/cli/src/scaffold/index.js
+++ b/packages/cli/src/scaffold/index.js
@@ -59,11 +59,24 @@ export async function scaffoldTier(tier, targetDir, config, templatesDir) {
     await copyTemplateDir(tierDir, targetDir, config, {}, config, []);
   }
 
-  // Copy rules/ subdirectory from common
+  // Copy rules/ subdirectory from common — select security variant by stack family
   const commonRulesDir = path.join(commonDir, 'rules');
   if (await fs.pathExists(commonRulesDir)) {
+    const securityVariant = securityRuleVariant(config);
     const rules = await fs.readdir(commonRulesDir);
     for (const rule of rules) {
+      // Security variant selection: skip all security-*.md variants and the base security.md.
+      // Only the selected variant is copied, always as security.md in the output.
+      if (rule.startsWith('security')) {
+        if (rule === securityVariant) {
+          const src = path.join(commonRulesDir, rule);
+          const dest = path.join(targetDir, '.claude', 'rules', 'security.md');
+          await fs.ensureDir(path.dirname(dest));
+          const content = await fs.readFile(src, 'utf8');
+          await fs.writeFile(dest, interpolate(content, config));
+        }
+        continue;
+      }
       const src = path.join(commonRulesDir, rule);
       const dest = path.join(targetDir, '.claude', 'rules', rule);
       await fs.ensureDir(path.dirname(dest));
@@ -91,6 +104,9 @@ export async function scaffoldTier(tier, targetDir, config, templatesDir) {
     await pruneConditionalDocs(targetDir, config);
     await pruneSkills(targetDir, config);
   }
+
+  // Post-process settings.json: replace default permissions.allow with stack-aware permissions
+  await patchSettingsPermissions(targetDir, config);
 }
 
 /**
@@ -147,6 +163,54 @@ async function pruneSkills(targetDir, config) {
 
   for (const skill of skipSkills) {
     await fs.remove(path.join(skillsDir, skill));
+  }
+}
+
+/**
+ * Patch settings.json permissions.allow to use stack-appropriate CLI tools.
+ * Default templates use node/npm/npx — this replaces them for non-JS stacks.
+ */
+async function patchSettingsPermissions(targetDir, config) {
+  const settingsPath = path.join(targetDir, '.claude', 'settings.json');
+  if (!(await fs.pathExists(settingsPath))) return;
+
+  const permissionsAllowByStack = {
+    swift:  ['Bash(git:*)', 'Bash(swift:*)', 'Bash(xcodebuild:*)', 'Bash(xcrun:*)', 'Bash(curl:*)'],
+    kotlin: ['Bash(git:*)', 'Bash(./gradlew:*)', 'Bash(gradle:*)', 'Bash(curl:*)'],
+    rust:   ['Bash(git:*)', 'Bash(cargo:*)', 'Bash(rustc:*)', 'Bash(curl:*)'],
+    dotnet: ['Bash(git:*)', 'Bash(dotnet:*)', 'Bash(curl:*)'],
+    java:   ['Bash(git:*)', 'Bash(mvn:*)', 'Bash(./gradlew:*)', 'Bash(gradle:*)', 'Bash(curl:*)'],
+    ruby:   ['Bash(git:*)', 'Bash(bundle:*)', 'Bash(rails:*)', 'Bash(rake:*)', 'Bash(curl:*)'],
+    go:     ['Bash(git:*)', 'Bash(go:*)', 'Bash(curl:*)'],
+    python: ['Bash(git:*)', 'Bash(python:*)', 'Bash(pip:*)', 'Bash(uv:*)', 'Bash(curl:*)'],
+  };
+
+  const denyByStack = {
+    swift:  ['Bash(xcodebuild archive*)', 'Bash(xcrun altool --upload-app*)'],
+    kotlin: ['Bash(./gradlew publish*)', 'Bash(gradle publish*)'],
+    rust:   ['Bash(cargo publish*)'],
+    dotnet: ['Bash(dotnet nuget push*)'],
+    java:   ['Bash(mvn deploy*)', 'Bash(./gradlew publish*)', 'Bash(gradle publish*)'],
+    ruby:   ['Bash(gem push*)'],
+    python: ['Bash(twine upload*)'],
+  };
+
+  const stackPerms = permissionsAllowByStack[config.techStack];
+  const stackDeny = denyByStack[config.techStack];
+  if (!stackPerms && !stackDeny) return; // default node/npm/npx already in template
+
+  try {
+    const raw = await fs.readFile(settingsPath, 'utf8');
+    const settings = JSON.parse(raw);
+    if (stackPerms && settings.permissions && Array.isArray(settings.permissions.allow)) {
+      settings.permissions.allow = stackPerms;
+    }
+    if (stackDeny && settings.permissions && Array.isArray(settings.permissions.deny)) {
+      settings.permissions.deny = [...settings.permissions.deny, ...stackDeny];
+    }
+    await fs.writeFile(settingsPath, JSON.stringify(settings, null, 2) + '\n');
+  } catch {
+    // If settings.json is malformed, skip patching silently
   }
 }
 
@@ -209,8 +273,20 @@ export async function scaffoldTierSafe(tier, targetDir, config, templatesDir) {
 
   const commonRulesDir = path.join(commonDir, 'rules');
   if (await fs.pathExists(commonRulesDir)) {
+    const securityVariant = securityRuleVariant(config);
     const rules = await fs.readdir(commonRulesDir);
     for (const rule of rules) {
+      if (rule.startsWith('security')) {
+        if (rule === securityVariant) {
+          const dest = path.join(targetDir, '.claude', 'rules', 'security.md');
+          if (await fs.pathExists(dest)) continue;
+          const src = path.join(commonRulesDir, rule);
+          await fs.ensureDir(path.dirname(dest));
+          const content = await fs.readFile(src, 'utf8');
+          await fs.writeFile(dest, interpolate(content, config));
+        }
+        continue;
+      }
       const src = path.join(commonRulesDir, rule);
       const dest = path.join(targetDir, '.claude', 'rules', rule);
       if (await fs.pathExists(dest)) continue;
@@ -234,6 +310,9 @@ export async function scaffoldTierSafe(tier, targetDir, config, templatesDir) {
     await pruneConditionalDocs(targetDir, config);
     await pruneSkills(targetDir, config);
   }
+
+  // Post-process settings.json: replace default permissions.allow with stack-aware permissions
+  await patchSettingsPermissions(targetDir, config);
 }
 
 async function copyTemplateDirSafe(srcDir, destDir, config, fileNameMap, userConfig, skipDirs = []) {
@@ -271,6 +350,45 @@ async function copyTemplateDirSafe(srcDir, destDir, config, fileNameMap, userCon
 /**
  * Replace template placeholders with actual values from config.
  */
+/**
+ * Select the security.md variant based on stack family.
+ * Returns the filename of the variant to use (e.g. 'security-native-apple.md').
+ * The base 'security.md' is the web default and is used when no variant matches.
+ */
+function securityRuleVariant(config) {
+  if (config.techStack === 'swift') return 'security-native-apple.md';
+  if (config.techStack === 'kotlin') return 'security-native-android.md';
+  const systemsStacks = ['rust', 'dotnet', 'java', 'go'];
+  if (systemsStacks.includes(config.techStack) && config.hasApi === false) {
+    return 'security-systems.md';
+  }
+  // Web default: node-ts, node-js, python, ruby, go (with API), dotnet (with API), java (with API), other
+  return 'security.md';
+}
+
+function frameworkValue(config) {
+  if (config.framework) return config.framework;
+  const nativeStacks = ['swift', 'kotlin', 'rust', 'dotnet', 'java'];
+  if (nativeStacks.includes(config.techStack)) return 'N/A — native app';
+  return '_fill in: e.g. Next.js 15, Express, Django, Rails_';
+}
+
+function languageFromStack(techStack) {
+  const map = {
+    'node-ts': 'TypeScript',
+    'node-js': 'JavaScript',
+    python: 'Python',
+    go: 'Go',
+    swift: 'Swift',
+    kotlin: 'Kotlin',
+    rust: 'Rust',
+    dotnet: 'C#',
+    ruby: 'Ruby',
+    java: 'Java',
+  };
+  return map[techStack] || '[TypeScript / Python / Go / etc.]';
+}
+
 function interpolate(content, config) {
   const techStackLabels = {
     'node-ts': 'Node.js + TypeScript',
@@ -317,5 +435,7 @@ function interpolate(content, config) {
     .replace(/\[FRAMEWORK\]/g, ['swift', 'kotlin', 'rust', 'dotnet'].includes(config.techStack) ? 'N/A — native app' : config.hasFrontend === false ? 'N/A — no web frontend' : 'your frontend framework')
     .replace(/\[SITEMAP_OR_ROUTE_LIST\]/g, config.hasFrontend === false ? 'N/A — no web frontend' : 'docs/sitemap.md')
     .replace(/\[API_ROUTES_PATH\]/g, config.hasApi === false ? 'N/A — no API routes' : 'src/app/api/')
-    .replace(/\[BUNDLE_TOOL\]/g, ['swift', 'kotlin', 'rust', 'dotnet', 'java'].includes(config.techStack) ? 'N/A — native app' : 'your build tool\'s bundle analyzer');
+    .replace(/\[BUNDLE_TOOL\]/g, ['swift', 'kotlin', 'rust', 'dotnet', 'java'].includes(config.techStack) ? 'N/A — native app' : 'your build tool\'s bundle analyzer')
+    .replace(/\[FRAMEWORK_VALUE\]/g, frameworkValue(config))
+    .replace(/\[LANGUAGE_VALUE\]/g, languageFromStack(config.techStack));
 }

--- a/packages/cli/templates/common/rules/security-native-android.md
+++ b/packages/cli/templates/common/rules/security-native-android.md
@@ -1,0 +1,58 @@
+# Security Rules — Native Android (Kotlin / Java)
+
+These rules apply when working on Android apps targeting the Android platform.
+
+## Permissions & Manifest
+
+- Every permission in `AndroidManifest.xml` must be justified. Never add permissions "just in case".
+- Use runtime permission requests (not just manifest declarations) for dangerous permissions (camera, microphone, location, storage).
+- Request permissions at the point of use, not at app launch. Explain why before the system dialog appears.
+- Handle the "denied" and "don't ask again" states gracefully — never crash or silently fail.
+
+## Credential Storage
+
+- Store secrets (API keys, tokens, passwords) in Android Keystore or EncryptedSharedPreferences — never in plain SharedPreferences, SQLite without encryption, or plain files.
+- Never log credentials or tokens, even at debug level.
+- Never embed API keys directly in source code or `BuildConfig` fields committed to the repo. Use `local.properties` (gitignored) or CI/CD secrets.
+
+## Data Persistence
+
+- Sensitive data in SQLite should use SQLCipher or Room with encryption if the threat model requires it.
+- Files with sensitive content must use internal storage (`context.filesDir`), not external storage.
+- Temporary files with sensitive content must be deleted after use.
+- Enable `android:allowBackup="false"` or use `android:fullBackupContent` to exclude sensitive data from backups.
+
+## Network Security
+
+- Use `network_security_config.xml` to enforce certificate pinning for critical API endpoints.
+- Never allow cleartext traffic in production (`android:usesCleartextTraffic="false"`).
+- Validate SSL certificates — never implement a trust-all `TrustManager`.
+
+## Input Handling
+
+- Validate all external input: deep links, Intent extras, ContentProvider queries, clipboard data.
+- Deep links and Intent filters must validate the source and sanitize parameters before acting on them.
+- Exported components (`Activity`, `Service`, `BroadcastReceiver`, `ContentProvider`) must validate caller permissions.
+
+## Code Signing & Distribution
+
+- Never commit signing keystores (`.jks`, `.keystore`) to the repository.
+- For CI/CD: use environment variables or secret managers for signing credentials.
+- ProGuard/R8 rules must not disable obfuscation for security-sensitive classes.
+
+## Secrets and Credentials
+
+- Never hardcode secrets, tokens, passwords, or connection strings in source code.
+- Never log secrets, even at debug level.
+- Use `.gitignore` to exclude any file that could contain secrets (`local.properties`, `*.jks`, `*.keystore`, `keystore.properties`).
+
+## Security Checklist (before every commit touching security-sensitive code)
+
+- [ ] Permissions are minimal and justified
+- [ ] Secrets stored in Keystore or EncryptedSharedPreferences
+- [ ] Runtime permissions requested at point of use with denial handling
+- [ ] Sensitive data uses internal storage, not external
+- [ ] No signing keystores in repository
+- [ ] External input validated (deep links, Intents, ContentProviders)
+- [ ] Network security config enforces HTTPS
+- [ ] No secrets in code or logs

--- a/packages/cli/templates/common/rules/security-native-apple.md
+++ b/packages/cli/templates/common/rules/security-native-apple.md
@@ -1,0 +1,56 @@
+# Security Rules — Native Apple (macOS / iOS)
+
+These rules apply when working on Swift/Objective-C apps targeting Apple platforms.
+
+## App Sandbox & Entitlements
+
+- Every entitlement in the `.entitlements` file must be justified. Never add entitlements "just in case".
+- If the app accesses network, files, or hardware: verify the matching entitlement is present and scoped correctly.
+- Hardened Runtime must be enabled for macOS distribution. Never disable it to work around a signing issue.
+
+## Keychain & Credentials
+
+- Store secrets (API keys, tokens, passwords) in Keychain Services — never in UserDefaults, plists, or plain files.
+- Use `kSecAttrAccessible` values appropriate to the data sensitivity. Prefer `kSecAttrAccessibleWhenUnlockedThisDeviceOnly` for high-sensitivity items.
+- Never log Keychain values, even at debug level.
+
+## TCC Permissions (Camera, Microphone, Location, Files)
+
+- Declare every required permission in `Info.plist` with a clear, user-facing usage description.
+- Request permissions at the point of use, not at app launch. Explain why before the system prompt appears.
+- Handle the "denied" state gracefully — never crash or silently fail when permission is denied.
+- Never access protected resources without checking authorization status first.
+
+## Data Persistence
+
+- Sensitive data written to disk must use Data Protection (`FileProtectionType.complete` or `.completeUnlessOpen`).
+- SQLite databases containing user data should enable encryption (SQLCipher or equivalent) if the threat model requires it.
+- Temporary files with sensitive content must be deleted after use — never leave them in `tmp/` indefinitely.
+
+## Code Signing & Distribution
+
+- Never disable code signing to fix a build error. Diagnose the actual signing identity issue.
+- Never embed provisioning profiles or signing certificates in the repository.
+- For CI/CD: use environment variables or Keychain for signing credentials, never checked-in files.
+
+## Input Handling
+
+- Validate all external input: URL schemes, deep links, clipboard data, file imports, IPC messages.
+- Custom URL schemes must validate the source and sanitize parameters before acting on them.
+- Pasted data from clipboard should be validated before use in sensitive operations.
+
+## Secrets and Credentials
+
+- Never hardcode API keys, tokens, or connection strings in source code.
+- Never log secrets, even at debug level.
+- Use `.gitignore` to exclude any file that could contain secrets (`.env*`, `*.pem`, `*.key`, `Secrets.swift`).
+
+## Security Checklist (before every commit touching security-sensitive code)
+
+- [ ] Entitlements are minimal and justified
+- [ ] Secrets stored in Keychain, not UserDefaults or plists
+- [ ] TCC permissions declared with usage descriptions
+- [ ] Sensitive disk writes use Data Protection
+- [ ] No signing credentials in repository
+- [ ] External input validated (URL schemes, clipboard, file imports)
+- [ ] No secrets in code or logs

--- a/packages/cli/templates/common/rules/security-systems.md
+++ b/packages/cli/templates/common/rules/security-systems.md
@@ -1,0 +1,56 @@
+# Security Rules — Systems & Backend (Rust / Go / .NET / Java / C++)
+
+These rules apply when working on systems-level applications, CLI tools, daemons, or backend services without a web API layer.
+
+## Memory & Resource Safety
+
+- Never use `unsafe` blocks (Rust) or raw pointers (Go, C++) without a comment justifying why safe alternatives are insufficient.
+- Validate buffer sizes before read/write operations. Never trust external input to determine buffer length without bounds checking.
+- Close file handles, network connections, and other resources deterministically — use RAII (Rust/C++), `defer` (Go), `using` (C#), or try-with-resources (Java).
+
+## Input Handling
+
+- Validate all external input at system boundaries: CLI arguments, environment variables, file contents, network data, IPC messages.
+- File paths from user input must be canonicalized and validated against an allowlist before use. Prevent path traversal (`../`).
+- Deserializing untrusted data (JSON, YAML, binary formats) must use strict schema validation. Never deserialize into arbitrary types.
+
+## File System & Permissions
+
+- Create files with restrictive permissions by default (e.g., 0600 for sensitive files). Never create world-readable files containing secrets.
+- Temporary files must be created in secure directories and deleted after use.
+- When writing to user-specified paths: validate the path, check permissions, handle symlink attacks (use `O_NOFOLLOW` where available).
+
+## Process Execution
+
+- Never construct shell commands from user input. Use direct process execution with argument arrays (no shell interpretation).
+- If shelling out is unavoidable: sanitize every argument and never pass raw user input to a shell.
+- Child processes should inherit minimal environment — strip sensitive environment variables before spawning.
+
+## Secrets and Credentials
+
+- Never hardcode secrets, tokens, passwords, or connection strings in source code.
+- Never log secrets, even at debug level.
+- Read secrets from environment variables, secret managers, or encrypted config files — never from command-line arguments (visible in `ps`).
+- Use `.gitignore` to exclude any file that could contain secrets (`.env*`, `*.pem`, `*.key`, `secrets/`, `credentials/`).
+
+## Dependency Management
+
+- Pin dependency versions. Avoid floating version ranges in production builds.
+- Audit dependencies for known vulnerabilities before release (`cargo audit`, `go vuln check`, `dotnet list package --vulnerable`, `mvn dependency-check:check`).
+- Minimize transitive dependencies — each dependency is an attack surface.
+
+## Error Handling
+
+- Never expose internal error details (stack traces, file paths, memory addresses) to external consumers.
+- Log detailed errors internally. Return generic error codes externally.
+- Panic/crash handlers must not leak sensitive data in crash reports.
+
+## Security Checklist (before every commit touching security-sensitive code)
+
+- [ ] External input validated at system boundaries
+- [ ] File operations use restrictive permissions
+- [ ] No shell command construction from user input
+- [ ] Secrets from environment/config, not hardcoded
+- [ ] Dependencies audited for vulnerabilities
+- [ ] No sensitive data in error messages or logs
+- [ ] Resource cleanup is deterministic (no leaks)

--- a/packages/cli/templates/tier-l/.claude/skills/security-audit/SKILL.md
+++ b/packages/cli/templates/tier-l/.claude/skills/security-audit/SKILL.md
@@ -14,6 +14,19 @@ argument-hint: [target:page:<route>|target:role:<role>|target:section:<section>]
 
 ---
 
+## Applicability check
+
+Before any other step: read `CLAUDE.md` and check the Framework and Language fields.
+
+- If the project is a native application (Swift, Kotlin, Objective-C, C++, desktop GUI) with no API routes (the `[HAS_API]` field is `false` or the Framework field is `N/A — native app`): output the following and stop — do not proceed to Step 0:
+
+  > **security-audit** targets web applications with API routes, middleware, and database access policies. This project uses a native stack with no server-side API surface. For native app security, audit manually: App Sandbox entitlements, Keychain access patterns, TCC permissions (camera, microphone, file access), code signing, and hardened runtime configuration.
+
+- If the project has API routes (`[HAS_API]` is `true`), even on a native stack: proceed to Step 0. The API surface is auditable.
+- If unsure: check for route handler files (e.g., `src/app/api/`, `routes/`, `handlers/`). If none exist, output the message above and stop.
+
+---
+
 ## Step 0 — Target resolution
 
 Parse `$ARGUMENTS` for a `target:` token.

--- a/packages/cli/templates/tier-l/CLAUDE.md
+++ b/packages/cli/templates/tier-l/CLAUDE.md
@@ -4,8 +4,8 @@
 [One paragraph: what the product does, who uses it, what problem it solves.]
 
 ## Tech Stack
-- **Framework**: [e.g. Next.js 15, Express, Django, Rails]
-- **Language**: [TypeScript / Python / Go / etc.]
+- **Framework**: [FRAMEWORK_VALUE]
+- **Language**: [LANGUAGE_VALUE]
 - **Database**: [PostgreSQL + RLS / Prisma / Drizzle]
 - **Auth**: [Auth mechanism]
 - **Storage**: [File storage if any]

--- a/packages/cli/templates/tier-m/.claude/skills/security-audit/SKILL.md
+++ b/packages/cli/templates/tier-m/.claude/skills/security-audit/SKILL.md
@@ -14,6 +14,19 @@ argument-hint: [target:page:<route>|target:role:<role>|target:section:<section>]
 
 ---
 
+## Applicability check
+
+Before any other step: read `CLAUDE.md` and check the Framework and Language fields.
+
+- If the project is a native application (Swift, Kotlin, Objective-C, C++, desktop GUI) with no API routes (the `[HAS_API]` field is `false` or the Framework field is `N/A — native app`): output the following and stop — do not proceed to Step 0:
+
+  > **security-audit** targets web applications with API routes, middleware, and database access policies. This project uses a native stack with no server-side API surface. For native app security, audit manually: App Sandbox entitlements, Keychain access patterns, TCC permissions (camera, microphone, file access), code signing, and hardened runtime configuration.
+
+- If the project has API routes (`[HAS_API]` is `true`), even on a native stack: proceed to Step 0. The API surface is auditable.
+- If unsure: check for route handler files (e.g., `src/app/api/`, `routes/`, `handlers/`). If none exist, output the message above and stop.
+
+---
+
 ## Step 0 — Target resolution
 
 Parse `$ARGUMENTS` for a `target:` token.

--- a/packages/cli/templates/tier-m/CLAUDE.md
+++ b/packages/cli/templates/tier-m/CLAUDE.md
@@ -4,8 +4,8 @@
 [One paragraph: what the product does, who uses it, what problem it solves.]
 
 ## Tech Stack
-- **Framework**: [e.g. Next.js 15, Express, Django, Rails]
-- **Language**: [TypeScript / Python / Go / etc.]
+- **Framework**: [FRAMEWORK_VALUE]
+- **Language**: [LANGUAGE_VALUE]
 - **Database**: [PostgreSQL / SQLite / MongoDB]
 - **Auth**: [Auth mechanism]
 - **Storage**: [File storage if any]

--- a/packages/cli/templates/tier-s/CLAUDE.md
+++ b/packages/cli/templates/tier-s/CLAUDE.md
@@ -4,8 +4,8 @@
 [One paragraph: what the product does, who uses it, what problem it solves.]
 
 ## Tech Stack
-- **Framework**: [e.g. Next.js 15, Express, Django, Rails]
-- **Language**: [TypeScript / Python / Go / etc.]
+- **Framework**: [FRAMEWORK_VALUE]
+- **Language**: [LANGUAGE_VALUE]
 - **Database**: [PostgreSQL / SQLite / MongoDB]
 - **Auth**: [Supabase Auth / Auth.js / Passport / etc.]
 - **Deploy**: [Vercel / Railway / Fly.io / etc.]

--- a/packages/cli/test/integration/run.js
+++ b/packages/cli/test/integration/run.js
@@ -95,6 +95,8 @@ const WIZARD_PLACEHOLDERS = [
   'E2E_COMMAND',
   'AUDIT_MODEL',
   'DESIGN_SYSTEM_NAME',
+  'FRAMEWORK_VALUE',
+  'LANGUAGE_VALUE',
 ];
 // All other placeholders (skill config, ADR template, state machines, etc.)
 // are intentionally left for the user/Claude to fill in at first session.
@@ -792,6 +794,65 @@ async function scenarioWizardCoverage() {
   }
 }
 
+async function scenarioSecurityVariants() {
+  section('Security rule variants — stack-aware security.md selection');
+
+  const variants = [
+    { stack: 'swift',  hasApi: true,  expected: 'Native Apple', label: 'swift → native-apple', denyIncludes: 'xcodebuild archive' },
+    { stack: 'kotlin', hasApi: true,  expected: 'Native Android', label: 'kotlin → native-android', denyIncludes: 'gradlew publish' },
+    { stack: 'rust',   hasApi: false, expected: 'Systems & Backend', label: 'rust (no API) → systems', denyIncludes: 'cargo publish' },
+    { stack: 'go',     hasApi: false, expected: 'Systems & Backend', label: 'go (no API) → systems', denyIncludes: null },
+    { stack: 'rust',   hasApi: true,  expected: 'Security Rules\n', label: 'rust (with API) → web', denyIncludes: 'cargo publish' },
+    { stack: 'node-ts', hasApi: true, expected: 'Security Rules\n', label: 'node-ts → web', denyIncludes: null },
+  ];
+
+  for (const { stack, hasApi, expected, label, denyIncludes } of variants) {
+    const config = {
+      ...BASE,
+      tier: 'm',
+      techStack: stack,
+      hasApi,
+      isDiscovery: false,
+    };
+    const dir = await scaffold(`security-variant-${stack}-${hasApi ? 'api' : 'noapi'}`, 'm', config);
+    const securityPath = path.join(dir, '.claude', 'rules', 'security.md');
+
+    if (!fs.existsSync(securityPath)) {
+      fail(`security-variant[${label}]: security.md missing`);
+      continue;
+    }
+
+    const content = fs.readFileSync(securityPath, 'utf8');
+    if (content.includes(expected)) {
+      pass(`security-variant[${label}]: correct variant`);
+    } else {
+      fail(`security-variant[${label}]: expected "${expected}" in security.md`);
+    }
+
+    // Verify no other security variant files leaked into output
+    const rulesDir = path.join(dir, '.claude', 'rules');
+    const ruleFiles = fs.readdirSync(rulesDir);
+    const securityFiles = ruleFiles.filter(f => f.startsWith('security'));
+    if (securityFiles.length === 1 && securityFiles[0] === 'security.md') {
+      pass(`security-variant[${label}]: no variant files leaked`);
+    } else {
+      fail(`security-variant[${label}]: unexpected security files: ${securityFiles.join(', ')}`);
+    }
+
+    // Verify stack-specific deny entries in settings.json
+    if (denyIncludes) {
+      const settingsPath = path.join(dir, '.claude', 'settings.json');
+      const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+      const denyList = (settings.permissions?.deny || []).join(' ');
+      if (denyList.includes(denyIncludes)) {
+        pass(`security-variant[${label}]: deny includes ${denyIncludes}`);
+      } else {
+        fail(`security-variant[${label}]: deny missing ${denyIncludes}`);
+      }
+    }
+  }
+}
+
 // ── Main ─────────────────────────────────────────────────────────────────────
 
 async function main() {
@@ -821,6 +882,7 @@ async function main() {
   await scenarioNewRuleFiles();
   await scenarioNewStacks();
   await scenarioNativeStackCommandDefaults();
+  await scenarioSecurityVariants();
   await scenarioWizardCoverage();
 
   // ── Summary ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- **Security rule variants**: 4 stack-aware variants (web, native-apple, native-android, systems) selected automatically based on `techStack` + `hasApi`
- **Stack-specific permissions.deny**: release guards added per stack (xcodebuild archive, cargo publish, gradlew publish, mvn deploy, gem push, twine upload, dotnet nuget push)
- **CLAUDE.md auto-population**: Framework and Language fields resolved from wizard/detection data instead of leaving placeholder text
- **security-audit applicability check**: bail-out for native apps without API routes (tier-m + tier-l)
- **Workspace Quality Rubric v1.0**: 8-dimension rubric (D1-D8) with weighted scoring 0-100%, gap attribution model, action priority framework
- **Docs sync**: README + operational guide updated with supported stacks table, security variant docs, permissions table, auto-populated fields

## Test plan
- [x] Integration tests: 249/249 PASS (+16 new: security variant selection, deny verification)
- [x] Verified: Swift → native-apple, Kotlin → native-android, Rust (no API) → systems, Rust (with API) → web, Node-TS → web
- [x] Verified: deny entries present per stack in settings.json output
- [x] Verified: Framework/Language resolved in all wizard fixture outputs
- [x] Verified: no security variant files leaked into scaffold output

🤖 Generated with [Claude Code](https://claude.com/claude-code)