### PR TITLE
fix(scaffold): MIGRATION_COMMAND placeholder + CLAUDE.md noise reduction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Run before every release to validate all tier/mode combinations:
 node packages/cli/test/integration/run.js
 # Add --verbose for per-check output
 ```
-249 checks: file structure per tier, Stop hook presence and resolution, pipeline gate counts, wizard placeholder resolution, safe-mode preservation, new named stacks (swift/kotlin/rust/dotnet/ruby/java), conditional docs pruning (sitemap.md, db-map.md), security rule variant selection (6 stack/API combinations + leak check + deny verification), full CLI execution via `--answers` fixtures (9 scenarios). Output is gitignored (`packages/cli/test/integration/output/`).
+271 checks: file structure per tier, Stop hook presence and resolution, pipeline gate counts, wizard placeholder resolution, safe-mode preservation, new named stacks (swift/kotlin/rust/dotnet/ruby/java), conditional docs pruning (sitemap.md, db-map.md), security rule variant selection (6 stack/API combinations + leak check + deny verification), placeholder noise reduction (unfilled sections stripped from CLAUDE.md), full CLI execution via `--answers` fixtures (9 scenarios). Output is gitignored (`packages/cli/test/integration/output/`).
 
 ## Interaction Protocol
 **Perimeter questions** (scope, vision, user, future): always use the `AskUserQuestion` tool — never present as inline text. Max 4 questions per call, each with 2–4 options. Open-ended questions get representative options + "Other" for custom input.

--- a/packages/cli/src/generators/claude-md.js
+++ b/packages/cli/src/generators/claude-md.js
@@ -37,6 +37,9 @@ export async function generateClaudeMd(config, targetDir) {
     content = injectActiveSkills(content, config);
   }
 
+  // Strip sections containing only placeholder content to save context tokens
+  content = stripUnfilledSections(content);
+
   await fs.writeFile(path.join(targetDir, 'CLAUDE.md'), content);
 }
 
@@ -89,6 +92,8 @@ function buildCommandsBlock(config) {
   const build = config.buildCommand || ncd.build || 'npm run build';
   const test = config.testCommand || ncd.test || 'npm test';
   const typeCheck = config.typeCheckCommand || ncd.typeCheck || '';
+  const migration = config.migrationCommand || '';
+  const e2e = config.e2eCommand || '';
 
   const lines = ['```bash'];
   if (install) lines.push(`${install}     # install dependencies`);
@@ -96,6 +101,8 @@ function buildCommandsBlock(config) {
   if (build) lines.push(`${build}       # production build`);
   if (test) lines.push(`${test}         # run tests`);
   if (typeCheck) lines.push(`${typeCheck}  # type check`);
+  if (migration && migration !== '# not configured') lines.push(`${migration}  # run migrations`);
+  if (e2e && e2e !== '# not configured') lines.push(`${e2e}  # end-to-end tests`);
   lines.push('```');
   return lines.join('\n');
 }
@@ -140,6 +147,41 @@ function injectActiveSkills(content, config) {
     return content.replace('\n## Environment', section + '\n## Environment');
   }
   return content + section;
+}
+
+/**
+ * Remove sections that contain only placeholder content (bracket patterns,
+ * HTML comments, empty lines). These waste context tokens every session
+ * until the user fills them in. Stripped sections are documented in
+ * FIRST_SESSION.md so users know they exist.
+ */
+function stripUnfilledSections(content) {
+  const sectionsToStrip = new Set([
+    'RBAC / Roles',
+    'Key Workflows',
+    'Navigation by Role',
+    'Known Patterns',
+  ]);
+
+  const lines = content.split('\n');
+  const sections = [];
+  let current = { heading: null, lines: [] };
+
+  for (const line of lines) {
+    const match = line.match(/^## (.+)/);
+    if (match) {
+      sections.push(current);
+      current = { heading: match[1].trim(), lines: [line] };
+    } else {
+      current.lines.push(line);
+    }
+  }
+  sections.push(current);
+
+  const kept = sections.filter(s => !s.heading || !sectionsToStrip.has(s.heading));
+
+  // Rejoin and collapse runs of 3+ blank lines to 2
+  return kept.map(s => s.lines.join('\n')).join('\n').replace(/\n{3,}/g, '\n\n');
 }
 
 function getMinimalTemplate() {

--- a/packages/cli/src/scaffold/index.js
+++ b/packages/cli/src/scaffold/index.js
@@ -438,5 +438,6 @@ function interpolate(content, config) {
     .replace(/\[API_ROUTES_PATH\]/g, config.hasApi === false ? 'N/A — no API routes' : 'src/app/api/')
     .replace(/\[BUNDLE_TOOL\]/g, ['swift', 'kotlin', 'rust', 'dotnet', 'java'].includes(config.techStack) ? 'N/A — native app' : 'your build tool\'s bundle analyzer')
     .replace(/\[FRAMEWORK_VALUE\]/g, frameworkValue(config))
-    .replace(/\[LANGUAGE_VALUE\]/g, languageFromStack(config.techStack));
+    .replace(/\[LANGUAGE_VALUE\]/g, languageFromStack(config.techStack))
+    .replace(/\[MIGRATION_COMMAND\]/g, config.migrationCommand || '# not configured');
 }

--- a/packages/cli/templates/tier-l/FIRST_SESSION.md
+++ b/packages/cli/templates/tier-l/FIRST_SESSION.md
@@ -25,11 +25,15 @@ Your development scaffold is ready. This guide walks through setup and your firs
 
 **1. Fill in `CLAUDE.md`** — replace every `[PLACEHOLDER]`:
 - Overview: what the product does and who uses it
-- Tech stack: framework, language, database, auth, storage, email, deploy
-- RBAC / Roles: role names and their access levels
-- Key workflows: state machines, approval flows, document lifecycle
-- Key commands: install, dev, build, test, type-check, migration, E2E
+- Tech stack: framework, language, database, auth, storage, email, deploy (framework + language are auto-populated)
+- Key commands: install, dev, build, test, type-check (auto-populated from wizard)
 - Coding conventions: any non-obvious rules for your codebase
+
+**Sections removed to save context tokens** — add them back to `CLAUDE.md` when you have real content:
+- `## RBAC / Roles` — role/permission table (copy from tier template or write your own)
+- `## Key Workflows` — state machines, approval flows, document lifecycle
+- `## Navigation by Role` — role-to-page mapping table
+- `## Known Patterns` — non-obvious gotchas discovered during development
 
 **2. Fill in `docs/requirements.md`** — define your blocks in priority order. Include acceptance criteria. This is what Claude reads at Phase 1.
 

--- a/packages/cli/templates/tier-m/FIRST_SESSION.md
+++ b/packages/cli/templates/tier-m/FIRST_SESSION.md
@@ -23,9 +23,14 @@ Your development scaffold is ready. This guide walks through setup and your firs
 
 **1. Fill in `CLAUDE.md`** — replace every `[PLACEHOLDER]`:
 - Overview: what the product does and who uses it
-- Tech stack: framework, language, database, auth
-- Key commands: install, dev, build, test, type-check
+- Tech stack: framework, language, database, auth (framework + language are auto-populated)
+- Key commands: install, dev, build, test, type-check (auto-populated from wizard)
 - Coding conventions: any non-obvious rules for your codebase
+
+**Sections removed to save context tokens** — add them back to `CLAUDE.md` when you have real content:
+- `## RBAC / Roles` — role/permission table (copy from tier template or write your own)
+- `## Key Workflows` — state machines, approval flows, document lifecycle
+- `## Known Patterns` — non-obvious gotchas discovered during development
 
 **2. Fill in `docs/requirements.md`** — list the blocks you plan to implement, in priority order. Even a rough list is enough to start.
 

--- a/packages/cli/test/integration/run.js
+++ b/packages/cli/test/integration/run.js
@@ -98,6 +98,7 @@ const WIZARD_PLACEHOLDERS = [
   'FRAMEWORK_VALUE',
   'LANGUAGE_VALUE',
   'API_TESTS_PATH',
+  'MIGRATION_COMMAND',
 ];
 // All other placeholders (skill config, ADR template, state machines, etc.)
 // are intentionally left for the user/Claude to fill in at first session.
@@ -854,6 +855,71 @@ async function scenarioSecurityVariants() {
   }
 }
 
+async function scenarioPlaceholderNoiseReduction() {
+  section('Placeholder noise reduction — unfilled sections stripped from CLAUDE.md');
+
+  // Tier M — RBAC, Key Workflows, Known Patterns stripped
+  const configM = { ...BASE, tier: 'm', isDiscovery: false };
+  const dirM = await scaffold('noise-reduction-tier-m', 'm', configM);
+  const claudeM = fs.readFileSync(path.join(dirM, 'CLAUDE.md'), 'utf8');
+
+  for (const stripped of ['## RBAC / Roles', '## Key Workflows', '## Known Patterns']) {
+    if (!claudeM.includes(stripped)) {
+      pass(`Tier M: section "${stripped}" stripped`);
+    } else {
+      fail(`Tier M: section "${stripped}" should be stripped`);
+    }
+  }
+
+  for (const kept of ['## Overview', '## Tech Stack', '## Key Commands', '## Coding Conventions', '## Interaction Protocol', '## Reference Documents', '## Environment']) {
+    if (claudeM.includes(kept)) {
+      pass(`Tier M: section "${kept}" preserved`);
+    } else {
+      fail(`Tier M: section "${kept}" should be preserved`);
+    }
+  }
+
+  // Tier L — additionally strips Navigation by Role
+  const configL = { ...BASE, tier: 'l', isDiscovery: false, e2eCommand: 'npx playwright test', hasE2E: true };
+  const dirL = await scaffold('noise-reduction-tier-l', 'l', configL);
+  const claudeL = fs.readFileSync(path.join(dirL, 'CLAUDE.md'), 'utf8');
+
+  for (const stripped of ['## RBAC / Roles', '## Key Workflows', '## Navigation by Role', '## Known Patterns']) {
+    if (!claudeL.includes(stripped)) {
+      pass(`Tier L: section "${stripped}" stripped`);
+    } else {
+      fail(`Tier L: section "${stripped}" should be stripped`);
+    }
+  }
+
+  for (const kept of ['## Overview', '## Tech Stack', '## Key Commands', '## Interaction Protocol', '## Reference Documents', '## Environment']) {
+    if (claudeL.includes(kept)) {
+      pass(`Tier L: section "${kept}" preserved`);
+    } else {
+      fail(`Tier L: section "${kept}" should be preserved`);
+    }
+  }
+
+  // Verify CLAUDE.md line count reduced (raw template ~92 lines with injections, stripped should be < 80)
+  const lineCountM = claudeM.split('\n').length;
+  if (lineCountM < 80) {
+    pass(`Tier M: CLAUDE.md line count reduced (${lineCountM} lines)`);
+  } else {
+    fail(`Tier M: CLAUDE.md still ${lineCountM} lines — expected < 80 after stripping`);
+  }
+
+  // Tier S — Known Patterns stripped (only section applicable)
+  const configS = { ...BASE, tier: 's', isDiscovery: false };
+  const dirS = await scaffold('noise-reduction-tier-s', 's', configS);
+  const claudeS = fs.readFileSync(path.join(dirS, 'CLAUDE.md'), 'utf8');
+
+  if (!claudeS.includes('## Known Patterns')) {
+    pass('Tier S: section "## Known Patterns" stripped');
+  } else {
+    fail('Tier S: section "## Known Patterns" should be stripped');
+  }
+}
+
 // ── Main ─────────────────────────────────────────────────────────────────────
 
 async function main() {
@@ -884,6 +950,7 @@ async function main() {
   await scenarioNewStacks();
   await scenarioNativeStackCommandDefaults();
   await scenarioSecurityVariants();
+  await scenarioPlaceholderNoiseReduction();
   await scenarioWizardCoverage();
 
   // ── Summary ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Fix `[MIGRATION_COMMAND]` unresolved placeholder in tier-l CLAUDE.md — add to `buildCommandsBlock()` and `interpolate()`
- Strip unfilled placeholder sections (RBAC, Key Workflows, Navigation by Role, Known Patterns) from scaffolded CLAUDE.md to save context tokens
- Update FIRST_SESSION.md (tier-m/l) documenting stripped sections and how to add them back
- 271 integration checks (was 249, +22 noise reduction validations)

## Test plan
- [x] `node packages/cli/test/integration/run.js` — 271/271 pass
- [x] Tier M/L: stripped sections absent, kept sections present
- [x] Tier S: Known Patterns stripped
- [x] All wizard fixtures pass placeholder resolution
- [x] MIGRATION_COMMAND in WIZARD_PLACEHOLDERS list

🤖 Generated with [Claude Code](https://claude.com/claude-code)