### PR TITLE
feat(cli): add `new skill` command - interactive custom skill scaffolder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased] — v1.9.1
 
 ### Added
+- `new skill` command - interactive wizard to scaffold custom skills with valid frontmatter, test fixture, and CLAUDE.md registration (#55)
+- `claudemd-update.js` shared utility - extracted CLAUDE.md Active Skills registration for reuse across commands
 - `add skill <name>` command - install a single skill without full scaffold (12 skills available)
 - `add rule <name>` command - install a single rule with stack-specific security variants (`--stack swift|kotlin|rust|dotnet|java|go`)
 - `custom-*` skill convention - user-created skills preserved across `upgrade` and `init` operations

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Run before every release to validate all tier/mode combinations:
 node packages/cli/test/integration/run.js
 # Add --verbose for per-check output
 ```
-459 checks: file structure per tier, Stop hook presence and resolution, pipeline gate counts, wizard placeholder resolution, safe-mode preservation, new named stacks (swift/kotlin/rust/dotnet/ruby/java), conditional docs pruning (sitemap.md, db-map.md), security rule variant selection (6 stack/API combinations + leak check + deny verification), placeholder noise reduction (unfilled sections stripped from CLAUDE.md), native skill adaptation (8 stacks), simplify skill presence, rubric scoring (D2/D5/D7/D8 for node-ts/swift/python with quality floor), full CLI execution via `--answers` fixtures (9 scenarios). Output is gitignored (`packages/cli/test/integration/output/`).
+481 checks: file structure per tier, Stop hook presence and resolution, pipeline gate counts, wizard placeholder resolution, safe-mode preservation, new named stacks (swift/kotlin/rust/dotnet/ruby/java), conditional docs pruning (sitemap.md, db-map.md), security rule variant selection (6 stack/API combinations + leak check + deny verification), placeholder noise reduction (unfilled sections stripped from CLAUDE.md), native skill adaptation (8 stacks), simplify skill presence, rubric scoring (D2/D5/D7/D8 for node-ts/swift/python with quality floor), full CLI execution via `--answers` fixtures (9 scenarios). Output is gitignored (`packages/cli/test/integration/output/`).
 
 ## Interaction Protocol
 **Perimeter questions** (scope, vision, user, future): always use the `AskUserQuestion` tool — never present as inline text. Max 4 questions per call, each with 2–4 options. Open-ended questions get representative options + "Other" for custom input.
@@ -77,4 +77,4 @@ node packages/cli/test/integration/run.js
 - Both updated as mandatory final step after every round of changes (standing rule)
 
 ## Current Version
-`v1.9.0` — alignment block (Phases 1-3). CI consolidation, ESLint+Prettier, 199 unit tests, CLAUDE.md single-authority generation, security-audit 3-path selector (NS1-NS6), perf-audit native resource checks (NR1-NR4), Node.js >=22. 459 integration checks.
+`v1.9.0` — alignment block (Phases 1-3). CI consolidation, ESLint+Prettier, 271 unit tests, CLAUDE.md single-authority generation, security-audit 3-path selector (NS1-NS6), perf-audit native resource checks (NR1-NR4), Node.js >=22. 481 integration checks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,10 +71,25 @@ node packages/cli/test/integration/run.js
 
 **Lessons Capture**: after any user correction, check if the pattern is non-obvious. If so, save it as a feedback memory immediately.
 
+## Roadmap Tracking
+
+When work starts or completes on a roadmap item (any issue linked to a GitHub milestone), update these three locations:
+
+**On start**: set status to `In Progress`, record start date in `.claude/initiatives/roadmap-status.md`. Update GitHub Project board start date via `gh api graphql`.
+
+**On completion** (PR created, before merging):
+1. `.claude/initiatives/roadmap-status.md` — set status to `Done`, record end date and PR number
+2. `docs/reviews/roadmap-v1.9.1.md` — update the deliverable's Status column to **Done** with PR reference
+3. GitHub Project board — set status to Done, update start/target dates via `gh api graphql`
+4. Close the GitHub issue with implementation summary
+
+These updates are part of the commit sequence (docs commit), not a post-merge afterthought.
+
 ## Reference Documents
 - `README.md` — public-facing, must stay in sync with all template/CLI changes
 - `docs/operational-guide.md` — full reference, must stay in sync
-- Both updated as mandatory final step after every round of changes (standing rule)
+- `.claude/initiatives/roadmap-status.md` — local roadmap progress tracking
+- All updated as mandatory final step after every round of changes (standing rule)
 
 ## Current Version
 `v1.9.0` — alignment block (Phases 1-3). CI consolidation, ESLint+Prettier, 271 unit tests, CLAUDE.md single-authority generation, security-audit 3-path selector (NS1-NS6), perf-audit native resource checks (NR1-NR4), Node.js >=22. 481 integration checks.

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ npx mg-claude-dev-kit upgrade                 # update template files
 npx mg-claude-dev-kit upgrade --tier=m        # promote to higher tier
 npx mg-claude-dev-kit add skill <name>        # install one skill
 npx mg-claude-dev-kit add rule <name>         # install one rule
+npx mg-claude-dev-kit new skill               # create a custom skill (wizard)
 ```
 
 ---

--- a/docs/operational-guide.md
+++ b/docs/operational-guide.md
@@ -427,6 +427,25 @@ The security rule supports stack-specific variants via `--stack`:
 
 Options: `--force`, `--dry-run` (same as `add skill`).
 
+### 7c. Creating custom skills
+
+```bash
+npx mg-claude-dev-kit new skill
+```
+
+Interactive wizard that generates a complete custom skill:
+
+1. **SKILL.md** with valid frontmatter (name, description, model, context, effort, allowed-tools) and a step-by-step body template
+2. **test-skill.js** alongside SKILL.md - validates frontmatter structure, description length, and allowed-tools compliance
+3. **CLAUDE.md registration** - adds the skill to the Active Skills section automatically
+
+The generated skill uses the `custom-` naming convention, which protects it from being overwritten during `upgrade` or `init` operations.
+
+Options:
+- `--name <name>` - skip the name prompt (auto-prepends `custom-` if missing)
+- `--dry-run` - preview what would be created
+- `--answers <json>` - bypass all prompts with JSON (for automation)
+
 ### Minimum viable CDK
 
 The smallest useful CDK setup - no full scaffold required:

--- a/packages/cli/src/commands/add.js
+++ b/packages/cli/src/commands/add.js
@@ -3,6 +3,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { SKILL_REGISTRY } from '../scaffold/skill-registry.js';
+import { registerSkillInClaudeMd } from '../utils/claudemd-update.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const TEMPLATES_DIR = path.resolve(__dirname, '../../templates');
@@ -82,14 +83,9 @@ export async function addSkill(name, options) {
   console.log(`${chalk.green('✓')} Installed .claude/skills/${name}/SKILL.md`);
 
   // Append to CLAUDE.md Active Skills section if it exists
-  const claudePath = path.join(cwd, 'CLAUDE.md');
-  if (fs.existsSync(claudePath)) {
-    const content = fs.readFileSync(claudePath, 'utf8');
-    if (content.includes('## Active Skills') && !content.includes(`/${name}`)) {
-      const updated = content.replace(/## Active Skills\n/, `## Active Skills\n- \`/${name}\`\n`);
-      fs.writeFileSync(claudePath, updated);
-      console.log(`${chalk.green('✓')} Added /${name} to CLAUDE.md Active Skills`);
-    }
+  const reg = registerSkillInClaudeMd(cwd, name);
+  if (reg.updated) {
+    console.log(`${chalk.green('✓')} Added /${name} to CLAUDE.md Active Skills`);
   }
 }
 

--- a/packages/cli/src/commands/new-skill.js
+++ b/packages/cli/src/commands/new-skill.js
@@ -1,0 +1,331 @@
+import chalk from 'chalk';
+import fs from 'fs-extra';
+import path from 'path';
+import inquirer from 'inquirer';
+import { registerSkillInClaudeMd } from '../utils/claudemd-update.js';
+
+// Standard Playwright MCP tools (sourced from visual-audit SKILL.md)
+const PLAYWRIGHT_TOOLS = [
+  'Read',
+  'Glob',
+  'Grep',
+  'Bash',
+  'mcp__playwright__browser_navigate',
+  'mcp__playwright__browser_take_screenshot',
+  'mcp__playwright__browser_snapshot',
+  'mcp__playwright__browser_click',
+  'mcp__playwright__browser_type',
+  'mcp__playwright__browser_wait_for',
+  'mcp__playwright__browser_resize',
+  'mcp__playwright__browser_evaluate',
+].join(', ');
+
+const NAME_RE = /^custom-[a-z][a-z0-9-]{1,37}$/;
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+function normalizeName(raw) {
+  let name = raw.trim().toLowerCase().replace(/\s+/g, '-');
+  if (!name.startsWith('custom-')) name = `custom-${name}`;
+  return name;
+}
+
+function buildSkillMd(answers) {
+  const lines = ['---'];
+  lines.push(`name: ${answers.name}`);
+  lines.push(`description: ${answers.description}`);
+  lines.push(`user-invocable: ${answers.userInvocable !== false}`);
+  lines.push(`model: ${answers.model || 'sonnet'}`);
+  lines.push('context: fork');
+  if (answers.effort && answers.effort !== '(skip)') {
+    lines.push(`effort: ${answers.effort}`);
+  }
+  if (answers.argumentHint) {
+    lines.push(`argument-hint: ${answers.argumentHint}`);
+  }
+  if (answers.allowedTools) {
+    lines.push(`allowed-tools: ${answers.allowedTools}`);
+  }
+  lines.push('---');
+  lines.push('');
+  lines.push('**Scope**: [What this skill covers.]');
+  lines.push('**Out of scope**: [What it does NOT cover.]');
+
+  const count = Number(answers.stepCount) || 3;
+  for (let i = 1; i <= count; i++) {
+    lines.push('');
+    if (i === count) {
+      lines.push(`## Step ${i} - Produce report`);
+      lines.push('');
+      lines.push('[Define the output format. Structured reports work better than prose.]');
+    } else {
+      lines.push(`## Step ${i} - [action]`);
+      lines.push('');
+      lines.push(
+        '[Instructions for Claude. Be specific - include file paths, commands, decision criteria.]',
+      );
+    }
+  }
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+function buildTestFixture(name) {
+  return `// Validates SKILL.md structure for ${name}
+// Run: node .claude/skills/${name}/test-skill.js
+import { readFileSync } from 'fs';
+import { strict as assert } from 'assert';
+
+const content = readFileSync(new URL('./SKILL.md', import.meta.url), 'utf8');
+const [, frontmatter] = content.match(/^---\\n([\\s\\S]*?)\\n---/) || [];
+
+assert.ok(frontmatter, 'SKILL.md must have YAML frontmatter');
+assert.ok(frontmatter.includes('name:'), 'frontmatter must include name');
+assert.ok(frontmatter.includes('description:'), 'frontmatter must include description');
+assert.ok(frontmatter.includes('context: fork'), 'context must be fork');
+
+const desc = frontmatter.match(/description:\\s*(.+)/)?.[1] || '';
+assert.ok(desc.length <= 250, \`description too long: \${desc.length}/250\`);
+
+if (content.includes('browser_')) {
+  assert.ok(frontmatter.includes('allowed-tools'), 'Playwright skills must declare allowed-tools');
+}
+
+console.log('\\u2713 SKILL.md structure valid');
+`;
+}
+
+function validateSkillMd(content, dirName) {
+  const errors = [];
+  const warnings = [];
+
+  // Frontmatter presence
+  const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!fmMatch) {
+    errors.push('Missing YAML frontmatter (--- delimiters)');
+    return { errors, warnings };
+  }
+
+  const fm = fmMatch[1];
+
+  // Name matches directory
+  const nameMatch = fm.match(/^name:\s*(.+)/m);
+  if (nameMatch && nameMatch[1].trim() !== dirName) {
+    errors.push(`name field "${nameMatch[1].trim()}" does not match directory "${dirName}"`);
+  }
+
+  // Description length
+  const descMatch = fm.match(/^description:\s*(.+)/m);
+  if (descMatch) {
+    const desc = descMatch[1].trim();
+    if (desc.length > 250) {
+      errors.push(`Description too long: ${desc.length}/250 chars`);
+    } else if (desc.length < 10) {
+      warnings.push(`Description very short: ${desc.length} chars (min recommended: 10)`);
+    }
+  }
+
+  // Context must be fork
+  if (!fm.includes('context: fork')) {
+    warnings.push('context should be "fork" to prevent context pollution');
+  }
+
+  // Playwright + allowed-tools
+  const body = content.slice(fmMatch[0].length);
+  if (body.includes('browser_') && !fm.includes('allowed-tools')) {
+    warnings.push('Body references browser_ but frontmatter lacks allowed-tools');
+  }
+
+  return { errors, warnings };
+}
+
+// ── command handler ─────────────────────────────────────────────────────────
+
+export async function newSkill(options) {
+  const cwd = process.cwd();
+
+  // Require .claude/ directory
+  if (!fs.existsSync(path.join(cwd, '.claude'))) {
+    console.error(chalk.red('No .claude/ directory found.'));
+    console.log(
+      'Run ' + chalk.cyan('claude-dev-kit init') + ' first, or create .claude/ manually.',
+    );
+    process.exit(1);
+  }
+
+  // Collect answers
+  let answers;
+  if (options.answers) {
+    try {
+      answers = JSON.parse(options.answers);
+    } catch {
+      console.error(chalk.red('Invalid JSON in --answers.'));
+      process.exit(1);
+    }
+  } else {
+    const prompts = [];
+
+    if (!options.name) {
+      prompts.push({
+        type: 'input',
+        name: 'name',
+        message: 'Skill name (custom- prefix added automatically):',
+        validate: (v) => {
+          const n = normalizeName(v);
+          return NAME_RE.test(n) || 'Use lowercase letters, numbers, and hyphens (2-40 chars).';
+        },
+      });
+    }
+
+    prompts.push(
+      {
+        type: 'input',
+        name: 'description',
+        message: 'One-line description (max 250 chars):',
+        validate: (v) => {
+          if (!v || v.trim().length < 10) return 'Description must be at least 10 characters.';
+          if (v.trim().length > 250) return `Too long: ${v.trim().length}/250 chars.`;
+          return true;
+        },
+      },
+      {
+        type: 'list',
+        name: 'model',
+        message: 'Model:',
+        choices: [
+          { name: 'haiku  — fast, pattern-matching, grep-based checks', value: 'haiku' },
+          { name: 'sonnet — balanced analysis, multi-file reasoning', value: 'sonnet' },
+          { name: 'opus   — visual analysis, complex architectural reasoning', value: 'opus' },
+        ],
+        default: 'sonnet',
+      },
+      {
+        type: 'confirm',
+        name: 'userInvocable',
+        message: 'Can users invoke this skill directly with /name?',
+        default: true,
+      },
+      {
+        type: 'list',
+        name: 'effort',
+        message: 'Expected effort level:',
+        choices: [
+          { name: 'low    — quick checks, single file', value: 'low' },
+          { name: 'medium — multi-file analysis', value: 'medium' },
+          { name: 'high   — deep audit, subagent delegation', value: 'high' },
+          { name: '(skip) — omit from frontmatter', value: '(skip)' },
+        ],
+        default: 'medium',
+      },
+      {
+        type: 'input',
+        name: 'argumentHint',
+        message: 'Argument hint (e.g. [quick|full]) — leave blank for none:',
+        default: '',
+      },
+      {
+        type: 'confirm',
+        name: 'usesPlaywright',
+        message: 'Will this skill use Playwright (browser screenshots, navigation)?',
+        default: false,
+      },
+      {
+        type: 'input',
+        name: 'allowedTools',
+        message: 'Allowed tools (comma-separated MCP tool names):',
+        default: PLAYWRIGHT_TOOLS,
+        when: (a) => a.usesPlaywright,
+      },
+      {
+        type: 'list',
+        name: 'stepCount',
+        message: 'Number of steps in the skill:',
+        choices: ['2', '3', '4', '5'],
+        default: '3',
+      },
+    );
+
+    answers = await inquirer.prompt(prompts);
+    if (options.name) answers.name = options.name;
+  }
+
+  // Normalize name
+  answers.name = normalizeName(answers.name);
+
+  if (!NAME_RE.test(answers.name)) {
+    console.error(
+      chalk.red(`Invalid skill name: ${answers.name}. Use lowercase letters, numbers, hyphens.`),
+    );
+    process.exit(1);
+  }
+
+  // Conflict check
+  const targetDir = path.join(cwd, '.claude', 'skills', answers.name);
+  const targetSkill = path.join(targetDir, 'SKILL.md');
+
+  if (fs.existsSync(targetSkill)) {
+    console.log(chalk.yellow(`⚠ .claude/skills/${answers.name}/SKILL.md already exists.`));
+    console.log('Remove it first or choose a different name.');
+    return;
+  }
+
+  // Build content
+  const skillContent = buildSkillMd(answers);
+  const testContent = buildTestFixture(answers.name);
+
+  // Validate
+  const { errors, warnings } = validateSkillMd(skillContent, answers.name);
+  if (errors.length > 0) {
+    console.error(chalk.red('Validation errors:'));
+    errors.forEach((e) => console.error(`  ${chalk.red('✗')} ${e}`));
+    process.exit(1);
+  }
+
+  // Dry run
+  if (options.dryRun) {
+    console.log(chalk.yellow('Dry run — no files written.'));
+    console.log(`  Would create: .claude/skills/${answers.name}/SKILL.md`);
+    console.log(`  Would create: .claude/skills/${answers.name}/test-skill.js`);
+    console.log(`  Would register: /${answers.name} in CLAUDE.md Active Skills`);
+    return;
+  }
+
+  // Write files
+  await fs.ensureDir(targetDir);
+  await fs.writeFile(targetSkill, skillContent);
+  console.log(`${chalk.green('✓')} Created .claude/skills/${answers.name}/SKILL.md`);
+
+  const targetTest = path.join(targetDir, 'test-skill.js');
+  await fs.writeFile(targetTest, testContent);
+  console.log(`${chalk.green('✓')} Created .claude/skills/${answers.name}/test-skill.js`);
+
+  // Register in CLAUDE.md
+  const reg = registerSkillInClaudeMd(cwd, answers.name, answers.description);
+  if (reg.updated) {
+    console.log(`${chalk.green('✓')} Added /${answers.name} to CLAUDE.md Active Skills`);
+  } else if (reg.reason === 'CLAUDE.md not found') {
+    console.log(
+      chalk.dim(`  No CLAUDE.md found — add /${answers.name} to Active Skills manually.`),
+    );
+  }
+
+  // Validation summary
+  if (warnings.length > 0) {
+    console.log();
+    warnings.forEach((w) => console.log(`  ${chalk.yellow('⚠')} ${w}`));
+  }
+  console.log(`  Validation: ${errors.length} errors, ${warnings.length} warnings`);
+
+  // Next steps
+  console.log();
+  console.log(chalk.dim('Next steps:'));
+  console.log(
+    chalk.dim(`  1. Edit .claude/skills/${answers.name}/SKILL.md — fill in the step instructions`),
+  );
+  console.log(chalk.dim(`  2. Test: invoke /${answers.name} in Claude Code`));
+  console.log(chalk.dim(`  3. Validate: node .claude/skills/${answers.name}/test-skill.js`));
+}
+
+// Export internals for testing
+export const _testHelpers = { normalizeName, buildSkillMd, buildTestFixture, validateSkillMd };

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -5,6 +5,7 @@ import { init } from './commands/init.js';
 import { doctor } from './commands/doctor.js';
 import { upgrade } from './commands/upgrade.js';
 import { addSkill, addRule } from './commands/add.js';
+import { newSkill } from './commands/new-skill.js';
 import chalk from 'chalk';
 
 program
@@ -55,6 +56,16 @@ add
   .option('--force', 'Overwrite if the rule already exists')
   .option('--dry-run', 'Show what would be created without writing files')
   .action(addRule);
+
+const newCmd = program.command('new').description('Create a new custom resource from scratch');
+
+newCmd
+  .command('skill')
+  .description('Create a custom skill with an interactive wizard')
+  .option('--name <name>', 'Skill name (auto-prepends custom- if missing)')
+  .option('--dry-run', 'Show what would be created without writing files')
+  .option('--answers <json>', 'Bypass prompts with JSON answers (for testing)')
+  .action(newSkill);
 
 program.on('command:*', () => {
   console.error(chalk.red(`Unknown command: ${program.args.join(' ')}`));

--- a/packages/cli/src/utils/claudemd-update.js
+++ b/packages/cli/src/utils/claudemd-update.js
@@ -1,0 +1,36 @@
+import fs from 'fs-extra';
+import path from 'path';
+
+/**
+ * Register a skill in the CLAUDE.md Active Skills section.
+ * Shared by add.js and new-skill.js.
+ *
+ * @param {string} cwd - Project root directory
+ * @param {string} skillName - Skill name (e.g. 'custom-deploy' or 'api-design')
+ * @param {string} [description] - Optional description appended after the name
+ * @returns {{ updated: boolean, reason?: string }}
+ */
+export function registerSkillInClaudeMd(cwd, skillName, description) {
+  const claudePath = path.join(cwd, 'CLAUDE.md');
+
+  if (!fs.existsSync(claudePath)) {
+    return { updated: false, reason: 'CLAUDE.md not found' };
+  }
+
+  const content = fs.readFileSync(claudePath, 'utf8');
+
+  if (!content.includes('## Active Skills')) {
+    return { updated: false, reason: 'No Active Skills section in CLAUDE.md' };
+  }
+
+  if (content.includes(`/${skillName}`)) {
+    return { updated: false, reason: 'Skill already registered' };
+  }
+
+  const suffix = description ? ` - ${description}` : '';
+  const entry = `- \`/${skillName}\`${suffix}\n`;
+  const updated = content.replace(/## Active Skills\n/, `## Active Skills\n${entry}`);
+  fs.writeFileSync(claudePath, updated);
+
+  return { updated: true };
+}

--- a/packages/cli/test/fixtures/new-skill/new-skill-basic.json
+++ b/packages/cli/test/fixtures/new-skill/new-skill-basic.json
@@ -1,0 +1,9 @@
+{
+  "name": "deploy",
+  "description": "Deploy the application to staging and run smoke tests.",
+  "model": "haiku",
+  "userInvocable": true,
+  "effort": "medium",
+  "usesPlaywright": false,
+  "stepCount": 3
+}

--- a/packages/cli/test/integration/run.js
+++ b/packages/cli/test/integration/run.js
@@ -1731,6 +1731,127 @@ async function scenarioRubricScore() {
   }
 }
 
+// ── new skill scaffolder ────────────────────────────────────────────────────
+
+async function scenarioNewSkillScaffolder() {
+  section('new skill scaffolder — end-to-end');
+
+  const dir = path.join(OUTPUT_DIR, 'new-skill');
+  await fs.ensureDir(path.join(dir, '.claude'));
+  await fs.writeFile(
+    path.join(dir, 'CLAUDE.md'),
+    '# Test\n\n## Active Skills\n- `/arch-audit`\n\n## Environment\nNode 22\n',
+  );
+
+  const CLI = path.resolve(__dirname, '../../src/index.js');
+  const answers = JSON.stringify({
+    name: 'deploy',
+    description: 'Deploy the application to staging and run smoke tests.',
+    model: 'haiku',
+    userInvocable: true,
+    effort: 'medium',
+    usesPlaywright: false,
+    stepCount: 3,
+  });
+
+  try {
+    execFileSync('node', [CLI, 'new', 'skill', '--answers', answers], {
+      cwd: dir,
+      encoding: 'utf8',
+      stdio: 'pipe',
+    });
+  } catch (e) {
+    fail('new skill command', e.stderr || e.message);
+    return;
+  }
+
+  // Verify SKILL.md created
+  const skillPath = path.join(dir, '.claude', 'skills', 'custom-deploy', 'SKILL.md');
+  if (fs.existsSync(skillPath)) {
+    pass('new skill: SKILL.md created');
+  } else {
+    fail('new skill: SKILL.md not created');
+    return;
+  }
+
+  // Verify test-skill.js created
+  const testPath = path.join(dir, '.claude', 'skills', 'custom-deploy', 'test-skill.js');
+  if (fs.existsSync(testPath)) {
+    pass('new skill: test-skill.js created');
+  } else {
+    fail('new skill: test-skill.js not created');
+  }
+
+  // Verify frontmatter
+  const content = fs.readFileSync(skillPath, 'utf8');
+  const hasFrontmatter = content.startsWith('---\n') && content.includes('\n---\n');
+  if (hasFrontmatter) pass('new skill: valid frontmatter delimiters');
+  else fail('new skill: missing frontmatter');
+
+  if (content.includes('name: custom-deploy')) pass('new skill: name field correct');
+  else fail('new skill: name field incorrect');
+
+  if (content.includes('context: fork')) pass('new skill: context is fork');
+  else fail('new skill: context not fork');
+
+  if (content.includes('model: haiku')) pass('new skill: model field correct');
+  else fail('new skill: model field incorrect');
+
+  // Verify description under 250 chars
+  const descMatch = content.match(/^description:\s*(.+)/m);
+  if (descMatch && descMatch[1].length <= 250) pass('new skill: description under 250 chars');
+  else fail('new skill: description over 250 chars or missing');
+
+  // Verify step structure
+  if (content.includes('## Step 1') && content.includes('## Step 3 - Produce report'))
+    pass('new skill: step structure correct');
+  else fail('new skill: step structure incorrect');
+
+  // Verify CLAUDE.md registration
+  const claudeMd = fs.readFileSync(path.join(dir, 'CLAUDE.md'), 'utf8');
+  if (claudeMd.includes('/custom-deploy')) pass('new skill: registered in CLAUDE.md');
+  else fail('new skill: not registered in CLAUDE.md');
+
+  // Verify custom- prefix was auto-applied (input was "deploy", output is "custom-deploy")
+  if (fs.existsSync(path.join(dir, '.claude', 'skills', 'custom-deploy')))
+    pass('new skill: custom- prefix auto-applied');
+  else fail('new skill: custom- prefix not applied');
+
+  // Test with Playwright answers
+  const playwrightAnswers = JSON.stringify({
+    name: 'visual-check',
+    description: 'Run visual regression checks with Playwright screenshots.',
+    model: 'opus',
+    userInvocable: true,
+    effort: 'high',
+    usesPlaywright: true,
+    allowedTools: 'mcp__playwright__browser_navigate, mcp__playwright__browser_take_screenshot',
+    stepCount: 2,
+  });
+
+  try {
+    execFileSync('node', [CLI, 'new', 'skill', '--answers', playwrightAnswers], {
+      cwd: dir,
+      encoding: 'utf8',
+      stdio: 'pipe',
+    });
+  } catch (e) {
+    fail('new skill (playwright)', e.stderr || e.message);
+    return;
+  }
+
+  const pwContent = fs.readFileSync(
+    path.join(dir, '.claude', 'skills', 'custom-visual-check', 'SKILL.md'),
+    'utf8',
+  );
+  if (pwContent.includes('allowed-tools:')) pass('new skill: Playwright allowed-tools present');
+  else fail('new skill: Playwright allowed-tools missing');
+
+  if (pwContent.includes('mcp__playwright__browser_navigate'))
+    pass('new skill: Playwright tools listed');
+  else fail('new skill: Playwright tools not listed');
+}
+
 // ── Main ─────────────────────────────────────────────────────────────────────
 
 async function main() {
@@ -1768,6 +1889,7 @@ async function main() {
   await scenarioNativeSkillAdaptation();
   await scenarioWizardCoverage();
   await scenarioRubricScore();
+  await scenarioNewSkillScaffolder();
 
   // ── Summary ────────────────────────────────────────────────────────────────
 

--- a/packages/cli/test/unit/new-skill.test.js
+++ b/packages/cli/test/unit/new-skill.test.js
@@ -1,0 +1,329 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'child_process';
+import fs from 'fs-extra';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CLI = path.resolve(__dirname, '../../src/index.js');
+const TMP = path.resolve(__dirname, '../integration/output/new-skill-test');
+
+function run(args, cwd = TMP) {
+  const argList = Array.isArray(args) ? args : args.split(' ');
+  try {
+    return execFileSync('node', [CLI, ...argList], {
+      cwd,
+      encoding: 'utf8',
+      stdio: 'pipe',
+    });
+  } catch (e) {
+    return { stderr: e.stderr, stdout: e.stdout, exitCode: e.status };
+  }
+}
+
+function answersArgs(overrides = {}) {
+  const base = {
+    name: 'deploy',
+    description: 'Deploy the application to staging and run smoke tests.',
+    model: 'haiku',
+    userInvocable: true,
+    effort: 'medium',
+    usesPlaywright: false,
+    stepCount: 3,
+  };
+  return ['new', 'skill', '--answers', JSON.stringify({ ...base, ...overrides })];
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers — internal functions
+// ---------------------------------------------------------------------------
+
+import { _testHelpers } from '../../src/commands/new-skill.js';
+const { normalizeName, buildSkillMd, buildTestFixture, validateSkillMd } = _testHelpers;
+
+describe('normalizeName', () => {
+  it('prepends custom- to bare name', () => {
+    assert.equal(normalizeName('deploy'), 'custom-deploy');
+  });
+
+  it('preserves existing custom- prefix', () => {
+    assert.equal(normalizeName('custom-deploy'), 'custom-deploy');
+  });
+
+  it('lowercases and replaces spaces with hyphens', () => {
+    assert.equal(normalizeName('My Cool Skill'), 'custom-my-cool-skill');
+  });
+
+  it('trims whitespace', () => {
+    assert.equal(normalizeName('  deploy  '), 'custom-deploy');
+  });
+});
+
+describe('buildSkillMd', () => {
+  it('generates valid frontmatter with all required fields', () => {
+    const md = buildSkillMd({
+      name: 'custom-test',
+      description: 'A test skill.',
+      model: 'sonnet',
+      userInvocable: true,
+      effort: 'medium',
+      stepCount: 3,
+    });
+    assert.ok(md.startsWith('---\n'));
+    assert.ok(md.includes('name: custom-test'));
+    assert.ok(md.includes('description: A test skill.'));
+    assert.ok(md.includes('model: sonnet'));
+    assert.ok(md.includes('user-invocable: true'));
+    assert.ok(md.includes('context: fork'));
+    assert.ok(md.includes('effort: medium'));
+  });
+
+  it('omits effort when set to (skip)', () => {
+    const md = buildSkillMd({
+      name: 'custom-test',
+      description: 'Test.',
+      model: 'haiku',
+      effort: '(skip)',
+      stepCount: 2,
+    });
+    assert.ok(!md.includes('effort:'));
+  });
+
+  it('omits argumentHint when empty', () => {
+    const md = buildSkillMd({
+      name: 'custom-test',
+      description: 'Test.',
+      model: 'haiku',
+      argumentHint: '',
+      stepCount: 2,
+    });
+    assert.ok(!md.includes('argument-hint:'));
+  });
+
+  it('includes argumentHint when provided', () => {
+    const md = buildSkillMd({
+      name: 'custom-test',
+      description: 'Test.',
+      model: 'haiku',
+      argumentHint: '[quick|full]',
+      stepCount: 2,
+    });
+    assert.ok(md.includes('argument-hint: [quick|full]'));
+  });
+
+  it('includes allowed-tools when provided', () => {
+    const md = buildSkillMd({
+      name: 'custom-test',
+      description: 'Test.',
+      model: 'opus',
+      allowedTools: 'Read, Glob, mcp__playwright__browser_navigate',
+      stepCount: 2,
+    });
+    assert.ok(md.includes('allowed-tools: Read, Glob, mcp__playwright__browser_navigate'));
+  });
+
+  it('generates correct number of steps', () => {
+    const md = buildSkillMd({
+      name: 'custom-test',
+      description: 'Test.',
+      model: 'haiku',
+      stepCount: 4,
+    });
+    assert.ok(md.includes('## Step 1 - [action]'));
+    assert.ok(md.includes('## Step 2 - [action]'));
+    assert.ok(md.includes('## Step 3 - [action]'));
+    assert.ok(md.includes('## Step 4 - Produce report'));
+  });
+
+  it('last step is always "Produce report"', () => {
+    const md = buildSkillMd({
+      name: 'custom-test',
+      description: 'Test.',
+      model: 'haiku',
+      stepCount: 2,
+    });
+    assert.ok(md.includes('## Step 2 - Produce report'));
+    assert.ok(!md.includes('## Step 1 - Produce report'));
+  });
+
+  it('context is always fork regardless of input', () => {
+    const md = buildSkillMd({
+      name: 'custom-test',
+      description: 'Test.',
+      model: 'haiku',
+      stepCount: 2,
+    });
+    assert.ok(md.includes('context: fork'));
+  });
+});
+
+describe('validateSkillMd', () => {
+  it('passes for valid SKILL.md', () => {
+    const md = buildSkillMd({
+      name: 'custom-test',
+      description: 'A valid test skill for unit testing purposes.',
+      model: 'sonnet',
+      stepCount: 2,
+    });
+    const { errors, warnings } = validateSkillMd(md, 'custom-test');
+    assert.equal(errors.length, 0);
+  });
+
+  it('errors on missing frontmatter', () => {
+    const { errors } = validateSkillMd('# No frontmatter', 'custom-test');
+    assert.ok(errors.some((e) => e.includes('frontmatter')));
+  });
+
+  it('errors on name mismatch', () => {
+    const md = buildSkillMd({
+      name: 'custom-wrong',
+      description: 'A valid test skill.',
+      model: 'haiku',
+      stepCount: 2,
+    });
+    const { errors } = validateSkillMd(md, 'custom-right');
+    assert.ok(errors.some((e) => e.includes('does not match')));
+  });
+
+  it('errors on description over 250 chars', () => {
+    const md = buildSkillMd({
+      name: 'custom-test',
+      description: 'A'.repeat(251),
+      model: 'haiku',
+      stepCount: 2,
+    });
+    const { errors } = validateSkillMd(md, 'custom-test');
+    assert.ok(errors.some((e) => e.includes('too long')));
+  });
+
+  it('warns on short description', () => {
+    const md = buildSkillMd({
+      name: 'custom-test',
+      description: 'Short.',
+      model: 'haiku',
+      stepCount: 2,
+    });
+    const { warnings } = validateSkillMd(md, 'custom-test');
+    assert.ok(warnings.some((w) => w.includes('very short')));
+  });
+});
+
+describe('buildTestFixture', () => {
+  it('returns valid JavaScript', () => {
+    const fixture = buildTestFixture('custom-deploy');
+    assert.ok(fixture.includes('import { readFileSync }'));
+    assert.ok(fixture.includes('custom-deploy'));
+    assert.ok(fixture.includes('context: fork'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLI integration via --answers
+// ---------------------------------------------------------------------------
+
+describe('new skill — CLI', () => {
+  before(async () => {
+    await fs.remove(TMP);
+    await fs.ensureDir(path.join(TMP, '.claude'));
+    await fs.writeFile(
+      path.join(TMP, 'CLAUDE.md'),
+      '# Test Project\n\n## Active Skills\n- `/arch-audit`\n\n## Environment\nNode 22\n',
+    );
+  });
+
+  after(async () => {
+    await fs.remove(TMP);
+  });
+
+  it('creates skill directory and SKILL.md', () => {
+    const out = run(answersArgs());
+    assert.ok(typeof out === 'string');
+    assert.ok(out.includes('Created .claude/skills/custom-deploy/SKILL.md'));
+    assert.ok(fs.existsSync(path.join(TMP, '.claude', 'skills', 'custom-deploy', 'SKILL.md')));
+  });
+
+  it('creates test-skill.js alongside SKILL.md', () => {
+    assert.ok(fs.existsSync(path.join(TMP, '.claude', 'skills', 'custom-deploy', 'test-skill.js')));
+  });
+
+  it('generated SKILL.md has all required frontmatter fields', () => {
+    const content = fs.readFileSync(
+      path.join(TMP, '.claude', 'skills', 'custom-deploy', 'SKILL.md'),
+      'utf8',
+    );
+    assert.ok(content.includes('name: custom-deploy'));
+    assert.ok(content.includes('description:'));
+    assert.ok(content.includes('user-invocable: true'));
+    assert.ok(content.includes('model: haiku'));
+    assert.ok(content.includes('context: fork'));
+  });
+
+  it('registers in CLAUDE.md Active Skills', () => {
+    const content = fs.readFileSync(path.join(TMP, 'CLAUDE.md'), 'utf8');
+    assert.ok(content.includes('/custom-deploy'));
+  });
+
+  it('does not duplicate in CLAUDE.md on second run', () => {
+    // Remove skill file to allow re-creation
+    fs.removeSync(path.join(TMP, '.claude', 'skills', 'custom-deploy'));
+    run(answersArgs());
+    const content = fs.readFileSync(path.join(TMP, 'CLAUDE.md'), 'utf8');
+    const count = content.split('/custom-deploy').length - 1;
+    assert.equal(count, 1, 'Should appear exactly once');
+  });
+
+  it('rejects if skill already exists', () => {
+    const out = run(answersArgs());
+    // out is a string (stdout) or object with stderr
+    const text = typeof out === 'string' ? out : out.stdout || '';
+    assert.ok(text.includes('already exists'));
+  });
+
+  it('--dry-run does not create files', async () => {
+    await fs.remove(path.join(TMP, '.claude', 'skills', 'custom-drytest'));
+    run([
+      'new',
+      'skill',
+      '--dry-run',
+      '--answers',
+      JSON.stringify({ name: 'drytest', description: 'Dry test.', model: 'haiku', stepCount: 2 }),
+    ]);
+    assert.ok(!fs.existsSync(path.join(TMP, '.claude', 'skills', 'custom-drytest')));
+  });
+
+  it('fails without .claude/ directory', async () => {
+    const emptyDir = path.join(TMP, '..', 'new-skill-no-claude');
+    await fs.ensureDir(emptyDir);
+    const out = run(answersArgs(), emptyDir);
+    assert.ok(out.stderr && out.stderr.includes('No .claude/ directory'));
+    await fs.remove(emptyDir);
+  });
+
+  it('includes allowed-tools when usesPlaywright is true', async () => {
+    await fs.remove(path.join(TMP, '.claude', 'skills', 'custom-visual'));
+    run(
+      answersArgs({
+        name: 'visual',
+        usesPlaywright: true,
+        allowedTools: 'mcp__playwright__browser_navigate, mcp__playwright__browser_take_screenshot',
+      }),
+    );
+    const content = fs.readFileSync(
+      path.join(TMP, '.claude', 'skills', 'custom-visual', 'SKILL.md'),
+      'utf8',
+    );
+    assert.ok(content.includes('allowed-tools:'));
+    assert.ok(content.includes('mcp__playwright__browser_navigate'));
+  });
+
+  it('omits effort field when set to (skip)', async () => {
+    await fs.remove(path.join(TMP, '.claude', 'skills', 'custom-noeffort'));
+    run(answersArgs({ name: 'noeffort', effort: '(skip)' }));
+    const content = fs.readFileSync(
+      path.join(TMP, '.claude', 'skills', 'custom-noeffort', 'SKILL.md'),
+      'utf8',
+    );
+    assert.ok(!content.includes('effort:'));
+  });
+});

--- a/packages/cli/test/unit/new-skill.test.js
+++ b/packages/cli/test/unit/new-skill.test.js
@@ -166,7 +166,7 @@ describe('validateSkillMd', () => {
       model: 'sonnet',
       stepCount: 2,
     });
-    const { errors, warnings } = validateSkillMd(md, 'custom-test');
+    const { errors } = validateSkillMd(md, 'custom-test');
     assert.equal(errors.length, 0);
   });
 


### PR DESCRIPTION
## Summary

Closes #55. Adds `cdk new skill` - an interactive wizard that scaffolds custom skills with valid SKILL.md frontmatter, a test fixture, and automatic CLAUDE.md registration.

- **9-prompt Inquirer wizard** with `--answers` JSON bypass for CI/automation
- **Shared `registerSkillInClaudeMd()` utility** extracted from `add.js` to eliminate duplication
- **Post-generation validation** checks frontmatter structure, description length, name consistency, and Playwright/allowed-tools compliance
- **`--dry-run` support** previews what would be created without writing files
- **28 unit tests** covering normalizeName, buildSkillMd, validateSkillMd, buildTestFixture, and full CLI integration
- **12 integration checks** added to the existing suite (481 total, all passing)

### New files
- `packages/cli/src/commands/new-skill.js` - command handler + wizard
- `packages/cli/src/utils/claudemd-update.js` - shared CLAUDE.md update utility
- `packages/cli/test/unit/new-skill.test.js` - 28 unit tests
- `packages/cli/test/fixtures/new-skill/new-skill-basic.json` - test fixture

### Modified files
- `packages/cli/src/index.js` - register `new` parent + `skill` child command
- `packages/cli/src/commands/add.js` - refactored to use shared utility
- `packages/cli/test/integration/run.js` - 12 new integration checks

## Test plan
- [ ] Unit tests: `node --test packages/cli/test/unit/new-skill.test.js` (28/28 pass)
- [ ] All unit tests: `node --test packages/cli/test/unit/*.test.js` (271/271 pass)
- [ ] Integration tests: `node packages/cli/test/integration/run.js` (481/481 pass)
- [ ] Manual: `node packages/cli/src/index.js new skill --answers '{"name":"test","description":"A test skill for validation.","model":"haiku","stepCount":2}'`
- [ ] Verify `add skill` still works (regression check for shared utility extraction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)