### PR TITLE
fix(scaffold): security-audit always installed + doctor checks #18 #19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - (CodeQL Medium) `add.test.js` shell injection risk - `execSync` template literal replaced with `execFileSync` + args array
 - (CodeQL Medium) `review-wizard-output.js` no-op `.replace('─', '─')` removed
 - (CodeQL Medium) `ci.yml` and `claude-dev-kit-verify.yml` missing `permissions:` blocks - added `contents: read` (least privilege)
+- `security-audit` skill was gated on `hasApi: true` in skill registry - native apps (Swift, Kotlin, Rust) never received it despite having NS1-NS6 native security checks
+- `arch-audit` SKILL.md description exceeded 250-char limit (255 chars) - trimmed to 211
+- `doctor` now checks Stop hook timeout presence (check #18) and deny list duplicates (check #19)
 
 ### Evaluated (decisions documented, no code change)
 - P5 Tier L: frozen - maintain functional, no new investment until real adoption signal

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ packages/cli/
 - **Tier boundaries**: no Tier L features in Tier M templates. No Tier M features in Tier S.
 - **Custom skills**: files matching `.claude/skills/custom-*/SKILL.md` are never touched by `upgrade` or `init`. This convention is documented for end users.
 - **Stack agnosticity**: templates contain no framework-specific assumptions. Stack adaptation happens in `interpolate()` and `skill-registry.js`.
-- **Doctor check count**: must match what README documents (currently 17).
+- **Doctor check count**: must match what README documents (currently 19).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ The Stop hook in `settings.json` is the core enforcement mechanism. It blocks Cl
 npx mg-claude-dev-kit init                    # scaffold wizard
 npx mg-claude-dev-kit init --dry-run          # preview without writing
 npx mg-claude-dev-kit init --answers file.json  # skip prompts (CI/automation)
-npx mg-claude-dev-kit doctor                  # validate setup (17 checks)
+npx mg-claude-dev-kit doctor                  # validate setup (19 checks)
 npx mg-claude-dev-kit doctor --report         # JSON output for CI
 npx mg-claude-dev-kit doctor --ci             # silent, exit 1 on failure
 npx mg-claude-dev-kit upgrade                 # update template files

--- a/docs/operational-guide.md
+++ b/docs/operational-guide.md
@@ -1015,7 +1015,7 @@ npx mg-claude-dev-kit doctor --report  # JSON compliance output for CI pipelines
 npx mg-claude-dev-kit doctor --ci      # silent mode: exit 1 if any check fails
 ```
 
-Runs 17 checks:
+Runs 19 checks:
 
 1. Claude Code CLI is installed and reachable
 2. `CLAUDE.md` is present
@@ -1034,8 +1034,10 @@ Runs 17 checks:
 15. `.claude/skills/commit/` present (Tier M/L - warn if missing)
 16. Skills invoking Playwright `browser_*` tools declare `allowed-tools` frontmatter (warn if missing)
 17. `.claude/rules/context-review.md` includes C12 (warn if not present - upgrade needed)
+18. Stop hook has `timeout` configured and ≤ 600000ms (warn if missing - prevents hanging test commands)
+19. No duplicate entries in `permissions.deny` list (warn if duplicates found)
 
-Checks 12-17 are skipped for Tier 0 projects.
+Checks 12-19 are skipped for Tier 0 projects.
 
 **`--report` output**: machine-readable JSON with timestamp, cwd, summary (passed/warned/failed/skipped), and per-check details. Consumed by CI systems or external audit tools.
 

--- a/packages/cli/src/commands/doctor.js
+++ b/packages/cli/src/commands/doctor.js
@@ -278,6 +278,56 @@ const checks = [
       };
     },
   },
+  {
+    id: 'stop-hook-timeout',
+    label: 'Stop hook has timeout configured',
+    check: (cwd) => {
+      const p = path.join(cwd, '.claude', 'settings.json');
+      if (!fs.existsSync(p)) return { pass: true, skip: true };
+      try {
+        const settings = JSON.parse(fs.readFileSync(p, 'utf8'));
+        const stopHooks = settings?.hooks?.Stop || [];
+        if (stopHooks.length === 0) return { pass: true, skip: true };
+        const allHaveTimeout = stopHooks.every(
+          (entry) => typeof entry.timeout === 'number' && entry.timeout <= 600000,
+        );
+        return {
+          pass: allHaveTimeout,
+          warn: true,
+          fix: 'Add "timeout": 300000 to each Stop hook entry in .claude/settings.json. Without a timeout, a hanging test command blocks Claude indefinitely.',
+        };
+      } catch {
+        return { pass: true, skip: true };
+      }
+    },
+  },
+  {
+    id: 'permissions-no-duplicates',
+    label: 'No duplicate entries in permissions deny list',
+    check: (cwd) => {
+      const p = path.join(cwd, '.claude', 'settings.json');
+      if (!fs.existsSync(p)) return { pass: true, skip: true };
+      try {
+        const settings = JSON.parse(fs.readFileSync(p, 'utf8'));
+        const deny = settings?.permissions?.deny;
+        if (!Array.isArray(deny) || deny.length === 0) return { pass: true, skip: true };
+        const seen = new Set();
+        const dupes = [];
+        for (const entry of deny) {
+          if (seen.has(entry)) dupes.push(entry);
+          seen.add(entry);
+        }
+        return {
+          pass: dupes.length === 0,
+          warn: true,
+          info: dupes.length > 0 ? `duplicates: ${dupes.join(', ')}` : undefined,
+          fix: `Remove duplicate entries from permissions.deny in .claude/settings.json: ${dupes.join(', ')}`,
+        };
+      } catch {
+        return { pass: true, skip: true };
+      }
+    },
+  },
 ];
 
 export async function doctor(options = {}) {

--- a/packages/cli/src/scaffold/skill-registry.js
+++ b/packages/cli/src/scaffold/skill-registry.js
@@ -27,7 +27,7 @@ export const SKILL_REGISTRY = [
   { name: 'simplify', minTier: 's', requires: {}, cheatsheet: true },
   { name: 'skill-dev', minTier: 's', requires: {}, cheatsheet: true },
   { name: 'perf-audit', minTier: 's', requires: {}, cheatsheet: true },
-  { name: 'security-audit', minTier: 's', requires: { hasApi: true }, cheatsheet: true },
+  { name: 'security-audit', minTier: 's', requires: {}, cheatsheet: true },
   { name: 'api-design', minTier: 'm', requires: { hasApi: true }, cheatsheet: true },
   { name: 'skill-db', minTier: 'm', requires: { hasDatabase: true }, cheatsheet: true },
   {

--- a/packages/cli/templates/tier-l/.claude/skills/arch-audit/SKILL.md
+++ b/packages/cli/templates/tier-l/.claude/skills/arch-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: arch-audit
-description: Audit the Claude Code architecture files against latest Anthropic documentation and release notes, AND verify internal ecosystem consistency. Run weekly to maintain compliance, catch new features, and keep the project's context system clean and efficient.
+description: Audit Claude Code architecture files against Anthropic docs and release notes, and verify internal ecosystem consistency. Run weekly to maintain compliance, catch new features, and keep the context system clean.
 user-invocable: true
 model: sonnet
 context: fork

--- a/packages/cli/templates/tier-m/.claude/skills/arch-audit/SKILL.md
+++ b/packages/cli/templates/tier-m/.claude/skills/arch-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: arch-audit
-description: Audit the Claude Code architecture files against latest Anthropic documentation and release notes, AND verify internal ecosystem consistency. Run weekly to maintain compliance, catch new features, and keep the project's context system clean and efficient.
+description: Audit Claude Code architecture files against Anthropic docs and release notes, and verify internal ecosystem consistency. Run weekly to maintain compliance, catch new features, and keep the context system clean.
 user-invocable: true
 model: sonnet
 context: fork

--- a/packages/cli/templates/tier-s/.claude/skills/arch-audit/SKILL.md
+++ b/packages/cli/templates/tier-s/.claude/skills/arch-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: arch-audit
-description: Audit the Claude Code architecture files against latest Anthropic documentation and release notes, AND verify internal ecosystem consistency. Run weekly to maintain compliance, catch new features, and keep the project's context system clean and efficient.
+description: Audit Claude Code architecture files against Anthropic docs and release notes, and verify internal ecosystem consistency. Run weekly to maintain compliance, catch new features, and keep the context system clean.
 user-invocable: true
 model: sonnet
 context: fork

--- a/packages/cli/test/integration/run.js
+++ b/packages/cli/test/integration/run.js
@@ -666,9 +666,9 @@ async function scenarioSkillPruning() {
   assertNotExists(dir, 'docs/sitemap.md');
   assertNotExists(dir, 'docs/db-map.md');
 
-  // Skills that must be absent (hasApi=false → api-design + security-audit pruned)
+  // Skills that must be absent (hasApi=false → api-design pruned; hasDatabase=false → skill-db pruned)
   assertNotExists(dir, '.claude/skills/api-design/SKILL.md');
-  assertNotExists(dir, '.claude/skills/security-audit/SKILL.md');
+  assertExists(dir, '.claude/skills/security-audit/SKILL.md');
   assertNotExists(dir, '.claude/skills/skill-db/SKILL.md');
   assertNotExists(dir, '.claude/skills/responsive-audit/SKILL.md');
   assertNotExists(dir, '.claude/skills/visual-audit/SKILL.md');
@@ -683,7 +683,7 @@ async function scenarioSkillPruning() {
 }
 
 async function scenarioTierSSkillPruning() {
-  section('Tier S skill pruning — hasApi=false → security-audit pruned');
+  section('Tier S skill pruning — hasApi=false keeps security-audit (stack-agnostic)');
   const config = {
     ...BASE,
     tier: 's',
@@ -694,8 +694,8 @@ async function scenarioTierSSkillPruning() {
   };
   const dir = await scaffold('tier-s-pruned', 's', config);
 
-  // security-audit must be pruned when hasApi=false
-  assertNotExists(dir, '.claude/skills/security-audit/SKILL.md');
+  // security-audit must be present regardless of hasApi (has native security path)
+  assertExists(dir, '.claude/skills/security-audit/SKILL.md');
 
   // Universal skills must remain
   assertExists(dir, '.claude/skills/arch-audit/SKILL.md');
@@ -704,12 +704,12 @@ async function scenarioTierSSkillPruning() {
   assertExists(dir, '.claude/skills/simplify/SKILL.md');
   assertExists(dir, '.claude/skills/commit/SKILL.md');
 
-  // Active Skills must not list security-audit
+  // Active Skills must list security-audit
   const claude = fs.readFileSync(path.join(dir, 'CLAUDE.md'), 'utf8');
-  if (!claude.includes('/security-audit')) {
-    pass('Tier S pruned: Active Skills does not list security-audit');
+  if (claude.includes('/security-audit')) {
+    pass('Tier S pruned: Active Skills lists security-audit (stack-agnostic)');
   } else {
-    fail('Tier S pruned: Active Skills should not list security-audit when hasApi=false');
+    fail('Tier S pruned: Active Skills should list security-audit even when hasApi=false');
   }
 
   // Active Skills must list universal skills
@@ -1066,10 +1066,8 @@ async function scenarioSecurityVariants() {
       }
     }
 
-    // Verify security-audit skill pruned when hasApi=false
-    if (!hasApi) {
-      assertNotExists(dir, '.claude/skills/security-audit/SKILL.md');
-    }
+    // security-audit is always present (stack-agnostic, has native security path)
+    assertExists(dir, '.claude/skills/security-audit/SKILL.md');
   }
 }
 
@@ -1287,10 +1285,10 @@ async function scenarioCheatsheetPruning() {
     fail('cheatsheet: /skill-db row should be removed when hasDatabase=false');
   }
 
-  if (!cheat.includes('/security-audit')) {
-    pass('cheatsheet: /security-audit row removed (hasApi=false)');
+  if (cheat.includes('/security-audit')) {
+    pass('cheatsheet: /security-audit row present (stack-agnostic, not API-gated)');
   } else {
-    fail('cheatsheet: /security-audit row should be removed when hasApi=false');
+    fail('cheatsheet: /security-audit row should be present regardless of hasApi');
   }
 
   // Doc reference must be correct
@@ -1337,7 +1335,7 @@ async function scenarioNativeSkillAdaptation() {
   ];
 
   for (const { stack, perfTool, lintCmd, secChecklist } of stacks) {
-    // hasApi=true so security-audit is not pruned
+    // security-audit is always present (stack-agnostic)
     const config = {
       ...BASE,
       tier: 'm',
@@ -1588,9 +1586,9 @@ async function scenarioRubricScore() {
       }
     }
 
-    // No pruned skill should be listed
+    // No pruned skill should be listed (security-audit is always present — not API-gated)
     if (!hasApi) {
-      if (!activeBlock.includes('/api-design') && !activeBlock.includes('/security-audit')) {
+      if (!activeBlock.includes('/api-design')) {
         rubricPass('D5', `[${name}] no API-only skills listed when hasApi=false`);
       } else {
         rubricFail('D5', `[${name}] API-only skill listed when hasApi=false`);
@@ -1603,7 +1601,6 @@ async function scenarioRubricScore() {
       const cheat = fs.readFileSync(cheatPath, 'utf8');
       let cheatClean = true;
       if (!hasApi && cheat.includes('/api-design')) cheatClean = false;
-      if (!hasApi && cheat.includes('/security-audit')) cheatClean = false;
       if (config.hasDatabase === false && cheat.includes('/skill-db')) cheatClean = false;
       if (cheatClean) {
         rubricPass('D5', `[${name}] cheatsheet has no phantom skill rows`);

--- a/packages/cli/test/unit/claude-md.test.js
+++ b/packages/cli/test/unit/claude-md.test.js
@@ -132,9 +132,9 @@ describe('injectActiveSkills', () => {
     assert.ok(result.includes('`/security-audit`'));
   });
 
-  it('tier S with hasApi=false excludes security-audit', () => {
+  it('tier S with hasApi=false keeps security-audit (stack-agnostic)', () => {
     const result = injectActiveSkills(base, { tier: 's', hasApi: false });
-    assert.ok(!result.includes('`/security-audit`'));
+    assert.ok(result.includes('`/security-audit`'));
     assert.ok(result.includes('`/arch-audit`'));
   });
 
@@ -155,10 +155,10 @@ describe('injectActiveSkills', () => {
     assert.ok(result.includes('`/ui-audit`'));
   });
 
-  it('tier M hasApi=false excludes api-design and security-audit', () => {
+  it('tier M hasApi=false excludes api-design but keeps security-audit', () => {
     const result = injectActiveSkills(base, { tier: 'm', hasApi: false });
     assert.ok(!result.includes('`/api-design`'));
-    assert.ok(!result.includes('`/security-audit`'));
+    assert.ok(result.includes('`/security-audit`'));
   });
 
   it('tier M hasFrontend=false excludes all frontend skills', () => {

--- a/packages/cli/test/unit/scaffold.test.js
+++ b/packages/cli/test/unit/scaffold.test.js
@@ -544,12 +544,12 @@ describe('pruneSkills', () => {
     await fs.remove(tmpDir);
   });
 
-  it('hasApi=false removes api-design and security-audit', async () => {
+  it('hasApi=false removes api-design but keeps security-audit', async () => {
     await setupSkills(tmpDir);
     await pruneSkills(tmpDir, { techStack: 'node-ts', hasApi: false });
     const left = remaining(tmpDir);
     assert.ok(!left.includes('api-design'));
-    assert.ok(!left.includes('security-audit'));
+    assert.ok(left.includes('security-audit'));
   });
 
   it('hasDatabase=false removes skill-db', async () => {
@@ -606,12 +606,12 @@ describe('pruneSkills', () => {
     // should complete without error
   });
 
-  it('combined: hasApi=false + hasFrontend=false removes both groups', async () => {
+  it('combined: hasApi=false + hasFrontend=false removes both groups but keeps security-audit', async () => {
     await setupSkills(tmpDir);
     await pruneSkills(tmpDir, { techStack: 'node-ts', hasApi: false, hasFrontend: false });
     const left = remaining(tmpDir);
     assert.ok(!left.includes('api-design'));
-    assert.ok(!left.includes('security-audit'));
+    assert.ok(left.includes('security-audit'));
     assert.ok(!left.includes('responsive-audit'));
     assert.ok(!left.includes('visual-audit'));
     assert.ok(!left.includes('ux-audit'));

--- a/packages/cli/test/unit/skill-registry.test.js
+++ b/packages/cli/test/unit/skill-registry.test.js
@@ -58,10 +58,10 @@ describe('getSkillsToRemove', () => {
     assert.equal(result.length, 0);
   });
 
-  it('hasApi=false removes api-design and security-audit', () => {
+  it('hasApi=false removes api-design but keeps security-audit', () => {
     const result = getSkillsToRemove({ techStack: 'node-ts', hasApi: false });
     assert.ok(result.includes('api-design'));
-    assert.ok(result.includes('security-audit'));
+    assert.ok(!result.includes('security-audit'));
     assert.ok(!result.includes('perf-audit'));
   });
 
@@ -92,10 +92,10 @@ describe('getSkillsToRemove', () => {
     assert.ok(!result.includes('visual-audit'));
   });
 
-  it('combined: hasApi=false + hasFrontend=false removes both groups', () => {
+  it('combined: hasApi=false + hasFrontend=false removes both groups but keeps security-audit', () => {
     const result = getSkillsToRemove({ techStack: 'node-ts', hasApi: false, hasFrontend: false });
     assert.ok(result.includes('api-design'));
-    assert.ok(result.includes('security-audit'));
+    assert.ok(!result.includes('security-audit'));
     assert.ok(result.includes('responsive-audit'));
     assert.ok(result.includes('visual-audit'));
     assert.ok(result.includes('ux-audit'));
@@ -127,9 +127,9 @@ describe('getActiveSkills', () => {
     assert.ok(!result.includes('skill-db'));
   });
 
-  it('tier S hasApi=false excludes security-audit', () => {
+  it('tier S hasApi=false keeps security-audit (stack-agnostic)', () => {
     const result = getActiveSkills({ tier: 's', hasApi: false });
-    assert.ok(!result.includes('security-audit'));
+    assert.ok(result.includes('security-audit'));
     assert.ok(result.includes('arch-audit'));
   });
 
@@ -150,10 +150,10 @@ describe('getActiveSkills', () => {
     assert.ok(result.includes('ui-audit'));
   });
 
-  it('tier M hasApi=false excludes api-design and security-audit', () => {
+  it('tier M hasApi=false excludes api-design but keeps security-audit', () => {
     const result = getActiveSkills({ tier: 'm', hasApi: false });
     assert.ok(!result.includes('api-design'));
-    assert.ok(!result.includes('security-audit'));
+    assert.ok(result.includes('security-audit'));
   });
 
   it('tier M hasFrontend=false excludes all frontend skills', () => {
@@ -199,9 +199,9 @@ describe('getCheatsheetSkillsToRemove', () => {
     assert.equal(result.length, 0);
   });
 
-  it('hasApi=false removes security-audit and api-design from cheatsheet', () => {
+  it('hasApi=false removes api-design from cheatsheet but keeps security-audit', () => {
     const result = getCheatsheetSkillsToRemove({ techStack: 'node-ts', hasApi: false });
-    assert.ok(result.includes('security-audit'));
+    assert.ok(!result.includes('security-audit'));
     assert.ok(result.includes('api-design'));
   });
 


### PR DESCRIPTION
## Summary

- **security-audit skill registry bug**: `requires: { hasApi: true }` changed to `requires: {}` — native apps (Swift, Kotlin, Rust) now receive NS1-NS6 security checks. Scaffold output already listed the skill as "included" but the directory was silently not created.
- **arch-audit description**: trimmed from 255 to 211 chars (limit is 250)
- **doctor check #18**: warns if Stop hook has no `timeout` configured (prevents hanging test commands blocking Claude indefinitely)
- **doctor check #19**: warns if `permissions.deny` contains duplicate entries
- Updated doctor check count: 17 → 19 in README, CONTRIBUTING, operational-guide

Found via quality audit of CDK v1.9.1 scaffold applied to mac-transcription-collector (Swift/macOS).

## Test plan

- [x] Unit tests: 243/243 passed
- [x] Integration tests: 469/469 passed (5 new assertions)
- [ ] Re-scaffold mac-transcription-collector and verify security-audit is now present
- [ ] Run `doctor` on mac-transcription-collector and verify checks #18 #19 report correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)