### PR TITLE
fix(generators): correct @import paths in CLAUDE.md

### DIFF
--- a/packages/cli/src/generators/claude-md.js
+++ b/packages/cli/src/generators/claude-md.js
@@ -124,8 +124,8 @@ function buildCommandsBlock(config) {
 function injectRuleImports(content) {
   const imports = [
     '@.claude/rules/output-style.md',
-    '@.claude/rules/claudemd-standards.md',
-    '@.claude/rules/pipeline-standards.md',
+    '@docs/claudemd-standards.md',
+    '@docs/pipeline-standards.md',
   ];
   // If any import already present, skip (idempotent)
   if (imports.every((i) => content.includes(i))) return content;

--- a/packages/cli/test/unit/claude-md.test.js
+++ b/packages/cli/test/unit/claude-md.test.js
@@ -93,8 +93,8 @@ describe('injectRuleImports', () => {
     const input = '# My Project\n\n## Overview\nSome text';
     const result = injectRuleImports(input);
     assert.ok(result.includes('@.claude/rules/output-style.md'));
-    assert.ok(result.includes('@.claude/rules/claudemd-standards.md'));
-    assert.ok(result.includes('@.claude/rules/pipeline-standards.md'));
+    assert.ok(result.includes('@docs/claudemd-standards.md'));
+    assert.ok(result.includes('@docs/pipeline-standards.md'));
     // imports appear between # heading and ## Overview
     const headingIdx = result.indexOf('# My Project');
     const importIdx = result.indexOf('@.claude/rules/output-style.md');
@@ -105,12 +105,12 @@ describe('injectRuleImports', () => {
 
   it('is idempotent — skips if all imports present', () => {
     const input =
-      '# My Project\n@.claude/rules/output-style.md\n@.claude/rules/claudemd-standards.md\n@.claude/rules/pipeline-standards.md\n\n## Overview';
+      '# My Project\n@.claude/rules/output-style.md\n@docs/claudemd-standards.md\n@docs/pipeline-standards.md\n\n## Overview';
     const result = injectRuleImports(input);
     // count occurrences — should be exactly 1 each
     const count = (str, sub) => str.split(sub).length - 1;
     assert.equal(count(result, '@.claude/rules/output-style.md'), 1);
-    assert.equal(count(result, '@.claude/rules/claudemd-standards.md'), 1);
+    assert.equal(count(result, '@docs/claudemd-standards.md'), 1);
   });
 });
 


### PR DESCRIPTION
## Summary
- `injectRuleImports()` referenced `@.claude/rules/claudemd-standards.md` and `@.claude/rules/pipeline-standards.md` but scaffold copies these files to `docs/`
- Claude Code could not resolve the broken `@`-imports, making those two rule files invisible to every scaffolded project
- Discovered during real-project validation on mac-transcription-collector

## Test plan
- [x] 29/29 unit tests pass (including updated `injectRuleImports` assertions)
- [x] 459/459 integration checks pass
- [x] Verified re-scaffold on mac-transcription-collector produces correct `@docs/` paths
- [x] Confirmed `docs/claudemd-standards.md` and `docs/pipeline-standards.md` exist in scaffold output

🤖 Generated with [Claude Code](https://claude.com/claude-code)