### PR TITLE
fix(hooks): correct timeout units from ms to seconds per Anthropic schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - GitHub Project board populated with Q1-Q2 roadmap deliverables (14 issues across 2 milestones)
 - Skill `description` field in all 12 SKILL.md frontmatter files (max 250 chars, used by Claude for auto-invocation)
 
+### Fixed
+- Hook `timeout` values corrected from milliseconds to seconds per Anthropic JSON schema (Tier M: 300000→300, Tier L: 600000→600)
+- Doctor check #18 threshold corrected from 600000 to 600 (seconds, not milliseconds)
+- Doctor check #18 fix message now suggests correct value (`"timeout": 300`)
+
 ### Changed
 - `pruneSkills()` rewritten from 37 to 5 lines (delegates to skill registry)
 - `pruneCheatsheet()` rewritten from 15 to 9 lines (delegates to skill registry)

--- a/docs/operational-guide.md
+++ b/docs/operational-guide.md
@@ -1034,7 +1034,7 @@ Runs 19 checks:
 15. `.claude/skills/commit/` present (Tier M/L - warn if missing)
 16. Skills invoking Playwright `browser_*` tools declare `allowed-tools` frontmatter (warn if missing)
 17. `.claude/rules/context-review.md` includes C12 (warn if not present - upgrade needed)
-18. Stop hook has `timeout` configured and ≤ 600000ms (warn if missing - prevents hanging test commands)
+18. Stop hook has `timeout` configured and ≤ 600s (warn if missing - prevents hanging test commands)
 19. No duplicate entries in `permissions.deny` list (warn if duplicates found)
 
 Checks 12-19 are skipped for Tier 0 projects.

--- a/packages/cli/src/commands/doctor.js
+++ b/packages/cli/src/commands/doctor.js
@@ -289,12 +289,12 @@ const checks = [
         const stopHooks = settings?.hooks?.Stop || [];
         if (stopHooks.length === 0) return { pass: true, skip: true };
         const allHaveTimeout = stopHooks.every(
-          (entry) => typeof entry.timeout === 'number' && entry.timeout <= 600000,
+          (entry) => typeof entry.timeout === 'number' && entry.timeout <= 600,
         );
         return {
           pass: allHaveTimeout,
           warn: true,
-          fix: 'Add "timeout": 300000 to each Stop hook entry in .claude/settings.json. Without a timeout, a hanging test command blocks Claude indefinitely.',
+          fix: 'Add "timeout": 300 to each Stop hook entry in .claude/settings.json (value is in seconds). Without a timeout, a hanging test command blocks Claude indefinitely.',
         };
       } catch {
         return { pass: true, skip: true };

--- a/packages/cli/templates/tier-l/.claude/settings.json
+++ b/packages/cli/templates/tier-l/.claude/settings.json
@@ -32,7 +32,7 @@
           {
             "type": "command",
             "command": "[ \"$stop_hook_active\" = \"1\" ] && exit 0; cd $CLAUDE_PROJECT_DIR && [TEST_COMMAND] 2>&1 | tail -10; [[ ${PIPESTATUS[0]} -ne 0 ]] && echo '{\"decision\": \"block\", \"reason\": \"Tests must pass before completing. Fix failing tests first.\"}'",
-            "timeout": 600000
+            "timeout": 600
           }
         ]
       },

--- a/packages/cli/templates/tier-m/.claude/settings.json
+++ b/packages/cli/templates/tier-m/.claude/settings.json
@@ -6,13 +6,7 @@
   },
   "includeGitInstructions": false,
   "permissions": {
-    "allow": [
-      "Bash(git:*)",
-      "Bash(node:*)",
-      "Bash(npm:*)",
-      "Bash(npx:*)",
-      "Bash(curl:*)"
-    ],
+    "allow": ["Bash(git:*)", "Bash(node:*)", "Bash(npm:*)", "Bash(npx:*)", "Bash(curl:*)"],
     "deny": [
       "Bash(git push --force*)",
       "Bash(git push origin main*)",
@@ -28,7 +22,7 @@
           {
             "type": "command",
             "command": "[ \"$stop_hook_active\" = \"1\" ] && exit 0; cd $CLAUDE_PROJECT_DIR && [TEST_COMMAND] 2>&1 | tail -5; [[ ${PIPESTATUS[0]} -ne 0 ]] && echo '{\"decision\": \"block\", \"reason\": \"Tests must pass before completing the task. Fix failing tests first.\"}'",
-            "timeout": 300000
+            "timeout": 300
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Hook `timeout` field is in **seconds** per the [Anthropic JSON schema](https://json.schemastore.org/claude-code-settings.json), but CDK templates used millisecond-scale values (300000, 600000) — resulting in 83-hour and 166-hour timeouts instead of the intended 5 and 10 minutes
- Tier M template: `300000` → `300` (5 minutes)
- Tier L template: `600000` → `600` (10 minutes)
- Doctor check #18: threshold corrected from `600000` to `600`, fix message updated
- Operational guide: documentation corrected from `≤ 600000ms` to `≤ 600s`

## Found by
Arch-audit against official Anthropic documentation and JSON schema at `json.schemastore.org/claude-code-settings.json`, which explicitly states: `"Optional timeout in seconds"`.

## Test plan
- [x] Unit tests: 243/243 passed
- [x] Integration tests: 469/469 passed
- [ ] Verify scaffolded Tier M project has `"timeout": 300` in settings.json
- [ ] Verify scaffolded Tier L project has `"timeout": 600` in settings.json
- [ ] Verify `doctor` warns when timeout > 600

🤖 Generated with [Claude Code](https://claude.com/claude-code)