### PR TITLE
feat(drift-tracker): Anthropic drift tracker - weekly feature overlap scan

### DIFF
--- a/.github/drift-tracker/check-drift.mjs
+++ b/.github/drift-tracker/check-drift.mjs
@@ -51,18 +51,22 @@ export async function fetchPage(url) {
 
 export function stripHtml(html) {
   if (!html) return '';
-  return html
-    .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, ' ')
-    .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, ' ')
-    .replace(/<[^>]+>/g, ' ')
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(Number(n)))
-    .replace(/\s+/g, ' ')
-    .trim();
+  let text = html;
+  // Remove script/style blocks (allow optional whitespace before closing >)
+  text = text.replace(/<script[^>]*>[\s\S]*?<\/script\s*>/gi, ' ');
+  text = text.replace(/<style[^>]*>[\s\S]*?<\/style\s*>/gi, ' ');
+  // Strip remaining tags
+  text = text.replace(/<[^>]+>/g, ' ');
+  // Decode entities — &amp; must be decoded LAST to avoid double-unescaping
+  text = text.replace(/&#(\d+);/g, (_, n) => String.fromCharCode(Number(n)));
+  text = text.replace(/&#39;/g, "'");
+  text = text.replace(/&quot;/g, '"');
+  text = text.replace(/&gt;/g, '>');
+  text = text.replace(/&lt;/g, '<');
+  text = text.replace(/&amp;/g, '&');
+  // Normalize whitespace
+  text = text.replace(/\s+/g, ' ');
+  return text.trim();
 }
 
 export function extractRecentChangelog(html, days = 7) {
@@ -183,7 +187,7 @@ export function formatIssueBody(matchResult, feature, scanMeta) {
   lines.push('|---|---|');
   for (let i = 0; i < matchResult.matchedKeywords.length; i++) {
     const kw = matchResult.matchedKeywords[i];
-    const ctx = (matchResult.snippets[i] || '').replace(/\|/g, '\\|').replace(/\n/g, ' ');
+    const ctx = (matchResult.snippets[i] || '').replace(/\\/g, '\\\\').replace(/\|/g, '\\|').replace(/\n/g, ' ');
     lines.push(`| \`${kw}\` | ${ctx} |`);
   }
 

--- a/.github/drift-tracker/check-drift.mjs
+++ b/.github/drift-tracker/check-drift.mjs
@@ -52,9 +52,9 @@ export async function fetchPage(url) {
 export function stripHtml(html) {
   if (!html) return '';
   let text = html;
-  // Remove script/style blocks (allow optional whitespace before closing >)
-  text = text.replace(/<script[^>]*>[\s\S]*?<\/script\s*>/gi, ' ');
-  text = text.replace(/<style[^>]*>[\s\S]*?<\/style\s*>/gi, ' ');
+  // Remove script/style blocks (closing tag may contain whitespace or attributes)
+  text = text.replace(/<script[^>]*>[\s\S]*?<\/script[^>]*>/gi, ' ');
+  text = text.replace(/<style[^>]*>[\s\S]*?<\/style[^>]*>/gi, ' ');
   // Strip remaining tags
   text = text.replace(/<[^>]+>/g, ' ');
   // Decode entities — &amp; must be decoded LAST to avoid double-unescaping

--- a/.github/drift-tracker/check-drift.mjs
+++ b/.github/drift-tracker/check-drift.mjs
@@ -1,0 +1,326 @@
+// Anthropic drift tracker — scans Anthropic docs for features overlapping with CDK.
+// Zero external dependencies. Runs on Node.js >= 22 (native fetch).
+
+import { readFileSync, appendFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const REGEX_META = /[.*+?^${}()|[\]\\]/;
+
+// ── Feature manifest ────────────────────────────────────────────────────────
+
+export function loadFeatures(manifestPath) {
+  const p = manifestPath || join(__dirname, 'features.json');
+  const raw = JSON.parse(readFileSync(p, 'utf8'));
+
+  if (!raw.features || !Array.isArray(raw.features)) {
+    throw new Error('features.json must contain a "features" array');
+  }
+
+  const ids = new Set();
+  for (const f of raw.features) {
+    if (!f.id || !f.name || !f.risk || !f.keywords || !f.cdkFiles) {
+      throw new Error(`Feature "${f.id || '(unnamed)'}" missing required fields`);
+    }
+    if (!['high', 'medium', 'low'].includes(f.risk)) {
+      throw new Error(`Feature "${f.id}" has invalid risk: ${f.risk}`);
+    }
+    if (ids.has(f.id)) {
+      throw new Error(`Duplicate feature ID: ${f.id}`);
+    }
+    ids.add(f.id);
+  }
+
+  return raw;
+}
+
+// ── HTML processing ─────────────────────────────────────────────────────────
+
+export async function fetchPage(url) {
+  const res = await fetch(url, {
+    headers: { 'User-Agent': 'claude-dev-kit-drift-tracker/1.0' },
+    redirect: 'follow',
+  });
+  if (!res.ok) {
+    throw new Error(`Fetch failed: ${res.status} ${res.statusText} for ${url}`);
+  }
+  return res.text();
+}
+
+export function stripHtml(html) {
+  if (!html) return '';
+  return html
+    .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(Number(n)))
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function extractRecentChangelog(html, days = 7) {
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - days);
+  cutoff.setHours(0, 0, 0, 0);
+
+  const entries = [];
+  const blockRegex = /<Update\s+label="([^"]+)"\s+description="([^"]+)">([\s\S]*?)<\/Update>/gi;
+  let match;
+
+  while ((match = blockRegex.exec(html)) !== null) {
+    const version = match[1];
+    const dateStr = match[2];
+    const body = match[3];
+    const entryDate = new Date(dateStr);
+
+    if (isNaN(entryDate.getTime())) continue;
+    if (entryDate < cutoff) continue;
+
+    entries.push({
+      version,
+      date: dateStr,
+      text: stripHtml(body),
+    });
+  }
+
+  return entries;
+}
+
+// ── URL helpers ─────────────────────────────────────────────────────────────
+
+export function getISOWeek(date) {
+  const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+  const dayNum = d.getUTCDay() || 7;
+  d.setUTCDate(d.getUTCDate() + 4 - dayNum);
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  return Math.ceil(((d - yearStart) / 86400000 + 1) / 7);
+}
+
+export function currentWhatsNewUrl(now = new Date()) {
+  const week = getISOWeek(now);
+  const year = now.getFullYear();
+  return `https://docs.anthropic.com/en/docs/claude-code/whats-new/${year}-w${String(week).padStart(2, '0')}`;
+}
+
+// ── Keyword matching ────────────────────────────────────────────────────────
+
+export function extractSnippet(text, position, radius = 100) {
+  const start = Math.max(0, position - radius);
+  const end = Math.min(text.length, position + radius);
+  let snippet = text.slice(start, end).trim();
+  if (start > 0) snippet = '...' + snippet;
+  if (end < text.length) snippet = snippet + '...';
+  return snippet;
+}
+
+export function matchFeature(feature, text) {
+  const lowerText = text.toLowerCase();
+  const matchedKeywords = [];
+  const snippets = [];
+  const mode = feature.keywordMode || 'any';
+
+  for (const kw of feature.keywords) {
+    let found = false;
+    let pos = -1;
+
+    if (REGEX_META.test(kw)) {
+      try {
+        const re = new RegExp(kw, 'i');
+        const m = re.exec(text);
+        if (m) {
+          found = true;
+          pos = m.index;
+        }
+      } catch {
+        // Invalid regex — skip
+      }
+    } else {
+      const idx = lowerText.indexOf(kw.toLowerCase());
+      if (idx !== -1) {
+        found = true;
+        pos = idx;
+      }
+    }
+
+    if (found) {
+      matchedKeywords.push(kw);
+      if (pos >= 0) {
+        snippets.push(extractSnippet(text, pos));
+      }
+    }
+  }
+
+  const matched =
+    mode === 'all'
+      ? matchedKeywords.length === feature.keywords.length
+      : matchedKeywords.length > 0;
+
+  return { matched, matchedKeywords, snippets };
+}
+
+// ── Issue formatting ────────────────────────────────────────────────────────
+
+export function formatIssueBody(matchResult, feature, scanMeta) {
+  const lines = [];
+  lines.push(`## Anthropic Drift Alert: ${feature.name}`);
+  lines.push('');
+  lines.push(`**Risk level**: ${feature.risk.toUpperCase()}`);
+  lines.push(`**Scan date**: ${scanMeta.scanDate}`);
+  lines.push(`**Source**: ${scanMeta.changelogUrl}`);
+  lines.push('');
+  lines.push('### What was detected');
+  lines.push('');
+  lines.push('Keywords matched in Anthropic documentation:');
+  lines.push('');
+  lines.push('| Keyword | Context |');
+  lines.push('|---|---|');
+  for (let i = 0; i < matchResult.matchedKeywords.length; i++) {
+    const kw = matchResult.matchedKeywords[i];
+    const ctx = (matchResult.snippets[i] || '').replace(/\|/g, '\\|').replace(/\n/g, ' ');
+    lines.push(`| \`${kw}\` | ${ctx} |`);
+  }
+
+  if (feature.cdkFiles.length > 0) {
+    lines.push('');
+    lines.push('### CDK files at risk');
+    lines.push('');
+    for (const f of feature.cdkFiles) {
+      lines.push(`- \`${f}\``);
+    }
+  }
+
+  lines.push('');
+  lines.push('### Recommended action');
+  lines.push('');
+  lines.push('Review the Anthropic documentation and assess whether CDK\'s implementation still adds value beyond the native capability.');
+  lines.push('');
+  lines.push(`- [Changelog](${scanMeta.changelogUrl})`);
+
+  if (feature.notes) {
+    lines.push('');
+    lines.push('### Context');
+    lines.push('');
+    lines.push(feature.notes);
+  }
+
+  lines.push('');
+  lines.push('---');
+  lines.push(`_Generated by drift-tracker workflow. ${scanMeta.scanDate}_`);
+
+  return lines.join('\n');
+}
+
+// ── Scan orchestrator ───────────────────────────────────────────────────────
+
+export async function scan(manifest, options = {}) {
+  const { dryRun = false, days = 7 } = options;
+  const features = manifest.features;
+  const changelogUrl = manifest.sourceUrls.changelog;
+
+  const result = {
+    matches: [],
+    scanDate: new Date().toISOString().split('T')[0],
+    changelogUrl,
+    featuresChecked: features.length,
+  };
+
+  // Fetch changelog
+  let changelogText = '';
+  try {
+    const html = await fetchPage(changelogUrl);
+    const entries = extractRecentChangelog(html, days);
+    changelogText = entries.map((e) => `${e.version} ${e.date} ${e.text}`).join(' ');
+
+    if (changelogText.length < 50 && entries.length === 0) {
+      // Fallback: use full page text (no Update blocks found — page format may have changed)
+      changelogText = stripHtml(html);
+    }
+
+    if (changelogText.length < 500) {
+      console.warn(`Warning: changelog text is short (${changelogText.length} chars) — page may be SPA-rendered or empty`);
+    }
+  } catch (err) {
+    console.error(`Failed to fetch changelog: ${err.message}`);
+    if (!dryRun) process.exitCode = 1;
+    return result;
+  }
+
+  // Match features
+  for (const feature of features) {
+    const matchResult = matchFeature(feature, changelogText);
+    if (matchResult.matched) {
+      const issueBody = formatIssueBody(matchResult, feature, result);
+      result.matches.push({
+        featureId: feature.id,
+        featureName: feature.name,
+        risk: feature.risk,
+        matchedKeywords: matchResult.matchedKeywords,
+        snippets: matchResult.snippets,
+        issueBody,
+      });
+    }
+  }
+
+  return result;
+}
+
+// ── CLI entry point ─────────────────────────────────────────────────────────
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes('--dry-run') || process.env.DRY_RUN === 'true';
+  const daysArg = args.find((a) => a.startsWith('--days='));
+  const days = daysArg ? Number(daysArg.split('=')[1]) : 7;
+  const featuresArg = args.find((a) => a.startsWith('--features='));
+  const featuresPath = featuresArg ? featuresArg.split('=')[1] : undefined;
+
+  const manifest = loadFeatures(featuresPath);
+  console.log(`Scanning ${manifest.features.length} features (lookback: ${days} days, dry-run: ${dryRun})`);
+
+  const result = await scan(manifest, { dryRun, days });
+
+  console.log(`Found ${result.matches.length} matches out of ${result.featuresChecked} features checked`);
+
+  if (dryRun) {
+    if (result.matches.length === 0) {
+      console.log('No drift detected.');
+    } else {
+      for (const m of result.matches) {
+        console.log(`\n--- [${m.risk.toUpperCase()}] ${m.featureName} ---`);
+        console.log(`Keywords: ${m.matchedKeywords.join(', ')}`);
+        for (const s of m.snippets) {
+          console.log(`  > ${s.slice(0, 120)}`);
+        }
+      }
+    }
+    return;
+  }
+
+  // Write to GITHUB_OUTPUT for workflow consumption
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (outputFile) {
+    appendFileSync(outputFile, `match_count=${result.matches.length}\n`);
+    appendFileSync(outputFile, `features_checked=${result.featuresChecked}\n`);
+    // Use heredoc for JSON to avoid shell escaping issues
+    const json = JSON.stringify(result.matches);
+    appendFileSync(outputFile, `matches_json<<DRIFT_EOF\n${json}\nDRIFT_EOF\n`);
+  } else {
+    console.log(JSON.stringify(result, null, 2));
+  }
+}
+
+// Run if executed directly
+const isMain = process.argv[1] && fileURLToPath(import.meta.url).endsWith(process.argv[1].replace(/.*\//, ''));
+if (isMain) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/.github/drift-tracker/features.json
+++ b/.github/drift-tracker/features.json
@@ -1,0 +1,218 @@
+{
+  "version": 1,
+  "sourceUrls": {
+    "changelog": "https://docs.anthropic.com/en/docs/claude-code/changelog"
+  },
+  "features": [
+    {
+      "id": "claude-md-templates",
+      "name": "CLAUDE.md templates and scaffolding",
+      "risk": "high",
+      "keywords": [
+        "CLAUDE_CODE_NEW_INIT",
+        "scaffold.*CLAUDE",
+        "generate.*CLAUDE\\.md",
+        "CLAUDE\\.md.*template",
+        "project.*initialization.*template"
+      ],
+      "keywordMode": "any",
+      "cdkFiles": [
+        "packages/cli/src/generators/claude-md.js",
+        "packages/cli/templates/"
+      ],
+      "notes": "Anthropic's /init already generates CLAUDE.md. Watch for richer templates that overlap with CDK's tiered scaffolding."
+    },
+    {
+      "id": "settings-json-config",
+      "name": "settings.json managed configuration",
+      "risk": "high",
+      "keywords": [
+        "server-managed settings",
+        "managed.*settings",
+        "admin.*console.*settings",
+        "remote.*settings.*configuration",
+        "settings.*wizard"
+      ],
+      "keywordMode": "any",
+      "cdkFiles": [
+        "packages/cli/templates/tier-s/.claude/settings.json",
+        "packages/cli/templates/tier-m/.claude/settings.json",
+        "packages/cli/templates/tier-l/.claude/settings.json"
+      ],
+      "notes": "Anthropic has a managed settings scope. If they ship a configuration wizard or admin console, CDK's scaffolded settings.json loses unique value."
+    },
+    {
+      "id": "generic-hooks",
+      "name": "Hook templates and pre-built hooks",
+      "risk": "high",
+      "keywords": [
+        "hook.*template",
+        "pre-built.*hook",
+        "hook.*library",
+        "hook.*marketplace",
+        "default.*hook.*configuration"
+      ],
+      "keywordMode": "any",
+      "cdkFiles": [
+        "packages/cli/templates/tier-s/.claude/settings.json",
+        "packages/cli/templates/tier-m/.claude/settings.json",
+        "packages/cli/src/commands/doctor.js"
+      ],
+      "notes": "CDK wires Stop, SessionStart, PostToolUse hooks. If Anthropic ships pre-configured hook templates, this becomes redundant."
+    },
+    {
+      "id": "shallow-skills",
+      "name": "Built-in or bundled skills",
+      "risk": "high",
+      "keywords": [
+        "bundled.*skill",
+        "built-in.*skill",
+        "native.*skill",
+        "default.*skill.*library",
+        "skill.*included.*by.*default"
+      ],
+      "keywordMode": "any",
+      "cdkFiles": [
+        "packages/cli/templates/common/skills/commit/",
+        "packages/cli/templates/common/skills/simplify/"
+      ],
+      "notes": "CDK ships /commit and /simplify as shallow skills. If Anthropic bundles equivalent skills natively, these lose value."
+    },
+    {
+      "id": "stack-detection",
+      "name": "Automatic stack or framework detection",
+      "risk": "medium",
+      "keywords": [
+        "stack.*detect",
+        "language.*detect",
+        "auto.*detect.*framework",
+        "project.*type.*detect",
+        "framework.*recognition"
+      ],
+      "keywordMode": "any",
+      "cdkFiles": [
+        "packages/cli/src/utils/detect-stack.js",
+        "packages/cli/src/scaffold/skill-registry.js"
+      ],
+      "notes": "CDK detects 11 tech stacks to adapt security rules, skills, and permissions. Native stack detection would reduce this advantage."
+    },
+    {
+      "id": "multi-tier-scaffolding",
+      "name": "Tiered or graduated project setup",
+      "risk": "medium",
+      "keywords": [
+        "tier.*scaffold",
+        "governance.*tier",
+        "graduated.*setup",
+        "project.*complexity.*level",
+        "scaffold.*level"
+      ],
+      "keywordMode": "any",
+      "cdkFiles": [
+        "packages/cli/templates/tier-0/",
+        "packages/cli/templates/tier-s/",
+        "packages/cli/templates/tier-m/",
+        "packages/cli/templates/tier-l/"
+      ],
+      "notes": "CDK's four tiers (Discovery/Fast Lane/Standard/Full) are its primary structural differentiator."
+    },
+    {
+      "id": "rules-markdown",
+      "name": "Rule file scaffolding or templates",
+      "risk": "medium",
+      "keywords": [
+        "rule.*template",
+        "rule.*scaffold",
+        "pre-built.*rule",
+        "rule.*library",
+        "default.*rule.*file"
+      ],
+      "keywordMode": "any",
+      "cdkFiles": [
+        "packages/cli/templates/common/rules/"
+      ],
+      "notes": "CDK scaffolds pipeline.md, security.md, git.md as rules. If Anthropic ships starter rule templates, this overlap grows."
+    },
+    {
+      "id": "pipeline-stop-gates",
+      "name": "Pipeline gates or workflow enforcement",
+      "risk": "low",
+      "keywords": [
+        "pipeline.*gate",
+        "stop.*gate",
+        "mandatory.*review.*gate",
+        "workflow.*enforcement",
+        "phase.*gate"
+      ],
+      "keywordMode": "any",
+      "cdkFiles": [
+        "packages/cli/templates/tier-m/rules/pipeline.md",
+        "packages/cli/templates/tier-l/rules/pipeline.md"
+      ],
+      "notes": "CDK's multi-phase pipeline with STOP gates is deep and opinionated. Low absorption risk but monitor for native workflow features."
+    },
+    {
+      "id": "team-settings",
+      "name": "Team or org-wide settings enforcement",
+      "risk": "low",
+      "keywords": [
+        "team.*settings",
+        "org.*enforcement",
+        "centralized.*governance",
+        "org-wide.*restriction",
+        "team.*configuration.*policy"
+      ],
+      "keywordMode": "any",
+      "cdkFiles": [],
+      "notes": "CDK plans team-settings.json for org enforcement. Anthropic has server-managed settings via admin console - watch for expansion."
+    },
+    {
+      "id": "cross-project-analytics",
+      "name": "Cross-project compliance or analytics",
+      "risk": "low",
+      "keywords": [
+        "cross.*project.*analytics",
+        "compliance.*dashboard",
+        "project.*compliance.*report",
+        "multi-project.*overview"
+      ],
+      "keywordMode": "any",
+      "cdkFiles": [],
+      "notes": "CDK's SaaS layer (Q2) aggregates doctor reports across projects. No current Anthropic equivalent."
+    },
+    {
+      "id": "deep-audit-skills",
+      "name": "Multi-step audit or analysis skills",
+      "risk": "low",
+      "keywords": [
+        "audit.*skill",
+        "multi.*step.*audit",
+        "security.*audit.*skill",
+        "architecture.*audit.*skill",
+        "built-in.*audit"
+      ],
+      "keywordMode": "any",
+      "cdkFiles": [
+        "packages/cli/templates/common/skills/"
+      ],
+      "notes": "CDK ships 12 deep audit skills with model routing. Single-skill native equivalents are possible but full suite is unlikely."
+    },
+    {
+      "id": "skill-marketplace",
+      "name": "Skill registry or marketplace",
+      "risk": "medium",
+      "keywords": [
+        "skill.*registry",
+        "skill.*marketplace",
+        "community.*skill",
+        "skill.*sharing",
+        "public.*skill.*catalog"
+      ],
+      "keywordMode": "any",
+      "cdkFiles": [
+        "packages/cli/src/scaffold/skill-registry.js"
+      ],
+      "notes": "CDK plans a public skill registry (Q4). If Anthropic ships a native skill marketplace, this becomes redundant."
+    }
+  ]
+}

--- a/.github/drift-tracker/test/check-drift.test.mjs
+++ b/.github/drift-tracker/test/check-drift.test.mjs
@@ -1,0 +1,277 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import {
+  loadFeatures,
+  stripHtml,
+  extractRecentChangelog,
+  currentWhatsNewUrl,
+  getISOWeek,
+  matchFeature,
+  extractSnippet,
+  formatIssueBody,
+} from '../check-drift.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_DIR = join(__dirname, 'fixtures');
+
+// ── stripHtml ───────────────────────────────────────────────────────────────
+
+describe('stripHtml', () => {
+  it('removes script blocks', () => {
+    const html = '<p>before</p><script>alert("xss")</script><p>after</p>';
+    const text = stripHtml(html);
+    assert.ok(!text.includes('alert'));
+    assert.ok(text.includes('before'));
+    assert.ok(text.includes('after'));
+  });
+
+  it('removes style blocks', () => {
+    const html = '<style>.red { color: red; }</style><p>content</p>';
+    const text = stripHtml(html);
+    assert.ok(!text.includes('color'));
+    assert.ok(text.includes('content'));
+  });
+
+  it('strips all HTML tags', () => {
+    const html = '<div class="wrapper"><h1>Title</h1><p>Body <strong>bold</strong></p></div>';
+    const text = stripHtml(html);
+    assert.ok(!text.includes('<'));
+    assert.ok(text.includes('Title'));
+    assert.ok(text.includes('bold'));
+  });
+
+  it('decodes named entities', () => {
+    assert.ok(stripHtml('&amp; &lt; &gt; &quot; &#39;').includes('& < > " \''));
+  });
+
+  it('decodes numeric entities', () => {
+    assert.ok(stripHtml('&#65;&#66;').includes('AB'));
+  });
+
+  it('returns empty string for null/undefined', () => {
+    assert.equal(stripHtml(null), '');
+    assert.equal(stripHtml(undefined), '');
+    assert.equal(stripHtml(''), '');
+  });
+});
+
+// ── extractRecentChangelog ──────────────────────────────────────────────────
+
+describe('extractRecentChangelog', () => {
+  const html = readFileSync(join(FIXTURE_DIR, 'changelog-sample.html'), 'utf8');
+
+  it('parses Update blocks with version, date, and text', () => {
+    const entries = extractRecentChangelog(html, 365);
+    assert.ok(entries.length >= 3);
+    assert.ok(entries.some((e) => e.version === '2.1.105'));
+    assert.ok(entries.some((e) => e.version === '2.1.104'));
+  });
+
+  it('filters entries older than N days', () => {
+    // Only entries from "today" perspective — fixture has April 11, April 5, March 20, Feb 15
+    // With days=10 from April 12 (test date), only April 5 and April 11 should pass
+    const entries = extractRecentChangelog(html, 10);
+    const versions = entries.map((e) => e.version);
+    assert.ok(versions.includes('2.1.105'));
+    // March 20 and Feb 15 should be filtered
+    assert.ok(!versions.includes('2.1.102'));
+  });
+
+  it('returns empty array when no recent entries', () => {
+    const entries = extractRecentChangelog(html, 0);
+    assert.equal(entries.length, 0);
+  });
+
+  it('handles HTML with no Update blocks', () => {
+    const entries = extractRecentChangelog('<html><body>No updates here</body></html>', 7);
+    assert.equal(entries.length, 0);
+  });
+
+  it('strips HTML from entry text', () => {
+    const entries = extractRecentChangelog(html, 365);
+    const e = entries.find((e) => e.version === '2.1.105');
+    assert.ok(e);
+    assert.ok(!e.text.includes('<li>'));
+    assert.ok(e.text.includes('server-managed settings'));
+  });
+});
+
+// ── currentWhatsNewUrl / getISOWeek ─────────────────────────────────────────
+
+describe('currentWhatsNewUrl', () => {
+  it('returns correct URL format for a known date', () => {
+    const url = currentWhatsNewUrl(new Date('2026-04-12'));
+    assert.match(url, /\/whats-new\/2026-w\d{2}$/);
+  });
+
+  it('pads single-digit week numbers', () => {
+    // Jan 5 2026 is week 2
+    const url = currentWhatsNewUrl(new Date('2026-01-05'));
+    assert.ok(url.endsWith('-w02') || url.endsWith('-w01'));
+  });
+
+  it('computes ISO week correctly for a known date', () => {
+    // April 12 2026 is a Sunday — ISO week 15
+    const week = getISOWeek(new Date('2026-04-12'));
+    assert.equal(week, 15);
+  });
+});
+
+// ── matchFeature ────────────────────────────────────────────────────────────
+
+describe('matchFeature', () => {
+  it('matches plain string keyword case-insensitively', () => {
+    const feature = { keywords: ['server-managed settings'], keywordMode: 'any' };
+    const result = matchFeature(feature, 'New: Added Server-Managed Settings support');
+    assert.ok(result.matched);
+    assert.equal(result.matchedKeywords.length, 1);
+  });
+
+  it('matches regex keyword', () => {
+    const feature = { keywords: ['scaffold.*CLAUDE'], keywordMode: 'any' };
+    const result = matchFeature(feature, 'We now scaffold a CLAUDE.md file automatically');
+    assert.ok(result.matched);
+  });
+
+  it('does not match when no keywords hit', () => {
+    const feature = { keywords: ['nonexistent-feature-xyz'], keywordMode: 'any' };
+    const result = matchFeature(feature, 'This text has nothing relevant');
+    assert.ok(!result.matched);
+    assert.equal(result.matchedKeywords.length, 0);
+  });
+
+  it('mode "any" matches on single keyword', () => {
+    const feature = { keywords: ['alpha', 'beta', 'gamma'], keywordMode: 'any' };
+    const result = matchFeature(feature, 'Only beta is present here');
+    assert.ok(result.matched);
+    assert.deepEqual(result.matchedKeywords, ['beta']);
+  });
+
+  it('mode "all" requires all keywords', () => {
+    const feature = { keywords: ['alpha', 'beta'], keywordMode: 'all' };
+    const partial = matchFeature(feature, 'Only alpha is present');
+    assert.ok(!partial.matched);
+
+    const full = matchFeature(feature, 'Both alpha and beta are here');
+    assert.ok(full.matched);
+  });
+
+  it('returns snippets for each matched keyword', () => {
+    const feature = { keywords: ['hook template'], keywordMode: 'any' };
+    const result = matchFeature(feature, 'Some context before the hook template feature and more after');
+    assert.ok(result.matched);
+    assert.equal(result.snippets.length, 1);
+    assert.ok(result.snippets[0].includes('hook template'));
+  });
+
+  it('handles empty text', () => {
+    const feature = { keywords: ['test'], keywordMode: 'any' };
+    const result = matchFeature(feature, '');
+    assert.ok(!result.matched);
+  });
+
+  it('handles invalid regex gracefully', () => {
+    const feature = { keywords: ['[invalid(regex'], keywordMode: 'any' };
+    // Should not throw
+    const result = matchFeature(feature, 'some text with [invalid(regex');
+    // The keyword contains regex metacharacters so it tries regex, which fails,
+    // so it skips. No match.
+    assert.equal(result.matchedKeywords.length, 0);
+  });
+});
+
+// ── extractSnippet ──────────────────────────────────────────────────────────
+
+describe('extractSnippet', () => {
+  const text = 'A'.repeat(50) + 'MATCH' + 'B'.repeat(50);
+
+  it('returns window centered on position', () => {
+    const snippet = extractSnippet(text, 50, 20);
+    assert.ok(snippet.includes('MATCH'));
+    assert.ok(snippet.length <= 50); // 20 + 20 + ... prefix/suffix
+  });
+
+  it('handles match near start of text', () => {
+    const snippet = extractSnippet('MATCH and more text here', 0, 100);
+    assert.ok(snippet.startsWith('MATCH'));
+    assert.ok(!snippet.startsWith('...'));
+  });
+
+  it('handles match near end of text', () => {
+    const snippet = extractSnippet('text before MATCH', 12, 100);
+    assert.ok(snippet.includes('MATCH'));
+    assert.ok(!snippet.endsWith('...'));
+  });
+});
+
+// ── loadFeatures ────────────────────────────────────────────────────────────
+
+describe('loadFeatures', () => {
+  const manifestPath = join(__dirname, '..', 'features.json');
+
+  it('loads the actual features.json', () => {
+    const manifest = loadFeatures(manifestPath);
+    assert.ok(manifest.features.length >= 10);
+  });
+
+  it('every entry has required fields', () => {
+    const manifest = loadFeatures(manifestPath);
+    for (const f of manifest.features) {
+      assert.ok(f.id, `missing id`);
+      assert.ok(f.name, `missing name for ${f.id}`);
+      assert.ok(['high', 'medium', 'low'].includes(f.risk), `invalid risk for ${f.id}`);
+      assert.ok(Array.isArray(f.keywords), `keywords not array for ${f.id}`);
+      assert.ok(f.keywords.length > 0, `empty keywords for ${f.id}`);
+      assert.ok(Array.isArray(f.cdkFiles), `cdkFiles not array for ${f.id}`);
+    }
+  });
+
+  it('all IDs are unique', () => {
+    const manifest = loadFeatures(manifestPath);
+    const ids = manifest.features.map((f) => f.id);
+    assert.equal(ids.length, new Set(ids).size);
+  });
+});
+
+// ── formatIssueBody ─────────────────────────────────────────────────────────
+
+describe('formatIssueBody', () => {
+  const feature = {
+    id: 'test-feature',
+    name: 'Test Feature',
+    risk: 'high',
+    keywords: ['test keyword'],
+    cdkFiles: ['src/test.js'],
+    notes: 'Test context note.',
+  };
+  const matchResult = {
+    matchedKeywords: ['test keyword'],
+    snippets: ['...surrounding context with test keyword in it...'],
+  };
+  const scanMeta = {
+    scanDate: '2026-04-12',
+    changelogUrl: 'https://example.com/changelog',
+  };
+
+  it('produces valid markdown with all sections', () => {
+    const body = formatIssueBody(matchResult, feature, scanMeta);
+    assert.ok(body.includes('## Anthropic Drift Alert: Test Feature'));
+    assert.ok(body.includes('**Risk level**: HIGH'));
+    assert.ok(body.includes('### What was detected'));
+    assert.ok(body.includes('### CDK files at risk'));
+    assert.ok(body.includes('`src/test.js`'));
+    assert.ok(body.includes('### Recommended action'));
+    assert.ok(body.includes('### Context'));
+    assert.ok(body.includes('Test context note.'));
+  });
+
+  it('includes keyword table with snippets', () => {
+    const body = formatIssueBody(matchResult, feature, scanMeta);
+    assert.ok(body.includes('| `test keyword` |'));
+    assert.ok(body.includes('surrounding context'));
+  });
+});

--- a/.github/drift-tracker/test/fixtures/changelog-sample.html
+++ b/.github/drift-tracker/test/fixtures/changelog-sample.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Claude Code Changelog</title>
+  <style>body { font-family: sans-serif; }</style>
+  <script>console.log("analytics loaded");</script>
+</head>
+<body>
+  <h1>Changelog</h1>
+
+  <Update label="2.1.105" description="April 11, 2026">
+    <ul>
+      <li>New: Added server-managed settings support for enterprise admin console configuration</li>
+      <li>New: Built-in skill library with 3 bundled skills including /simplify and /commit</li>
+      <li>Fix: Resolved hook timeout edge case in Stop hook</li>
+    </ul>
+  </Update>
+
+  <Update label="2.1.104" description="April 5, 2026">
+    <ul>
+      <li>Improvement: Enhanced CLAUDE_CODE_NEW_INIT flow with multi-phase interactive setup</li>
+      <li>New: Path-specific rule templates for common project types</li>
+      <li>Fix: Memory page rendering issue</li>
+    </ul>
+  </Update>
+
+  <Update label="2.1.103" description="March 20, 2026">
+    <ul>
+      <li>New: Added /batch command for bulk file operations</li>
+      <li>Improvement: Better error messages for invalid tool calls</li>
+      <li>Fix: Session recovery on network timeout</li>
+    </ul>
+  </Update>
+
+  <Update label="2.1.102" description="February 15, 2026">
+    <ul>
+      <li>New: Support for custom MCP servers in settings.json</li>
+      <li>Improvement: Faster file indexing on large repositories</li>
+    </ul>
+  </Update>
+</body>
+</html>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,18 @@ jobs:
       - name: Run unit tests
         run: npm run test:unit --prefix packages/cli
 
+  drift-tracker-tests:
+    name: Drift tracker tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      - name: Run drift tracker tests
+        run: node --test .github/drift-tracker/test/check-drift.test.mjs
+
   integration-tests:
     name: Integration tests
     runs-on: ubuntu-latest

--- a/.github/workflows/drift-tracker.yml
+++ b/.github/workflows/drift-tracker.yml
@@ -1,0 +1,97 @@
+name: Anthropic drift tracker
+
+on:
+  schedule:
+    - cron: '0 9 * * 1' # Every Monday 9 AM UTC
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (no issues created)'
+        type: boolean
+        default: false
+      days:
+        description: 'Lookback window in days'
+        type: number
+        default: 7
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  check-drift:
+    name: Scan for Anthropic feature overlap
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Run drift scan
+        id: scan
+        run: |
+          node .github/drift-tracker/check-drift.mjs \
+            --days="${{ inputs.days || '7' }}" \
+            ${{ inputs.dry_run == true && '--dry-run' || '' }}
+
+      - name: Create drift issues
+        if: steps.scan.outputs.match_count != '0' && inputs.dry_run != true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo '${{ steps.scan.outputs.matches_json }}' | jq -c '.[]' | while IFS= read -r match; do
+            FID=$(echo "$match" | jq -r '.featureId')
+            FNAME=$(echo "$match" | jq -r '.featureName')
+            BODY=$(echo "$match" | jq -r '.issueBody')
+
+            # Dedup: skip if open issue with this feature ID exists
+            EXISTING=$(gh issue list \
+              --repo "${{ github.repository }}" \
+              --label "anthropic-drift" \
+              --state open \
+              --search "in:title [drift:${FID}]" \
+              --json number -q 'length')
+
+            if [ "$EXISTING" -gt "0" ]; then
+              echo "Skipping $FID — open issue already exists"
+              continue
+            fi
+
+            gh issue create \
+              --repo "${{ github.repository }}" \
+              --title "[drift:${FID}] ${FNAME} — new native capability detected" \
+              --body "$BODY" \
+              --label "anthropic-drift"
+
+            echo "Created issue for $FID"
+          done
+
+      - name: Auto-close stale drift issues
+        if: inputs.dry_run != true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CUTOFF=$(date -u -d '30 days ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -v-30d '+%Y-%m-%dT%H:%M:%SZ')
+          gh issue list \
+            --repo "${{ github.repository }}" \
+            --label "anthropic-drift" \
+            --state open \
+            --json number,createdAt -q \
+            ".[] | select(.createdAt < \"$CUTOFF\") | .number" | while read -r num; do
+            gh issue close "$num" \
+              --repo "${{ github.repository }}" \
+              --comment "Auto-closed: superseded by newer drift scan. Re-open if still relevant."
+          done
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "### Drift Tracker Results" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Features checked: ${{ steps.scan.outputs.features_checked || 'N/A' }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Matches found: ${{ steps.scan.outputs.match_count || '0' }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Dry run: ${{ inputs.dry_run || 'false' }}" >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 - `new skill` command - interactive wizard to scaffold custom skills with valid frontmatter, test fixture, and CLAUDE.md registration (#55)
 - `claudemd-update.js` shared utility - extracted CLAUDE.md Active Skills registration for reuse across commands
+- `.github/drift-tracker/` - weekly GitHub Action that scrapes Anthropic docs for native features overlapping with CDK, opens `anthropic-drift` issues when overlap detected (#56)
 - `add skill <name>` command - install a single skill without full scaffold (12 skills available)
 - `add rule <name>` command - install a single rule with stack-specific security variants (`--stack swift|kotlin|rust|dotnet|java|go`)
 - `custom-*` skill convention - user-created skills preserved across `upgrade` and `init` operations

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ See [GitHub Milestones](https://github.com/marcoguillermaz/claude-dev-kit/milest
 
 **Current**: v1.9.1 - skill registry, incremental adoption (`add skill`/`add rule`), custom skills convention, Tier S file reduction, Tier M pipeline fix.
 
-**Next**: agent-to-skill conversion, skill scaffolder CLI, Anthropic drift tracker.
+**Next**: agent-to-skill conversion, 4 new skills (`/test-audit`, `/migration-audit`, `/accessibility-audit`, `/doc-audit`).
 
 ---
 

--- a/docs/operational-guide.md
+++ b/docs/operational-guide.md
@@ -23,6 +23,7 @@
 13. [Governance mechanics](#13-governance-mechanics)
 14. [Conventions and non-negotiables](#14-conventions-and-non-negotiables)
 15. [Maintaining the scaffold](#15-maintaining-the-scaffold)
+15b. [Anthropic drift tracking](#15b-anthropic-drift-tracking)
 16. [Frequently asked questions](#16-frequently-asked-questions)
 
 ---
@@ -1082,6 +1083,22 @@ Do not edit scaffolded rule files directly if you want upgrade compatibility. In
 | Architectural decisions + rationale + AI constraints | `docs/adr/NNNN-title.md` |
 | Non-obvious patterns stable enough to be permanent | `CLAUDE.md` Known Patterns section |
 | Block-specific state for session recovery | `.claude/session/block-name.md` |
+
+---
+
+## 15b. Anthropic drift tracking
+
+CDK features risk being absorbed as Anthropic ships native Claude Code capabilities. The drift tracker monitors this automatically.
+
+**How it works**: Every Monday at 9 AM UTC, a GitHub Action fetches the Anthropic Claude Code changelog, matches content against a feature manifest (`.github/drift-tracker/features.json`), and opens issues for any overlap detected.
+
+**Feature manifest**: Each entry in `features.json` defines a CDK feature with keywords, risk level (high/medium/low), and affected CDK files. To add a new feature to track, add a JSON object to the `features` array.
+
+**Manual scan**: Go to Actions > "Anthropic drift tracker" > Run workflow. Enable "Dry run" to see results without creating issues. Adjust the lookback window with the "days" input.
+
+**Issue management**: Issues are labeled `anthropic-drift` and include the feature ID in the title as `[drift:feature-id]`. The tracker deduplicates by checking for existing open issues with the same feature ID. Stale issues (>30 days) are auto-closed.
+
+**Local dry-run**: `node .github/drift-tracker/check-drift.mjs --dry-run --days=30`
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #56. Weekly GitHub Action that scans Anthropic's Claude Code changelog for features overlapping with CDK capabilities, opening issues when overlap is detected.

- **`.github/drift-tracker/features.json`** - 12-feature manifest covering all CDK capabilities from the Anthropic-proofing strategy (high/medium/low risk tiers)
- **`.github/drift-tracker/check-drift.mjs`** - zero-dependency Node.js script using native `fetch()`. Keyword matching with plain strings + regex, any/all modes, snippet extraction
- **`.github/workflows/drift-tracker.yml`** - weekly cron (Monday 9 AM UTC) + manual dispatch with dry-run and configurable lookback window
- **30 unit tests** across 7 groups (stripHtml, extractRecentChangelog, currentWhatsNewUrl, matchFeature, extractSnippet, loadFeatures, formatIssueBody)
- **CI integration** - new `drift-tracker-tests` job in ci.yml
- Issue deduplication via `[drift:feature-id]` title prefix search
- Auto-close stale drift issues (>30 days)

## Test plan
- [ ] Drift tracker tests: `node --test .github/drift-tracker/test/check-drift.test.mjs` (30/30 pass)
- [ ] All CLI unit tests: `node --test packages/cli/test/unit/*.test.js` (271/271 pass)
- [ ] Integration tests: `node packages/cli/test/integration/run.js` (481/481 pass)
- [ ] Manual dry-run: `node .github/drift-tracker/check-drift.mjs --dry-run --days=30`
- [ ] Workflow manual dispatch from Actions tab (dry-run mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)