### PR TITLE
feat(skills): /migration-audit — stack-aware migration safety (#59)

### DIFF
--- a/.claude/rules/pipeline.md
+++ b/.claude/rules/pipeline.md
@@ -186,12 +186,13 @@ If either condition is false: **skip this phase and state so explicitly** — do
 **Track B — API/DB audit** *(if block creates/modifies API routes or applies migrations — static analysis, no dev server needed)*
 - Run `/security-audit` if the block creates or modifies any API route.
 - Run `/api-design` if the block adds new API routes. Both are static — run them concurrently.
-- Run `/skill-db` only if the block applies migrations.
+- Run `/migration-audit` if the block applies migrations — static analysis of migration files.
+- Run `/skill-db` if the block changes the schema or adds new tables — live SQL verification of schema state, RLS policies, and query patterns.
 
 **Severity handling — both tracks**:
 - **Critical**: fix before Phase 6. Do not proceed with open Critical issues.
 - **Major**: flag in Phase 6 checklist with planned resolution sprint.
-- **Minor**: append to `docs/refactoring-backlog.md` — assign ID prefix (`PERF-`, `API-`, `DB-`, `DEV-`, `UX-`).
+- **Minor**: append to `docs/refactoring-backlog.md` — assign ID prefix (`PERF-`, `API-`, `DB-`, `MIG-`, `DEV-`, `UX-`).
 - Output per skill: one-paragraph summary only.
 
 ## Phase 6 — Outcome checklist ⏸ STOP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased] — v1.9.1
 
 ### Added
+- `/migration-audit` skill (Tier M/L, `hasDatabase=true`) - stack-aware static analysis of migration files. Detects Prisma, Drizzle, Supabase CLI, raw SQL; Rails/Django/Alembic/Flyway detected but pending support. 8 check families (M1-M8): lock-heavy DDL, missing rollback, unsafe backfills, constraint sequencing, data loss, unsafe type changes, unindexed FKs, ordering integrity. Backlog prefix `MIG-`. Pipeline Phase 5d Track B now runs `/migration-audit` when migrations are applied (#59)
 - `new skill` command - interactive wizard to scaffold custom skills with valid frontmatter, test fixture, and CLAUDE.md registration (#55)
 - `claudemd-update.js` shared utility - extracted CLAUDE.md Active Skills registration for reuse across commands
 - `.github/drift-tracker/` - weekly GitHub Action that scrapes Anthropic docs for native features overlapping with CDK, opens `anthropic-drift` issues when overlap detected (#56)
@@ -31,6 +32,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Doctor check #18 fix message now suggests correct value (`"timeout": 300`)
 
 ### Changed
+- `/skill-db` scope narrowed to live SQL verification (schema quality S1-S6 + N+1 query patterns Q1-Q3). Migration file analysis extracted to `/migration-audit` - single source of truth for migration safety across all database stacks. Pipeline Phase 5d Track B splits migration audit (`/migration-audit`) from schema audit (`/skill-db`). Affects projects invoking `/skill-db` for migration checks (#59)
 - Agents converted to on-demand skills: `dependency-scanner` → `/dependency-scan`, `context-reviewer` → `/context-review` — eliminates `.claude/agents/` directory from all templates (#62)
 - `pruneSkills()` rewritten from 37 to 5 lines (delegates to skill registry)
 - `pruneCheatsheet()` rewritten from 15 to 9 lines (delegates to skill registry)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ After init, open Claude Code and start working. The scaffold is active immediate
 
 Start at Tier 0. Move up when you need more structure: `npx mg-claude-dev-kit upgrade --tier=m`
 
-### 12 audit skills
+### 13 audit skills
 
 Executable multi-step programs that run inside Claude Code. Not prompt instructions - structured audit workflows with model routing (haiku for mechanical checks, sonnet for analysis).
 
@@ -60,6 +60,7 @@ Executable multi-step programs that run inside Claude Code. Not prompt instructi
 | `/commit` | S M L | Conventional Commits - auto-detects type, scope, description. |
 | `/api-design` | M L | URL naming, HTTP verbs, response envelope, pagination. |
 | `/skill-db` | M L | Schema normalization, indexes, N+1 queries, RLS. |
+| `/migration-audit` | M L | Stack-aware migration safety: data loss, rollback, lock-heavy DDL. Prisma/Drizzle/Supabase/SQL. |
 | `/visual-audit` | M L | Typography, APCA contrast, spacing, dark-mode. |
 | `/ux-audit` | M L | ISO 9241-11, Nielsen heuristics, user confidence. |
 | `/responsive-audit` | M L | Layout at 320-1024px, tap targets, WCAG. |
@@ -183,7 +184,7 @@ See [GitHub Milestones](https://github.com/marcoguillermaz/claude-dev-kit/milest
 
 **Current**: v1.9.1 - skill registry, incremental adoption (`add skill`/`add rule`), custom skill scaffolder (`new skill`), Anthropic drift tracker, 481 integration checks.
 
-**Next**: agent-to-skill conversion, 4 new skills (`/test-audit`, `/migration-audit`, `/accessibility-audit`, `/doc-audit`).
+**Next**: 3 more skills (`/test-audit`, `/accessibility-audit`, `/doc-audit`).
 
 ---
 

--- a/docs/operational-guide.md
+++ b/docs/operational-guide.md
@@ -40,7 +40,7 @@ Claude Code is a powerful CLI assistant that can read, write, and reason about y
 - A development pipeline Claude follows strictly - requirements reviewed before code is written, tests verified before declaring done
 - Pre-wired hooks that enforce the pipeline mechanically, not just as instructions
 - A tiered system matching process overhead to task complexity: a two-line bugfix does not go through the same process as a multi-week feature
-- 12 audit skills - executable multi-step programs with model routing (haiku for mechanical checks, sonnet for analysis)
+- 13 audit skills - executable multi-step programs with model routing (haiku for mechanical checks, sonnet for analysis)
 - Audit trails, commit attribution, secret scanning, and CODEOWNERS gates for full visibility over AI-generated changes
 - A discovery mechanism that teaches Claude about your existing codebase in a single structured session
 
@@ -400,7 +400,7 @@ npx mg-claude-dev-kit add skill commit
 
 This copies the SKILL.md file into `.claude/skills/<name>/` and appends it to the `## Active Skills` section in CLAUDE.md (if that section exists). No other files are modified.
 
-Available skills (12): `arch-audit`, `security-audit`, `perf-audit`, `skill-dev`, `simplify`, `commit`, `api-design`, `skill-db`, `visual-audit`, `ux-audit`, `responsive-audit`, `ui-audit`.
+Available skills (13): `arch-audit`, `security-audit`, `perf-audit`, `skill-dev`, `simplify`, `commit`, `api-design`, `skill-db`, `migration-audit`, `visual-audit`, `ux-audit`, `responsive-audit`, `ui-audit`.
 
 Options:
 - `--force` - overwrite if the skill already exists
@@ -693,7 +693,7 @@ Defined in the `CLAUDE.md` template for Tier M/L. Governs how Claude handles non
 
 ## 10. Audit skills
 
-Twelve audit skills are scaffolded across the tiers. Run them as slash commands in Claude Code at any time - no pipeline phase required. Skills are **conditionally installed** based on wizard answers at init time.
+Thirteen audit skills are scaffolded across the tiers. Run them as slash commands in Claude Code at any time - no pipeline phase required. Skills are **conditionally installed** based on wizard answers at init time.
 
 All skill applicability rules are managed by a central skill registry (`packages/cli/src/scaffold/skill-registry.js`). Each skill declares which tiers and project conditions it requires.
 
@@ -709,6 +709,7 @@ All skill applicability rules are managed by a central skill registry (`packages
 | `/simplify` | x | x | x | always | - |
 | `/api-design` | - | x | x | `hasApi=true` | - |
 | `/skill-db` | - | x | x | `hasDatabase=true` | - |
+| `/migration-audit` | - | x | x | `hasDatabase=true` | - |
 | `/responsive-audit` | - | x | x | `hasFrontend=true` | Dev server + Playwright MCP |
 | `/ux-audit` | - | x | x | `hasFrontend=true` | Dev server + Playwright MCP |
 | `/visual-audit` | - | x | x | `hasFrontend=true` | Dev server + Playwright MCP |
@@ -716,7 +717,7 @@ All skill applicability rules are managed by a central skill registry (`packages
 
 ### General rules
 
-- Code-audit skills are **audit-only** - no code is modified (except `/simplify`, which applies changes directly). Findings go to `docs/refactoring-backlog.md` with severity-ranked IDs (`PERF-`, `API-`, `DB-`, `DEV-`, `SEC-`, `UX-`).
+- Code-audit skills are **audit-only** - no code is modified (except `/simplify`, which applies changes directly). Findings go to `docs/refactoring-backlog.md` with severity-ranked IDs (`PERF-`, `API-`, `DB-`, `MIG-`, `DEV-`, `SEC-`, `UX-`).
 - Live-browser skills (`/responsive-audit`, `/ux-audit`, `/visual-audit`, `/ui-audit`) require the Playwright MCP server configured in `.claude/settings.json` and the dev server running.
 - Each skill runs in an isolated context fork (`context: fork`) - it does not pollute the main session window.
 - Each skill delegates grep-heavy scanning to a Haiku Explore subagent to protect the main context window.
@@ -731,7 +732,7 @@ After the smoke test and before the outcome checklist, two tracks run in paralle
 `/ui-audit` (static, concurrent with first Playwright skill) -> `/visual-audit` -> `/ux-audit` -> `/responsive-audit` (sequential, shared Playwright session).
 
 **Track B - API/DB** (if the block touches API routes or applies migrations):
-`/security-audit` and `/api-design` (concurrent, static); `/skill-db` (if migration applied).
+`/security-audit` and `/api-design` (concurrent, static); `/migration-audit` (if the block applies migrations); `/skill-db` (if the block changes schema or adds new tables).
 
 ### Severity handling
 
@@ -782,7 +783,15 @@ Checks: cross-feature coupling (D1), duplicated lookups (D2), dead exports (D3),
 
 **File**: `.claude/skills/skill-db/SKILL.md` | **Backlog prefix**: `DB-n`
 
-Checks: schema quality (S1-S6: missing FK indexes, overly permissive access control, missing NOT NULL, wrong data types, missing ON DELETE, missing UNIQUE), N+1 query patterns (Q1-Q3), migration quality (M1-M2: destructive ops without rollback, NOT NULL without default).
+Checks: schema quality (S1-S6: missing FK indexes, overly permissive access control, missing NOT NULL, wrong data types, missing ON DELETE, missing UNIQUE), N+1 query patterns (Q1-Q3). Migration file analysis is delegated to `/migration-audit`.
+
+#### /migration-audit
+
+**File**: `.claude/skills/migration-audit/SKILL.md` | **Backlog prefix**: `MIG-n`
+
+Stack-aware static analysis of migration files - no live DB required. Detects stack automatically (Prisma, Drizzle, Supabase CLI, raw SQL; Rails/Django/Alembic/Flyway detected but pending support).
+
+Checks: M1 lock-heavy DDL (CREATE INDEX without CONCURRENTLY, ADD COLUMN NOT NULL without DEFAULT, ALTER COLUMN TYPE rewrites), M2 non-reversible ops without rollback comment, M3 unsafe backfills without batching, M4 constraint sequencing for status/enum renames, M5 data loss risk (DROP on column still referenced), M6 unsafe type changes, M7 FK without indexed child column, M8 migration ordering integrity. Optional live DB cross-reference escalates destructive migrations already applied.
 
 #### /api-design
 

--- a/packages/cli/src/scaffold/skill-registry.js
+++ b/packages/cli/src/scaffold/skill-registry.js
@@ -30,6 +30,7 @@ export const SKILL_REGISTRY = [
   { name: 'security-audit', minTier: 's', requires: {}, cheatsheet: true },
   { name: 'api-design', minTier: 'm', requires: { hasApi: true }, cheatsheet: true },
   { name: 'skill-db', minTier: 'm', requires: { hasDatabase: true }, cheatsheet: true },
+  { name: 'migration-audit', minTier: 'm', requires: { hasDatabase: true }, cheatsheet: true },
   {
     name: 'responsive-audit',
     minTier: 'm',

--- a/packages/cli/templates/tier-l/.claude/cheatsheet.md
+++ b/packages/cli/templates/tier-l/.claude/cheatsheet.md
@@ -37,6 +37,7 @@ Run these on demand. Each skill reads the codebase, produces a structured report
 | `/security-audit` | Auth guards, input validation, sensitive data in responses, HTTP headers | Before production deploy; after adding new API routes |
 | `/skill-dev` | Coupling, duplication, dead code, magic strings, oversized components | Before major refactoring; quarterly review |
 | `/skill-db` | Missing indexes, access control gaps, constraint completeness, N+1 queries | After migration waves; before production releases |
+| `/migration-audit` | Migration file safety: lock-heavy DDL, missing rollback, data loss, unsafe ALTER TYPE | After writing a migration, before applying to staging |
 | `/api-design` | HTTP verb correctness, URL structure, response shape, error codes, pagination | After adding 3+ new routes; quarterly |
 | `/perf-audit` | Server/client boundaries, heavy imports, serial awaits, image optimization, N+1 | Before production releases; after major UI changes |
 | `/simplify` | Early returns, nesting depth, local duplication, dead code, magic values | After writing code (Phase 2); on demand |

--- a/packages/cli/templates/tier-l/.claude/rules/pipeline.md
+++ b/packages/cli/templates/tier-l/.claude/rules/pipeline.md
@@ -210,12 +210,13 @@ If either condition is false: **skip this phase and state so explicitly** — do
 
 **Track B — API/DB audit** *(if block creates/modifies API routes or applies migrations — static analysis, no dev server needed)*
 - Run `/security-audit` if the block creates or modifies any API route. Run `/api-design` if the block adds new API routes. Both are static — run them concurrently.
-- Run `/skill-db` only if the block applies migrations.
+- Run `/migration-audit` if the block applies migrations — static analysis of migration files.
+- Run `/skill-db` if the block changes the schema or adds new tables — live SQL verification of schema state, RLS policies, and query patterns.
 
 **Severity handling — both tracks**:
 - **Critical**: fix before Phase 6. Do not proceed with open Critical issues.
 - **Major**: flag in Phase 6 checklist with planned resolution sprint.
-- **Minor**: append to `docs/refactoring-backlog.md` — assign ID prefix (`PERF-`, `API-`, `DB-`, `DEV-`, `UX-`).
+- **Minor**: append to `docs/refactoring-backlog.md` — assign ID prefix (`PERF-`, `API-`, `DB-`, `MIG-`, `DEV-`, `UX-`).
 - Output per skill: one-paragraph summary only.
 
 ## Phase 6 — Outcome checklist ⏸ STOP

--- a/packages/cli/templates/tier-l/.claude/skills/migration-audit/SKILL.md
+++ b/packages/cli/templates/tier-l/.claude/skills/migration-audit/SKILL.md
@@ -1,0 +1,252 @@
+---
+name: migration-audit
+description: Stack-aware migration safety audit: data loss risks, destructive ops without rollback, NOT NULL without DEFAULT, unsafe ALTER TYPE, lock-heavy DDL, constraint sequencing. Supports Prisma, Drizzle, Supabase CLI, raw SQL.
+user-invocable: true
+model: sonnet
+context: fork
+argument-hint: [target:file:<filename>|target:range:<from>-<to>|mode:all]
+---
+
+## Configuration (adapt before first run)
+
+> Replace these placeholders:
+> - `[MIGRATIONS_PATH]` — e.g. `prisma/migrations/`, `drizzle/`, `supabase/migrations/`, `db/migrations/`
+> - `[DB_SYSTEM]` — e.g. `PostgreSQL`, `MySQL`, `SQLite`
+> - `[APP_SOURCE_PATH]` — path to application source for column-reference cross-checks (e.g. `src/`, `app/`)
+> - `[STAGING_DB_URL]` — optional, for Step 4 applied-migration verification
+
+---
+
+## Step 0 — Target resolution
+
+Parse `$ARGUMENTS` for a `target:` or `mode:` token.
+
+| Pattern | Meaning |
+|---|---|
+| `target:file:<filename>` | Audit a single migration file (for debugging before apply) |
+| `target:range:<from>-<to>` | Audit a numeric range of migrations (e.g. `target:range:042-051`) |
+| `mode:all` / no argument | **Full audit — every migration file discovered in Step 2.** |
+
+**STRICT PARSING**: derive target ONLY from explicit text in `$ARGUMENTS`. Do NOT infer from conversation context, recent blocks, or memory.
+
+Announce: `Running migration-audit — scope: [FULL | target: <resolved>] — stack: <pending detection>`
+
+---
+
+## Step 1 — Stack detection
+
+Detect the migration framework in this priority order. First matching marker wins.
+
+| Framework | Marker file(s) | Path pattern for migrations |
+|---|---|---|
+| **Prisma** | `prisma/schema.prisma` | `prisma/migrations/*/migration.sql` |
+| **Drizzle** | `drizzle.config.ts` / `drizzle.config.js` | `drizzle/*.sql` (journal at `drizzle/meta/_journal.json`) |
+| **Supabase CLI** | `supabase/config.toml` | `supabase/migrations/*.sql` |
+| **Raw SQL** | `.sql` files in `migrations/` or `db/migrations/` | same |
+| Rails | `config/application.rb` + `Gemfile` | `db/migrate/*.rb` |
+| Django | `manage.py` + any `*/migrations/*.py` | `*/migrations/*.py` |
+| Alembic | `alembic.ini` | `alembic/versions/*.py` |
+| Flyway | `flyway.conf` or `flyway.toml` | `**/db/migration/V*__*.sql` |
+
+**Supported at launch**: Prisma, Drizzle, Supabase CLI, Raw SQL.
+
+For Rails / Django / Alembic / Flyway: announce `Framework detected: <name> — support pending. See https://github.com/marcoguillermaz/claude-dev-kit/issues/59 to contribute an adapter.` and exit 0.
+
+If no marker is found: announce `No migration framework detected. Checked: Prisma, Drizzle, Supabase CLI, Raw SQL. If migrations live elsewhere, pass target:file: with the absolute path.` and exit 0.
+
+Update announcement: `Running migration-audit — scope: [FULL | target: <resolved>] — stack: <detected>`
+
+---
+
+## Step 2 — Migration file discovery
+
+Use the path pattern from Step 1. Sort migrations by numeric prefix (or by `drizzle/meta/_journal.json` order for Drizzle, or Prisma timestamp directory order).
+
+**For `mode:all` and file count > 30**: prioritize analysis in this order:
+1. All files containing `DROP`, `TRUNCATE`, `ALTER TYPE`, `RENAME` (tokens in file body).
+2. The 15 most recent files by sort order.
+3. Remaining files time permitting.
+
+State: `Discovered N migration files. Auditing: <scope>`
+
+---
+
+## Step 3 — Static safety checks (main context)
+
+Run all eight checks per file. Record findings with SEVERITY / CHECK / FILE:LINE / SQL / REASON.
+
+### M1 — Lock-heavy DDL
+
+Flag the following patterns (grep per file body):
+
+- `CREATE INDEX` (not `CONCURRENTLY`) on a table with likely > 1000 rows. Severity: **High**. Suggest `CREATE INDEX CONCURRENTLY ...`.
+- `CREATE INDEX CONCURRENTLY` appearing **inside** a `BEGIN` / `COMMIT` block (or any transaction marker). Severity: **Critical** — this fails at runtime in PostgreSQL. CONCURRENTLY cannot run inside a transaction.
+- `ADD COLUMN <col> <type> NOT NULL` **without** `DEFAULT` in the same statement. Severity: **High** — fails immediately on tables with existing rows.
+- `ADD COLUMN <col> <type> NOT NULL DEFAULT <expr>` where `<expr>` is volatile (`now()`, `random()`, `gen_random_uuid()`). Severity: **High** — triggers full table rewrite under ACCESS EXCLUSIVE lock. Suggest: add nullable, backfill, then `ALTER COLUMN ... SET NOT NULL`.
+- `ALTER COLUMN <col> TYPE <new_type>` where the type change requires a cast and full rewrite (e.g. `int` → `bigint`, `text` → `uuid`). Severity: **High**.
+- `RENAME COLUMN` / `RENAME TABLE`. Severity: **Medium** if there are active consumers in app source; **Low** otherwise.
+- `ALTER TYPE ... RENAME VALUE` — ACCESS EXCLUSIVE lock on every table using the enum. Severity: **Medium**.
+
+### M2 — Non-reversible operations without rollback
+
+For any migration containing `DROP COLUMN`, `DROP TABLE`, `TRUNCATE`, `ALTER TYPE ... RENAME VALUE`, or irreversible `UPDATE <t> SET ...`:
+
+- **Require** a rollback SQL comment block at the top of the file:
+  ```sql
+  -- ROLLBACK:
+  -- <steps to reverse this migration>
+  ```
+- Severity: **High** if the comment block is absent.
+- Severity: **Critical** if Step 4 confirms the file is already applied in staging/prod.
+
+### M3 — Unsafe backfills
+
+Flag `UPDATE <table> SET <col> = <value>` statements without a `WHERE` clause that bounds scope, or without a batching pattern (e.g. `LIMIT`, cursor loop). Holds a table-level lock for the full duration and generates replication lag.
+
+Severity: **Medium** on any table; **High** if the table is called out as high-traffic in `docs/db-map.md` or `CLAUDE.md`.
+
+### M4 — Constraint sequencing
+
+If a migration changes a status / enum value (e.g. `UPDATE users SET role = 'MEMBER' WHERE role = 'USER'`), verify the sequence:
+
+1. `ALTER TABLE ... DROP CONSTRAINT <check_constraint>`
+2. `UPDATE ...` (the value rename)
+3. `ALTER TABLE ... ADD CONSTRAINT <check_constraint>` with the new value set
+
+Severity: **High** if the UPDATE appears without the surrounding DROP/ADD CONSTRAINT — would fail on tables with an existing CHECK constraint on the column.
+
+### M5 — Data loss risk
+
+For every `DROP COLUMN <col>`:
+- Grep `[APP_SOURCE_PATH]` for references to `<col>` (field name match). If references exist, severity: **Critical** — application will break at runtime.
+- If no references exist but the prior migration did NOT rename the column to `<col>_deprecated` (staged deprecation marker): severity: **High**. Data is removed before a cool-down period.
+
+For every `DROP TABLE <t>`:
+- Require a prior migration that renamed `<t>` to `<t>_deprecated` or added a deprecation comment. Severity: **High** if no staged deprecation found.
+
+### M6 — Unsafe type changes
+
+- `ALTER TYPE <enum> RENAME VALUE 'X' TO 'Y'` outside the M4 constraint-replay sequence: severity: **High**.
+- Implicit `int` → `string` or `string` → `int` casts in ORM-generated migrations (common Prisma/Drizzle pitfall when schema column type changed). Severity: **High** if data coercion is required without an explicit `USING` clause.
+
+### M7 — FK without indexed child column
+
+For each `ADD CONSTRAINT ... FOREIGN KEY (<col>) REFERENCES ...`:
+- Verify the same migration (or an earlier one in the same batch) adds `CREATE INDEX ON <table> (<col>)`.
+- Severity: **Medium** if the index is missing — every JOIN and every ON DELETE cascade on the parent will sequential-scan the child.
+
+### M8 — Migration ordering integrity
+
+Compare the numeric prefix ordering of new migration files in this branch vs. the highest prefix already on `main`.
+
+- If a new file has a prefix `N` and `main` already contains a file with prefix `M > N`, flag as **Medium** — migration ordering collision on merge. Suggest renumber.
+- For Prisma (timestamp dirs): check that new timestamps are strictly greater than the highest timestamp on `main`.
+- For Drizzle: check `drizzle/meta/_journal.json` ordering is consistent.
+
+---
+
+## Step 4 — Live DB cross-reference *(optional, Postgres / Supabase only)*
+
+**Skip this step** if `[STAGING_DB_URL]` is not configured, or if the stack is not Postgres-backed.
+
+For each file flagged under M2 (non-reversible without rollback), query the applied-migrations ledger:
+
+```sql
+-- Supabase CLI ledger
+SELECT version, name FROM supabase_migrations.schema_migrations WHERE version = '<prefix>';
+
+-- Prisma ledger
+SELECT id, migration_name, finished_at FROM _prisma_migrations WHERE migration_name LIKE '%<prefix>%';
+
+-- Drizzle ledger
+SELECT id, hash, created_at FROM __drizzle_migrations WHERE id = <prefix>;
+```
+
+If the file is already applied to staging/prod: escalate M2 finding to **Critical** and record the note: `Already applied — rollback must be run manually if issue confirmed.`
+
+---
+
+## Step 5 — Report and backlog decision gate
+
+### Output format
+
+```
+## Migration Audit — [DATE] — [SCOPE] — stack: [FRAMEWORK]
+
+### Executive summary
+[2-5 bullets — Critical and High findings only. Write concrete facts: file names, SQL line, impact.
+If nothing Critical/High: state that explicitly ("No Critical or High findings — migration set is safe to apply").
+Example bullets:
+- "Migration 052 drops `users.legacy_id` which is referenced in src/auth/session.ts:18 (M5 Critical)"
+- "Migration 047 has CREATE INDEX CONCURRENTLY inside a BEGIN block — will fail at apply time (M1 Critical)"]
+
+### Migration maturity assessment
+| Dimension | Rating | Notes |
+|---|---|---|
+| Rollback discipline | strong / adequate / weak | [% of destructive migrations with ROLLBACK comment] |
+| Lock posture | strong / adequate / weak | [count of non-CONCURRENT CREATE INDEX, full-rewrite ALTERs] |
+| Backfill safety | strong / adequate / weak | [unbatched UPDATEs on large tables] |
+| Constraint hygiene | strong / adequate / weak | [DROP→UPDATE→ADD sequencing, FK without index] |
+| Ordering integrity | strong / adequate / weak | [prefix collisions vs main] |
+| Release readiness | ready / conditional / blocked | [blocked = any Critical; conditional = High findings exist] |
+
+### Check verdicts
+| # | Check | Verdict | Findings |
+|---|---|---|---|
+| M1 | Lock-heavy DDL | ✅/⚠️ | [N files flagged] |
+| M2 | Non-reversible without rollback | ✅/⚠️ | |
+| M3 | Unsafe backfills | ✅/⚠️ | |
+| M4 | Constraint sequencing | ✅/⚠️ | |
+| M5 | Data loss risk | ✅/⚠️ | |
+| M6 | Unsafe type changes | ✅/⚠️ | |
+| M7 | FK without indexed child | ✅/⚠️ | |
+| M8 | Ordering integrity | ✅/⚠️ | |
+
+### Prioritized findings
+For each finding with severity Medium or above:
+[SEVERITY] [ID] [check] — [file:line] — [SQL excerpt] — [impact] — [fix] — [effort: S=<1h / M=half day / L=day+]
+
+### Quick wins
+[Findings that meet all three: (a) Medium or High, (b) effort S, (c) single-file fix]
+Format: "MIG-[n]: [one-line description]"
+If no quick wins: state explicitly.
+```
+
+### Backlog decision gate
+
+Present all findings with severity Medium or above as a numbered decision list, sorted Critical → High → Medium:
+
+```
+Found N findings at Medium or above. Which to add to backlog?
+
+[1] [CRITICAL] MIG-? — file:line — one-line description
+[2] [HIGH]     MIG-? — file:line — one-line description
+[3] [MEDIUM]   MIG-? — file:line — one-line description
+...
+
+Reply with numbers to include (e.g. "1 2 4"), "all", or "none".
+```
+
+**Wait for explicit user response before writing anything.**
+
+Then write ONLY the approved entries to `docs/refactoring-backlog.md`:
+- Assign ID: `MIG-[n]` (next available after existing MIG entries)
+- Add row to priority index
+- Add full detail section with: issue, evidence (SQL excerpt), file:line, fix suggestion, effort, rollback risk
+
+### Severity guide
+
+- **Critical**: `CREATE INDEX CONCURRENTLY` inside a transaction (M1); destructive migration already applied without rollback (M2); `DROP COLUMN` on a column referenced in app source (M5)
+- **High**: `ADD COLUMN NOT NULL` without DEFAULT (M1); `ADD COLUMN NOT NULL DEFAULT <volatile>` (M1); full-rewrite `ALTER COLUMN TYPE` (M1); destructive migration missing ROLLBACK comment, not yet applied (M2); unbatched UPDATE on high-traffic table (M3); value rename missing constraint-replay (M4); `DROP TABLE` without staged deprecation (M5); unsafe type coercion without explicit cast (M6)
+- **Medium**: `CREATE INDEX` without CONCURRENTLY on smaller tables (M1); `RENAME COLUMN` with active consumers (M1); `ALTER TYPE RENAME VALUE` (M1); unbatched UPDATE on low-traffic table (M3); FK without companion index (M7); ordering prefix collision vs main (M8)
+- **Low**: `RENAME COLUMN` with no consumers (M1)
+
+---
+
+## Execution notes
+
+- Do NOT apply, modify, or write any migration file. Audit only.
+- Do NOT connect to production DB. Staging DB is acceptable for Step 4 with explicit `[STAGING_DB_URL]` config.
+- `docs/db-map.md` (if present) is authoritative for "high-traffic" table classification used by M3.
+- After the report, ask: `Vuoi che prepari migration SQL corrette per i fix identificati?` Reply with `yes` only after the user has signed off on the specific findings.
+- This skill complements `/skill-db`: `/migration-audit` handles static analysis of migration files; `/skill-db` handles live SQL verification of schema state, RLS policies, index coverage, and query patterns. Run both during Phase 5d Track B when a block applies migrations.

--- a/packages/cli/templates/tier-l/.claude/skills/skill-db/SKILL.md
+++ b/packages/cli/templates/tier-l/.claude/skills/skill-db/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-db
-description: Database audit: schema quality, index coverage, RLS completeness, FK cascades, migration safety, query patterns. Runs live SQL verification against the database.
+description: Database audit: schema quality, index coverage, RLS completeness, FK cascades, query patterns. Runs live SQL verification. Migration file safety → /migration-audit.
 user-invocable: true
 model: sonnet
 context: fork
@@ -14,7 +14,6 @@ argument-hint: [target:section:<section>|target:table:<table>]
 > - `[ORM_OR_CLIENT]` — e.g. `Prisma`, `Drizzle`, `Supabase JS client`, `SQLAlchemy`, `raw SQL`
 > - `[API_ROUTES_PATH]` — path to API route files for N+1 check
 > - `[ACCESS_CONTROL]` — e.g. `row-level security policies`, `middleware guards`, `model-level scopes`
-> - `[MIGRATIONS_PATH]` — e.g. `prisma/migrations/`, `db/migrations/`, `drizzle/`
 
 
 
@@ -28,14 +27,14 @@ Parse `$ARGUMENTS` for a `target:` token.
 | Pattern | Meaning |
 |---|---|
 | `target:section:<other>` | Resolve to matching tables in db-map.md whose name contains `<other>` |
-| `target:table:<tablename>` | Focus on a specific table and its direct FKs. **Migration safety (Step 2.5) is skipped for this target type.** |
-| No argument | **Full audit — ALL tables in docs/db-map.md. Maximum depth across every check (S1–S7, Step 2.5).** |
+| `target:table:<tablename>` | Focus on a specific table and its direct FKs. |
+| No argument | **Full audit — ALL tables in docs/db-map.md. Maximum depth across every schema, RLS, and query check (S1–S7).** |
 
 **STRICT PARSING — mandatory**: derive target ONLY from the explicit text in `$ARGUMENTS`. Do NOT infer target from conversation context, recent work, active block names, or project memory. If `$ARGUMENTS` contains no `target:` token → full audit of the entire schema in db-map.md at maximum depth. When a target IS provided → act with maximum depth and completeness on that specific scope only.
 
 Announce: `Running skill-db — scope: [FULL | target: <resolved>]`
 
-**Target filter semantics**: apply the filter in Steps 2–4 as follows — S1 (only indexes on targeted tables and their FK children), S2/S3/S2b (only columns of targeted tables), S4 (only policies on targeted tables), S5/S6/S7 (only targeted tables). Step 2.5 (migration safety) scans only migration files that touch the targeted section; for `target:table:` it is skipped entirely.
+**Target filter semantics**: apply the filter in Steps 2–4 as follows — S1 (only indexes on targeted tables and their FK children), S2/S3/S2b (only columns of targeted tables), S4 (only policies on targeted tables), S5/S6/S7 (only targeted tables).
 
 **Critical constraints**:
 - `docs/db-map.md` is the authoritative schema reference. Read it first — do NOT query the live DB to discover schema unless verifying a specific detail.
@@ -298,40 +297,9 @@ ORDER BY pg_relation_size(indexrelid) DESC;
 
 ## Step 2.5 — Migration safety review
 
-**Scope**:
-- `target:section:*`: scan only migration files that touch the targeted tables (filter by filename convention or by grepping table names).
-- No argument (full audit): scan all migration files. If count > 30, prioritize: (1) all files containing `DROP`, `TRUNCATE`, `ALTER TYPE`, `RENAME`; (2) the 15 most recent files (highest-numbered); (3) any remaining files only if time permits.
-- `target:table:*`: **skip this step entirely** — announced at Step 0.
+Migration file safety checks (lock-heavy DDL, missing rollback comments, unsafe backfills, constraint sequencing, data loss risks, FK indexing, ordering integrity) are owned by the **`/migration-audit` skill** — a stack-aware static analyzer for Prisma, Drizzle, Supabase CLI, and raw SQL migrations.
 
-For each file in scope, evaluate these four risks:
-
-**M1 — Lock-heavy DDL**
-Operations that take an `ACCESS EXCLUSIVE` lock, blocking all reads and writes:
-- `CREATE INDEX` without `CONCURRENTLY` — locks the table for the full index build. Flag as High for any table with expected rows > 1000.
-- `CREATE INDEX CONCURRENTLY` inside a `BEGIN`/`COMMIT` block — **this fails in PostgreSQL**. CONCURRENTLY cannot run inside a transaction. Grep for files containing both `BEGIN` (or `START TRANSACTION`) and `CREATE INDEX CONCURRENTLY` in the same file. Flag as Critical.
-- `ADD COLUMN col type NOT NULL` without a DEFAULT — fails immediately on tables with existing rows. Flag as High.
-- `ADD COLUMN col type NOT NULL DEFAULT <volatile_expr>` — triggers a full table rewrite (e.g. `DEFAULT now()` is volatile). Flag as High; suggest: add as nullable first, backfill, then add NOT NULL constraint.
-- `ALTER COLUMN ... TYPE` that requires a cast and full rewrite — flag as High.
-- `RENAME COLUMN` / `RENAME TABLE` — takes ACCESS EXCLUSIVE but completes instantly; flag as Medium only if the renamed object has active API consumers (verify in sitemap.md).
-- `ALTER TYPE ... RENAME VALUE` — takes ACCESS EXCLUSIVE lock on all tables using that type; flag as Medium with the note that it is safe but blocking.
-
-**M2 — Non-reversible operations without rollback comment**
-Check each file for: `DROP COLUMN`, `DROP TABLE`, `TRUNCATE`, `ALTER TYPE ... RENAME VALUE`, or irreversible `UPDATE` statements.
-
-Per CLAUDE.md Known Patterns: destructive migrations MUST have a rollback SQL comment at the top: `-- ROLLBACK: ...`.
-Flag as High: any destructive migration lacking a rollback comment block.
-Flag as Critical: a destructive migration that has already been applied to staging (verify: `SELECT * FROM supabase_migrations.schema_migrations WHERE version = 'NNN'` — if found, it's applied).
-
-**M3 — Unsafe backfills**
-`UPDATE table SET col = value` without batching on a high-traffic table holds a lock for the full duration, generating excessive WAL and causing replication lag.
-
-**M4 — Constraint sequencing**
-Per CLAUDE.md Known Patterns: if a migration changes a status/enum value, it must follow the sequence: (1) DROP CONSTRAINT, (2) UPDATE data, (3) ADD CONSTRAINT — all in one migration for atomicity.
-
-Check: any migration with `UPDATE ... SET stato = ...` or similar value rename. Verify the DROP CONSTRAINT → UPDATE → ADD CONSTRAINT sequence is present. If a migration has only the UPDATE without constraint handling, flag as High (would fail on tables with existing CHECK constraints).
-
-**Migration safety output**:
-Report only files with at least one ⚠️. For clean files, report count only (e.g. "12 files reviewed, 10 clean"). For each flagged file: filename, issue code (M1/M2/M3/M4), severity, and the specific SQL line that raised the concern.
+When a block applies migrations, run `/migration-audit` alongside `/skill-db` in Phase 5d Track B. `/skill-db` keeps live SQL verification of schema state (RLS, indexes, FK cascades, query patterns); `/migration-audit` handles the files themselves.
 
 ---
 
@@ -411,7 +379,7 @@ Sources: Supabase RLS docs, PostgreSQL docs (indexes, constraints), wiki.postgre
 [2-5 bullets — Critical and High findings only. Write concrete facts: table names, column names, line counts.
 If nothing Critical/High: state that explicitly ("No Critical or High findings — schema is production-ready for this scope").
 Example bullets:
-- "2 migrations lack rollback comments for irreversible DROP COLUMN (M2): 045_..., 051_..."
+- "3 tables with UPDATE policy but no SELECT policy (S4D High)"
 
 ### DB maturity assessment
 | Dimension | Rating | Notes |
@@ -420,7 +388,6 @@ Example bullets:
 | Index quality | strong / adequate / weak | [unindexed FKs, missing filter indexes, unused indexes] |
 | RLS / security posture | strong / adequate / weak | [policy gaps, unsafe views, function caching] |
 | Query quality | strong / adequate / weak | [N+1, unbounded, missing error handling] |
-| Migration safety | strong / adequate / weak | [lock-heavy DDL, missing rollbacks, unsafe backfills] |
 | Release readiness | ready / conditional / blocked | [blocked = any Critical finding; conditional = High findings present but workarounded] |
 
 Rating guide: strong = no significant issues; adequate = issues exist but low production risk; weak = issues that should be resolved before next production release.
@@ -443,12 +410,6 @@ Rating guide: strong = no significant issues; adequate = issues exist but low pr
 | S5 | Data type choices | ✅/⚠️ | [timestamp/varchar/serial hits] |
 | S6 | FK cascade behavior | ✅/⚠️ | |
 | S7 | Unused indexes | ✅/⚠️ | [N with 0 scans and qualifying criteria] |
-
-### Migration Safety Checks
-[Only list files with at least one ⚠️. For clean files report summary count.]
-| File | M1 Lock | M2 Rollback | M3 Backfill | M4 Constraint seq | Notes |
-|---|---|---|---|---|---|
-| [migration filename] | ✅/⚠️ | ✅/⚠️ | ✅/⚠️ | ✅/⚠️ | [specific SQL line] |
 
 ### Query Pattern Checks (API routes)
 | # | Check | Matches | Verdict |
@@ -494,9 +455,9 @@ Then write ONLY the approved entries to `docs/refactoring-backlog.md`:
 
 ### Severity guide
 
-- **Critical**: RLS gap that allows unauthorized data access (S4A); UPDATE policy without SELECT (S4D); view bypassing RLS on sensitive table (S4E); `CASCADE` that would destroy financial records (S6); `CREATE INDEX CONCURRENTLY` inside a BEGIN block (M1); destructive migration applied to staging without rollback comment (M2)
-- **High**: N+1 on a list endpoint (Q1); missing await on a DB write call (Q2); unbounded query on a high-volume table (Q5); unindexed FK on a write-heavy table (S1B); bare `auth.uid()` on a table with thousands of rows (S4B); `CREATE INDEX` without CONCURRENTLY on a production-size table (M1); missing constraint DROP before status-value UPDATE (M4); `ADD COLUMN NOT NULL` without safe staging pattern (M1)
-- **Medium**: Missing CHECK constraint on financial column (S2b); missing composite UNIQUE where business rules require it (S2b); nullable column used in financial calculations (S3); `timestamp` without timezone (S5); `varchar(n)` with arbitrary limit (S5); `serial` instead of IDENTITY (S5); unsafe backfill on high-traffic table (M3); `stato` as unconstrained text (S2b/S5); `SET NULL` on a NOT NULL FK column (S6)
+- **Critical**: RLS gap that allows unauthorized data access (S4A); UPDATE policy without SELECT (S4D); view bypassing RLS on sensitive table (S4E); `CASCADE` that would destroy financial records (S6)
+- **High**: N+1 on a list endpoint (Q1); missing await on a DB write call (Q2); unbounded query on a high-volume table (Q5); unindexed FK on a write-heavy table (S1B); bare `auth.uid()` on a table with thousands of rows (S4B)
+- **Medium**: Missing CHECK constraint on financial column (S2b); missing composite UNIQUE where business rules require it (S2b); nullable column used in financial calculations (S3); `timestamp` without timezone (S5); `varchar(n)` with arbitrary limit (S5); `serial` instead of IDENTITY (S5); `stato` as unconstrained text (S2b/S5); `SET NULL` on a NOT NULL FK column (S6)
 - **Low**: Unused indexes with 0 scans meeting all qualifying criteria (S7); normalization observation with documented trade-off (S2); missing GIN for UUID[] (S1D); partial index opportunity where distribution warrants it (S1C); policies with `{public}` scope where a narrower role would be more precise (S4C)
 
 ---

--- a/packages/cli/templates/tier-m/.claude/cheatsheet.md
+++ b/packages/cli/templates/tier-m/.claude/cheatsheet.md
@@ -37,6 +37,7 @@ Run these on demand. Each skill reads the codebase, produces a structured report
 | `/security-audit` | Auth guards, input validation, sensitive data in responses, HTTP headers | Before production deploy; after adding new API routes |
 | `/skill-dev` | Coupling, duplication, dead code, magic strings, oversized components | Before major refactoring; quarterly review |
 | `/skill-db` | Missing indexes, access control gaps, constraint completeness, N+1 queries | After migration waves; before production releases |
+| `/migration-audit` | Migration file safety: lock-heavy DDL, missing rollback, data loss, unsafe ALTER TYPE | After writing a migration, before applying to staging |
 | `/api-design` | HTTP verb correctness, URL structure, response shape, error codes, pagination | After adding 3+ new routes; quarterly |
 | `/perf-audit` | Server/client boundaries, heavy imports, serial awaits, image optimization, N+1 | Before production releases; after major UI changes |
 | `/simplify` | Early returns, nesting depth, local duplication, dead code, magic values | After writing code (Phase 2); on demand |

--- a/packages/cli/templates/tier-m/.claude/rules/pipeline.md
+++ b/packages/cli/templates/tier-m/.claude/rules/pipeline.md
@@ -186,12 +186,13 @@ If either condition is false: **skip this phase and state so explicitly** — do
 **Track B — API/DB audit** *(if block creates/modifies API routes or applies migrations — static analysis, no dev server needed)*
 - Run `/security-audit` if the block creates or modifies any API route.
 - Run `/api-design` if the block adds new API routes. Both are static — run them concurrently.
-- Run `/skill-db` only if the block applies migrations.
+- Run `/migration-audit` if the block applies migrations — static analysis of migration files.
+- Run `/skill-db` if the block changes the schema or adds new tables — live SQL verification of schema state, RLS policies, and query patterns.
 
 **Severity handling — both tracks**:
 - **Critical**: fix before Phase 6. Do not proceed with open Critical issues.
 - **Major**: flag in Phase 6 checklist with planned resolution sprint.
-- **Minor**: append to `docs/refactoring-backlog.md` — assign ID prefix (`PERF-`, `API-`, `DB-`, `DEV-`, `UX-`).
+- **Minor**: append to `docs/refactoring-backlog.md` — assign ID prefix (`PERF-`, `API-`, `DB-`, `MIG-`, `DEV-`, `UX-`).
 - Output per skill: one-paragraph summary only.
 
 ## Phase 6 — Outcome checklist ⏸ STOP

--- a/packages/cli/templates/tier-m/.claude/skills/migration-audit/SKILL.md
+++ b/packages/cli/templates/tier-m/.claude/skills/migration-audit/SKILL.md
@@ -1,0 +1,252 @@
+---
+name: migration-audit
+description: Stack-aware migration safety audit: data loss risks, destructive ops without rollback, NOT NULL without DEFAULT, unsafe ALTER TYPE, lock-heavy DDL, constraint sequencing. Supports Prisma, Drizzle, Supabase CLI, raw SQL.
+user-invocable: true
+model: sonnet
+context: fork
+argument-hint: [target:file:<filename>|target:range:<from>-<to>|mode:all]
+---
+
+## Configuration (adapt before first run)
+
+> Replace these placeholders:
+> - `[MIGRATIONS_PATH]` — e.g. `prisma/migrations/`, `drizzle/`, `supabase/migrations/`, `db/migrations/`
+> - `[DB_SYSTEM]` — e.g. `PostgreSQL`, `MySQL`, `SQLite`
+> - `[APP_SOURCE_PATH]` — path to application source for column-reference cross-checks (e.g. `src/`, `app/`)
+> - `[STAGING_DB_URL]` — optional, for Step 4 applied-migration verification
+
+---
+
+## Step 0 — Target resolution
+
+Parse `$ARGUMENTS` for a `target:` or `mode:` token.
+
+| Pattern | Meaning |
+|---|---|
+| `target:file:<filename>` | Audit a single migration file (for debugging before apply) |
+| `target:range:<from>-<to>` | Audit a numeric range of migrations (e.g. `target:range:042-051`) |
+| `mode:all` / no argument | **Full audit — every migration file discovered in Step 2.** |
+
+**STRICT PARSING**: derive target ONLY from explicit text in `$ARGUMENTS`. Do NOT infer from conversation context, recent blocks, or memory.
+
+Announce: `Running migration-audit — scope: [FULL | target: <resolved>] — stack: <pending detection>`
+
+---
+
+## Step 1 — Stack detection
+
+Detect the migration framework in this priority order. First matching marker wins.
+
+| Framework | Marker file(s) | Path pattern for migrations |
+|---|---|---|
+| **Prisma** | `prisma/schema.prisma` | `prisma/migrations/*/migration.sql` |
+| **Drizzle** | `drizzle.config.ts` / `drizzle.config.js` | `drizzle/*.sql` (journal at `drizzle/meta/_journal.json`) |
+| **Supabase CLI** | `supabase/config.toml` | `supabase/migrations/*.sql` |
+| **Raw SQL** | `.sql` files in `migrations/` or `db/migrations/` | same |
+| Rails | `config/application.rb` + `Gemfile` | `db/migrate/*.rb` |
+| Django | `manage.py` + any `*/migrations/*.py` | `*/migrations/*.py` |
+| Alembic | `alembic.ini` | `alembic/versions/*.py` |
+| Flyway | `flyway.conf` or `flyway.toml` | `**/db/migration/V*__*.sql` |
+
+**Supported at launch**: Prisma, Drizzle, Supabase CLI, Raw SQL.
+
+For Rails / Django / Alembic / Flyway: announce `Framework detected: <name> — support pending. See https://github.com/marcoguillermaz/claude-dev-kit/issues/59 to contribute an adapter.` and exit 0.
+
+If no marker is found: announce `No migration framework detected. Checked: Prisma, Drizzle, Supabase CLI, Raw SQL. If migrations live elsewhere, pass target:file: with the absolute path.` and exit 0.
+
+Update announcement: `Running migration-audit — scope: [FULL | target: <resolved>] — stack: <detected>`
+
+---
+
+## Step 2 — Migration file discovery
+
+Use the path pattern from Step 1. Sort migrations by numeric prefix (or by `drizzle/meta/_journal.json` order for Drizzle, or Prisma timestamp directory order).
+
+**For `mode:all` and file count > 30**: prioritize analysis in this order:
+1. All files containing `DROP`, `TRUNCATE`, `ALTER TYPE`, `RENAME` (tokens in file body).
+2. The 15 most recent files by sort order.
+3. Remaining files time permitting.
+
+State: `Discovered N migration files. Auditing: <scope>`
+
+---
+
+## Step 3 — Static safety checks (main context)
+
+Run all eight checks per file. Record findings with SEVERITY / CHECK / FILE:LINE / SQL / REASON.
+
+### M1 — Lock-heavy DDL
+
+Flag the following patterns (grep per file body):
+
+- `CREATE INDEX` (not `CONCURRENTLY`) on a table with likely > 1000 rows. Severity: **High**. Suggest `CREATE INDEX CONCURRENTLY ...`.
+- `CREATE INDEX CONCURRENTLY` appearing **inside** a `BEGIN` / `COMMIT` block (or any transaction marker). Severity: **Critical** — this fails at runtime in PostgreSQL. CONCURRENTLY cannot run inside a transaction.
+- `ADD COLUMN <col> <type> NOT NULL` **without** `DEFAULT` in the same statement. Severity: **High** — fails immediately on tables with existing rows.
+- `ADD COLUMN <col> <type> NOT NULL DEFAULT <expr>` where `<expr>` is volatile (`now()`, `random()`, `gen_random_uuid()`). Severity: **High** — triggers full table rewrite under ACCESS EXCLUSIVE lock. Suggest: add nullable, backfill, then `ALTER COLUMN ... SET NOT NULL`.
+- `ALTER COLUMN <col> TYPE <new_type>` where the type change requires a cast and full rewrite (e.g. `int` → `bigint`, `text` → `uuid`). Severity: **High**.
+- `RENAME COLUMN` / `RENAME TABLE`. Severity: **Medium** if there are active consumers in app source; **Low** otherwise.
+- `ALTER TYPE ... RENAME VALUE` — ACCESS EXCLUSIVE lock on every table using the enum. Severity: **Medium**.
+
+### M2 — Non-reversible operations without rollback
+
+For any migration containing `DROP COLUMN`, `DROP TABLE`, `TRUNCATE`, `ALTER TYPE ... RENAME VALUE`, or irreversible `UPDATE <t> SET ...`:
+
+- **Require** a rollback SQL comment block at the top of the file:
+  ```sql
+  -- ROLLBACK:
+  -- <steps to reverse this migration>
+  ```
+- Severity: **High** if the comment block is absent.
+- Severity: **Critical** if Step 4 confirms the file is already applied in staging/prod.
+
+### M3 — Unsafe backfills
+
+Flag `UPDATE <table> SET <col> = <value>` statements without a `WHERE` clause that bounds scope, or without a batching pattern (e.g. `LIMIT`, cursor loop). Holds a table-level lock for the full duration and generates replication lag.
+
+Severity: **Medium** on any table; **High** if the table is called out as high-traffic in `docs/db-map.md` or `CLAUDE.md`.
+
+### M4 — Constraint sequencing
+
+If a migration changes a status / enum value (e.g. `UPDATE users SET role = 'MEMBER' WHERE role = 'USER'`), verify the sequence:
+
+1. `ALTER TABLE ... DROP CONSTRAINT <check_constraint>`
+2. `UPDATE ...` (the value rename)
+3. `ALTER TABLE ... ADD CONSTRAINT <check_constraint>` with the new value set
+
+Severity: **High** if the UPDATE appears without the surrounding DROP/ADD CONSTRAINT — would fail on tables with an existing CHECK constraint on the column.
+
+### M5 — Data loss risk
+
+For every `DROP COLUMN <col>`:
+- Grep `[APP_SOURCE_PATH]` for references to `<col>` (field name match). If references exist, severity: **Critical** — application will break at runtime.
+- If no references exist but the prior migration did NOT rename the column to `<col>_deprecated` (staged deprecation marker): severity: **High**. Data is removed before a cool-down period.
+
+For every `DROP TABLE <t>`:
+- Require a prior migration that renamed `<t>` to `<t>_deprecated` or added a deprecation comment. Severity: **High** if no staged deprecation found.
+
+### M6 — Unsafe type changes
+
+- `ALTER TYPE <enum> RENAME VALUE 'X' TO 'Y'` outside the M4 constraint-replay sequence: severity: **High**.
+- Implicit `int` → `string` or `string` → `int` casts in ORM-generated migrations (common Prisma/Drizzle pitfall when schema column type changed). Severity: **High** if data coercion is required without an explicit `USING` clause.
+
+### M7 — FK without indexed child column
+
+For each `ADD CONSTRAINT ... FOREIGN KEY (<col>) REFERENCES ...`:
+- Verify the same migration (or an earlier one in the same batch) adds `CREATE INDEX ON <table> (<col>)`.
+- Severity: **Medium** if the index is missing — every JOIN and every ON DELETE cascade on the parent will sequential-scan the child.
+
+### M8 — Migration ordering integrity
+
+Compare the numeric prefix ordering of new migration files in this branch vs. the highest prefix already on `main`.
+
+- If a new file has a prefix `N` and `main` already contains a file with prefix `M > N`, flag as **Medium** — migration ordering collision on merge. Suggest renumber.
+- For Prisma (timestamp dirs): check that new timestamps are strictly greater than the highest timestamp on `main`.
+- For Drizzle: check `drizzle/meta/_journal.json` ordering is consistent.
+
+---
+
+## Step 4 — Live DB cross-reference *(optional, Postgres / Supabase only)*
+
+**Skip this step** if `[STAGING_DB_URL]` is not configured, or if the stack is not Postgres-backed.
+
+For each file flagged under M2 (non-reversible without rollback), query the applied-migrations ledger:
+
+```sql
+-- Supabase CLI ledger
+SELECT version, name FROM supabase_migrations.schema_migrations WHERE version = '<prefix>';
+
+-- Prisma ledger
+SELECT id, migration_name, finished_at FROM _prisma_migrations WHERE migration_name LIKE '%<prefix>%';
+
+-- Drizzle ledger
+SELECT id, hash, created_at FROM __drizzle_migrations WHERE id = <prefix>;
+```
+
+If the file is already applied to staging/prod: escalate M2 finding to **Critical** and record the note: `Already applied — rollback must be run manually if issue confirmed.`
+
+---
+
+## Step 5 — Report and backlog decision gate
+
+### Output format
+
+```
+## Migration Audit — [DATE] — [SCOPE] — stack: [FRAMEWORK]
+
+### Executive summary
+[2-5 bullets — Critical and High findings only. Write concrete facts: file names, SQL line, impact.
+If nothing Critical/High: state that explicitly ("No Critical or High findings — migration set is safe to apply").
+Example bullets:
+- "Migration 052 drops `users.legacy_id` which is referenced in src/auth/session.ts:18 (M5 Critical)"
+- "Migration 047 has CREATE INDEX CONCURRENTLY inside a BEGIN block — will fail at apply time (M1 Critical)"]
+
+### Migration maturity assessment
+| Dimension | Rating | Notes |
+|---|---|---|
+| Rollback discipline | strong / adequate / weak | [% of destructive migrations with ROLLBACK comment] |
+| Lock posture | strong / adequate / weak | [count of non-CONCURRENT CREATE INDEX, full-rewrite ALTERs] |
+| Backfill safety | strong / adequate / weak | [unbatched UPDATEs on large tables] |
+| Constraint hygiene | strong / adequate / weak | [DROP→UPDATE→ADD sequencing, FK without index] |
+| Ordering integrity | strong / adequate / weak | [prefix collisions vs main] |
+| Release readiness | ready / conditional / blocked | [blocked = any Critical; conditional = High findings exist] |
+
+### Check verdicts
+| # | Check | Verdict | Findings |
+|---|---|---|---|
+| M1 | Lock-heavy DDL | ✅/⚠️ | [N files flagged] |
+| M2 | Non-reversible without rollback | ✅/⚠️ | |
+| M3 | Unsafe backfills | ✅/⚠️ | |
+| M4 | Constraint sequencing | ✅/⚠️ | |
+| M5 | Data loss risk | ✅/⚠️ | |
+| M6 | Unsafe type changes | ✅/⚠️ | |
+| M7 | FK without indexed child | ✅/⚠️ | |
+| M8 | Ordering integrity | ✅/⚠️ | |
+
+### Prioritized findings
+For each finding with severity Medium or above:
+[SEVERITY] [ID] [check] — [file:line] — [SQL excerpt] — [impact] — [fix] — [effort: S=<1h / M=half day / L=day+]
+
+### Quick wins
+[Findings that meet all three: (a) Medium or High, (b) effort S, (c) single-file fix]
+Format: "MIG-[n]: [one-line description]"
+If no quick wins: state explicitly.
+```
+
+### Backlog decision gate
+
+Present all findings with severity Medium or above as a numbered decision list, sorted Critical → High → Medium:
+
+```
+Found N findings at Medium or above. Which to add to backlog?
+
+[1] [CRITICAL] MIG-? — file:line — one-line description
+[2] [HIGH]     MIG-? — file:line — one-line description
+[3] [MEDIUM]   MIG-? — file:line — one-line description
+...
+
+Reply with numbers to include (e.g. "1 2 4"), "all", or "none".
+```
+
+**Wait for explicit user response before writing anything.**
+
+Then write ONLY the approved entries to `docs/refactoring-backlog.md`:
+- Assign ID: `MIG-[n]` (next available after existing MIG entries)
+- Add row to priority index
+- Add full detail section with: issue, evidence (SQL excerpt), file:line, fix suggestion, effort, rollback risk
+
+### Severity guide
+
+- **Critical**: `CREATE INDEX CONCURRENTLY` inside a transaction (M1); destructive migration already applied without rollback (M2); `DROP COLUMN` on a column referenced in app source (M5)
+- **High**: `ADD COLUMN NOT NULL` without DEFAULT (M1); `ADD COLUMN NOT NULL DEFAULT <volatile>` (M1); full-rewrite `ALTER COLUMN TYPE` (M1); destructive migration missing ROLLBACK comment, not yet applied (M2); unbatched UPDATE on high-traffic table (M3); value rename missing constraint-replay (M4); `DROP TABLE` without staged deprecation (M5); unsafe type coercion without explicit cast (M6)
+- **Medium**: `CREATE INDEX` without CONCURRENTLY on smaller tables (M1); `RENAME COLUMN` with active consumers (M1); `ALTER TYPE RENAME VALUE` (M1); unbatched UPDATE on low-traffic table (M3); FK without companion index (M7); ordering prefix collision vs main (M8)
+- **Low**: `RENAME COLUMN` with no consumers (M1)
+
+---
+
+## Execution notes
+
+- Do NOT apply, modify, or write any migration file. Audit only.
+- Do NOT connect to production DB. Staging DB is acceptable for Step 4 with explicit `[STAGING_DB_URL]` config.
+- `docs/db-map.md` (if present) is authoritative for "high-traffic" table classification used by M3.
+- After the report, ask: `Vuoi che prepari migration SQL corrette per i fix identificati?` Reply with `yes` only after the user has signed off on the specific findings.
+- This skill complements `/skill-db`: `/migration-audit` handles static analysis of migration files; `/skill-db` handles live SQL verification of schema state, RLS policies, index coverage, and query patterns. Run both during Phase 5d Track B when a block applies migrations.

--- a/packages/cli/templates/tier-m/.claude/skills/skill-db/SKILL.md
+++ b/packages/cli/templates/tier-m/.claude/skills/skill-db/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-db
-description: Database audit: schema quality, index coverage, RLS completeness, FK cascades, migration safety, query patterns. Runs live SQL verification against the database.
+description: Database audit: schema quality, index coverage, RLS completeness, FK cascades, query patterns. Runs live SQL verification. Migration file safety → /migration-audit.
 user-invocable: true
 model: sonnet
 context: fork
@@ -14,7 +14,6 @@ argument-hint: [target:section:<section>|target:table:<table>]
 > - `[ORM_OR_CLIENT]` — e.g. `Prisma`, `Drizzle`, `Supabase JS client`, `SQLAlchemy`, `raw SQL`
 > - `[API_ROUTES_PATH]` — path to API route files for N+1 check
 > - `[ACCESS_CONTROL]` — e.g. `row-level security policies`, `middleware guards`, `model-level scopes`
-> - `[MIGRATIONS_PATH]` — e.g. `prisma/migrations/`, `db/migrations/`, `drizzle/`
 
 
 
@@ -28,14 +27,14 @@ Parse `$ARGUMENTS` for a `target:` token.
 | Pattern | Meaning |
 |---|---|
 | `target:section:<other>` | Resolve to matching tables in db-map.md whose name contains `<other>` |
-| `target:table:<tablename>` | Focus on a specific table and its direct FKs. **Migration safety (Step 2.5) is skipped for this target type.** |
-| No argument | **Full audit — ALL tables in docs/db-map.md. Maximum depth across every check (S1–S7, Step 2.5).** |
+| `target:table:<tablename>` | Focus on a specific table and its direct FKs. |
+| No argument | **Full audit — ALL tables in docs/db-map.md. Maximum depth across every schema, RLS, and query check (S1–S7).** |
 
 **STRICT PARSING — mandatory**: derive target ONLY from the explicit text in `$ARGUMENTS`. Do NOT infer target from conversation context, recent work, active block names, or project memory. If `$ARGUMENTS` contains no `target:` token → full audit of the entire schema in db-map.md at maximum depth. When a target IS provided → act with maximum depth and completeness on that specific scope only.
 
 Announce: `Running skill-db — scope: [FULL | target: <resolved>]`
 
-**Target filter semantics**: apply the filter in Steps 2–4 as follows — S1 (only indexes on targeted tables and their FK children), S2/S3/S2b (only columns of targeted tables), S4 (only policies on targeted tables), S5/S6/S7 (only targeted tables). Step 2.5 (migration safety) scans only migration files that touch the targeted section; for `target:table:` it is skipped entirely.
+**Target filter semantics**: apply the filter in Steps 2–4 as follows — S1 (only indexes on targeted tables and their FK children), S2/S3/S2b (only columns of targeted tables), S4 (only policies on targeted tables), S5/S6/S7 (only targeted tables).
 
 **Critical constraints**:
 - `docs/db-map.md` is the authoritative schema reference. Read it first — do NOT query the live DB to discover schema unless verifying a specific detail.
@@ -298,40 +297,9 @@ ORDER BY pg_relation_size(indexrelid) DESC;
 
 ## Step 2.5 — Migration safety review
 
-**Scope**:
-- `target:section:*`: scan only migration files that touch the targeted tables (filter by filename convention or by grepping table names).
-- No argument (full audit): scan all migration files. If count > 30, prioritize: (1) all files containing `DROP`, `TRUNCATE`, `ALTER TYPE`, `RENAME`; (2) the 15 most recent files (highest-numbered); (3) any remaining files only if time permits.
-- `target:table:*`: **skip this step entirely** — announced at Step 0.
+Migration file safety checks (lock-heavy DDL, missing rollback comments, unsafe backfills, constraint sequencing, data loss risks, FK indexing, ordering integrity) are owned by the **`/migration-audit` skill** — a stack-aware static analyzer for Prisma, Drizzle, Supabase CLI, and raw SQL migrations.
 
-For each file in scope, evaluate these four risks:
-
-**M1 — Lock-heavy DDL**
-Operations that take an `ACCESS EXCLUSIVE` lock, blocking all reads and writes:
-- `CREATE INDEX` without `CONCURRENTLY` — locks the table for the full index build. Flag as High for any table with expected rows > 1000.
-- `CREATE INDEX CONCURRENTLY` inside a `BEGIN`/`COMMIT` block — **this fails in PostgreSQL**. CONCURRENTLY cannot run inside a transaction. Grep for files containing both `BEGIN` (or `START TRANSACTION`) and `CREATE INDEX CONCURRENTLY` in the same file. Flag as Critical.
-- `ADD COLUMN col type NOT NULL` without a DEFAULT — fails immediately on tables with existing rows. Flag as High.
-- `ADD COLUMN col type NOT NULL DEFAULT <volatile_expr>` — triggers a full table rewrite (e.g. `DEFAULT now()` is volatile). Flag as High; suggest: add as nullable first, backfill, then add NOT NULL constraint.
-- `ALTER COLUMN ... TYPE` that requires a cast and full rewrite — flag as High.
-- `RENAME COLUMN` / `RENAME TABLE` — takes ACCESS EXCLUSIVE but completes instantly; flag as Medium only if the renamed object has active API consumers (verify in sitemap.md).
-- `ALTER TYPE ... RENAME VALUE` — takes ACCESS EXCLUSIVE lock on all tables using that type; flag as Medium with the note that it is safe but blocking.
-
-**M2 — Non-reversible operations without rollback comment**
-Check each file for: `DROP COLUMN`, `DROP TABLE`, `TRUNCATE`, `ALTER TYPE ... RENAME VALUE`, or irreversible `UPDATE` statements.
-
-Per CLAUDE.md Known Patterns: destructive migrations MUST have a rollback SQL comment at the top: `-- ROLLBACK: ...`.
-Flag as High: any destructive migration lacking a rollback comment block.
-Flag as Critical: a destructive migration that has already been applied to staging (verify: `SELECT * FROM supabase_migrations.schema_migrations WHERE version = 'NNN'` — if found, it's applied).
-
-**M3 — Unsafe backfills**
-`UPDATE table SET col = value` without batching on a high-traffic table holds a lock for the full duration, generating excessive WAL and causing replication lag.
-
-**M4 — Constraint sequencing**
-Per CLAUDE.md Known Patterns: if a migration changes a status/enum value, it must follow the sequence: (1) DROP CONSTRAINT, (2) UPDATE data, (3) ADD CONSTRAINT — all in one migration for atomicity.
-
-Check: any migration with `UPDATE ... SET stato = ...` or similar value rename. Verify the DROP CONSTRAINT → UPDATE → ADD CONSTRAINT sequence is present. If a migration has only the UPDATE without constraint handling, flag as High (would fail on tables with existing CHECK constraints).
-
-**Migration safety output**:
-Report only files with at least one ⚠️. For clean files, report count only (e.g. "12 files reviewed, 10 clean"). For each flagged file: filename, issue code (M1/M2/M3/M4), severity, and the specific SQL line that raised the concern.
+When a block applies migrations, run `/migration-audit` alongside `/skill-db` in Phase 5d Track B. `/skill-db` keeps live SQL verification of schema state (RLS, indexes, FK cascades, query patterns); `/migration-audit` handles the files themselves.
 
 ---
 
@@ -411,7 +379,7 @@ Sources: Supabase RLS docs, PostgreSQL docs (indexes, constraints), wiki.postgre
 [2-5 bullets — Critical and High findings only. Write concrete facts: table names, column names, line counts.
 If nothing Critical/High: state that explicitly ("No Critical or High findings — schema is production-ready for this scope").
 Example bullets:
-- "2 migrations lack rollback comments for irreversible DROP COLUMN (M2): 045_..., 051_..."
+- "3 tables with UPDATE policy but no SELECT policy (S4D High)"
 
 ### DB maturity assessment
 | Dimension | Rating | Notes |
@@ -420,7 +388,6 @@ Example bullets:
 | Index quality | strong / adequate / weak | [unindexed FKs, missing filter indexes, unused indexes] |
 | RLS / security posture | strong / adequate / weak | [policy gaps, unsafe views, function caching] |
 | Query quality | strong / adequate / weak | [N+1, unbounded, missing error handling] |
-| Migration safety | strong / adequate / weak | [lock-heavy DDL, missing rollbacks, unsafe backfills] |
 | Release readiness | ready / conditional / blocked | [blocked = any Critical finding; conditional = High findings present but workarounded] |
 
 Rating guide: strong = no significant issues; adequate = issues exist but low production risk; weak = issues that should be resolved before next production release.
@@ -443,12 +410,6 @@ Rating guide: strong = no significant issues; adequate = issues exist but low pr
 | S5 | Data type choices | ✅/⚠️ | [timestamp/varchar/serial hits] |
 | S6 | FK cascade behavior | ✅/⚠️ | |
 | S7 | Unused indexes | ✅/⚠️ | [N with 0 scans and qualifying criteria] |
-
-### Migration Safety Checks
-[Only list files with at least one ⚠️. For clean files report summary count.]
-| File | M1 Lock | M2 Rollback | M3 Backfill | M4 Constraint seq | Notes |
-|---|---|---|---|---|---|
-| [migration filename] | ✅/⚠️ | ✅/⚠️ | ✅/⚠️ | ✅/⚠️ | [specific SQL line] |
 
 ### Query Pattern Checks (API routes)
 | # | Check | Matches | Verdict |
@@ -494,9 +455,9 @@ Then write ONLY the approved entries to `docs/refactoring-backlog.md`:
 
 ### Severity guide
 
-- **Critical**: RLS gap that allows unauthorized data access (S4A); UPDATE policy without SELECT (S4D); view bypassing RLS on sensitive table (S4E); `CASCADE` that would destroy financial records (S6); `CREATE INDEX CONCURRENTLY` inside a BEGIN block (M1); destructive migration applied to staging without rollback comment (M2)
-- **High**: N+1 on a list endpoint (Q1); missing await on a DB write call (Q2); unbounded query on a high-volume table (Q5); unindexed FK on a write-heavy table (S1B); bare `auth.uid()` on a table with thousands of rows (S4B); `CREATE INDEX` without CONCURRENTLY on a production-size table (M1); missing constraint DROP before status-value UPDATE (M4); `ADD COLUMN NOT NULL` without safe staging pattern (M1)
-- **Medium**: Missing CHECK constraint on financial column (S2b); missing composite UNIQUE where business rules require it (S2b); nullable column used in financial calculations (S3); `timestamp` without timezone (S5); `varchar(n)` with arbitrary limit (S5); `serial` instead of IDENTITY (S5); unsafe backfill on high-traffic table (M3); `stato` as unconstrained text (S2b/S5); `SET NULL` on a NOT NULL FK column (S6)
+- **Critical**: RLS gap that allows unauthorized data access (S4A); UPDATE policy without SELECT (S4D); view bypassing RLS on sensitive table (S4E); `CASCADE` that would destroy financial records (S6)
+- **High**: N+1 on a list endpoint (Q1); missing await on a DB write call (Q2); unbounded query on a high-volume table (Q5); unindexed FK on a write-heavy table (S1B); bare `auth.uid()` on a table with thousands of rows (S4B)
+- **Medium**: Missing CHECK constraint on financial column (S2b); missing composite UNIQUE where business rules require it (S2b); nullable column used in financial calculations (S3); `timestamp` without timezone (S5); `varchar(n)` with arbitrary limit (S5); `serial` instead of IDENTITY (S5); `stato` as unconstrained text (S2b/S5); `SET NULL` on a NOT NULL FK column (S6)
 - **Low**: Unused indexes with 0 scans meeting all qualifying criteria (S7); normalization observation with documented trade-off (S2); missing GIN for UUID[] (S1D); partial index opportunity where distribution warrants it (S1C); policies with `{public}` scope where a narrower role would be more precise (S4C)
 
 ---

--- a/packages/cli/test/integration/run.js
+++ b/packages/cli/test/integration/run.js
@@ -300,6 +300,7 @@ async function scenarioTierS_full() {
   // Tier S must NOT have M/L-only skills
   assertNotExists(dir, '.claude/skills/api-design/SKILL.md');
   assertNotExists(dir, '.claude/skills/skill-db/SKILL.md');
+  assertNotExists(dir, '.claude/skills/migration-audit/SKILL.md');
   assertNotExists(dir, '.claude/skills/responsive-audit/SKILL.md');
 
   // Active Skills section in CLAUDE.md
@@ -410,6 +411,7 @@ async function scenarioTierM() {
   assertExists(dir, '.claude/skills/security-audit/SKILL.md');
   assertExists(dir, '.claude/skills/skill-dev/SKILL.md');
   assertExists(dir, '.claude/skills/skill-db/SKILL.md');
+  assertExists(dir, '.claude/skills/migration-audit/SKILL.md');
   assertExists(dir, '.claude/skills/api-design/SKILL.md');
   assertExists(dir, '.claude/skills/perf-audit/SKILL.md');
   assertExists(dir, '.claude/skills/simplify/SKILL.md');
@@ -457,6 +459,7 @@ async function scenarioTierL() {
   assertExists(dir, '.claude/skills/security-audit/SKILL.md');
   assertExists(dir, '.claude/skills/skill-dev/SKILL.md');
   assertExists(dir, '.claude/skills/skill-db/SKILL.md');
+  assertExists(dir, '.claude/skills/migration-audit/SKILL.md');
   assertExists(dir, '.claude/skills/api-design/SKILL.md');
   assertExists(dir, '.claude/skills/perf-audit/SKILL.md');
   assertExists(dir, '.claude/skills/simplify/SKILL.md');
@@ -666,10 +669,11 @@ async function scenarioSkillPruning() {
   assertNotExists(dir, 'docs/sitemap.md');
   assertNotExists(dir, 'docs/db-map.md');
 
-  // Skills that must be absent (hasApi=false → api-design pruned; hasDatabase=false → skill-db pruned)
+  // Skills that must be absent (hasApi=false → api-design pruned; hasDatabase=false → skill-db + migration-audit pruned)
   assertNotExists(dir, '.claude/skills/api-design/SKILL.md');
   assertExists(dir, '.claude/skills/security-audit/SKILL.md');
   assertNotExists(dir, '.claude/skills/skill-db/SKILL.md');
+  assertNotExists(dir, '.claude/skills/migration-audit/SKILL.md');
   assertNotExists(dir, '.claude/skills/responsive-audit/SKILL.md');
   assertNotExists(dir, '.claude/skills/visual-audit/SKILL.md');
   assertNotExists(dir, '.claude/skills/ux-audit/SKILL.md');
@@ -1285,6 +1289,12 @@ async function scenarioCheatsheetPruning() {
     fail('cheatsheet: /skill-db row should be removed when hasDatabase=false');
   }
 
+  if (!cheat.includes('/migration-audit')) {
+    pass('cheatsheet: /migration-audit row removed (hasDatabase=false)');
+  } else {
+    fail('cheatsheet: /migration-audit row should be removed when hasDatabase=false');
+  }
+
   if (cheat.includes('/security-audit')) {
     pass('cheatsheet: /security-audit row present (stack-agnostic, not API-gated)');
   } else {
@@ -1602,6 +1612,7 @@ async function scenarioRubricScore() {
       let cheatClean = true;
       if (!hasApi && cheat.includes('/api-design')) cheatClean = false;
       if (config.hasDatabase === false && cheat.includes('/skill-db')) cheatClean = false;
+      if (config.hasDatabase === false && cheat.includes('/migration-audit')) cheatClean = false;
       if (cheatClean) {
         rubricPass('D5', `[${name}] cheatsheet has no phantom skill rows`);
       } else {

--- a/packages/cli/test/unit/skill-registry.test.js
+++ b/packages/cli/test/unit/skill-registry.test.js
@@ -23,8 +23,8 @@ describe('NATIVE_STACKS', () => {
 // ---------------------------------------------------------------------------
 
 describe('SKILL_REGISTRY', () => {
-  it('has 14 entries', () => {
-    assert.equal(SKILL_REGISTRY.length, 14);
+  it('has 15 entries', () => {
+    assert.equal(SKILL_REGISTRY.length, 15);
   });
 
   it('every entry has required fields', () => {
@@ -65,10 +65,11 @@ describe('getSkillsToRemove', () => {
     assert.ok(!result.includes('perf-audit'));
   });
 
-  it('hasDatabase=false removes skill-db', () => {
+  it('hasDatabase=false removes skill-db and migration-audit', () => {
     const result = getSkillsToRemove({ techStack: 'node-ts', hasDatabase: false });
     assert.ok(result.includes('skill-db'));
-    assert.equal(result.length, 1);
+    assert.ok(result.includes('migration-audit'));
+    assert.equal(result.length, 2);
   });
 
   it('hasFrontend=false removes all 4 frontend skills', () => {
@@ -158,10 +159,22 @@ describe('getActiveSkills', () => {
     assert.ok(result.includes('api-design'));
     assert.ok(result.includes('security-audit'));
     assert.ok(result.includes('skill-db'));
+    assert.ok(result.includes('migration-audit'));
     assert.ok(result.includes('responsive-audit'));
     assert.ok(result.includes('visual-audit'));
     assert.ok(result.includes('ux-audit'));
     assert.ok(result.includes('ui-audit'));
+  });
+
+  it('tier M hasDatabase=false excludes migration-audit', () => {
+    const result = getActiveSkills({ tier: 'm', hasDatabase: false });
+    assert.ok(!result.includes('migration-audit'));
+    assert.ok(!result.includes('skill-db'));
+  });
+
+  it('tier L hasDatabase=true includes migration-audit', () => {
+    const result = getActiveSkills({ tier: 'l', hasDatabase: true });
+    assert.ok(result.includes('migration-audit'));
   });
 
   it('tier M hasApi=false excludes api-design but keeps security-audit', () => {
@@ -219,10 +232,11 @@ describe('getCheatsheetSkillsToRemove', () => {
     assert.ok(result.includes('api-design'));
   });
 
-  it('hasDatabase=false removes skill-db from cheatsheet', () => {
+  it('hasDatabase=false removes skill-db and migration-audit from cheatsheet', () => {
     const result = getCheatsheetSkillsToRemove({ techStack: 'node-ts', hasDatabase: false });
     assert.ok(result.includes('skill-db'));
-    assert.equal(result.length, 1);
+    assert.ok(result.includes('migration-audit'));
+    assert.equal(result.length, 2);
   });
 
   it('only returns skills that have cheatsheet=true', () => {


### PR DESCRIPTION
## Summary

Adds `/migration-audit` — a stack-aware static analysis skill for migration files. Closes #59 (Q1 spike #1 of 4 planned skills in the #58-61 milestone).

**Why a standalone skill**: migration safety was previously bundled inside `/skill-db` (Supabase-specific, required live DB access). Projects using Prisma, Drizzle, Rails, Django, or raw SQL had zero CDK coverage. Extraction means single source of truth, faster feedback (no DB required, CI-friendly), and a direct compliance story (Q3 SOC2/HIPAA roadmap item).

## Changes

**New skill** — `packages/cli/templates/tier-{m,l}/.claude/skills/migration-audit/SKILL.md`
- Detects stack: Prisma, Drizzle, Supabase CLI, raw SQL (supported). Rails, Django, Alembic, Flyway (detected, pending)
- 8 check families M1-M8: lock-heavy DDL, missing rollback, unsafe backfills, constraint sequencing, data loss, unsafe type changes, unindexed FKs, ordering integrity
- Gating: `minTier: m`, `requires: { hasDatabase: true }`, `cheatsheet: true`, `user-invocable: true`, `model: sonnet`, `context: fork`

**Narrowed `/skill-db`** — migration Step 2.5 removed, cross-reference added. `/skill-db` now covers live SQL verification only (S1-S6 schema quality + Q1-Q3 N+1 patterns).

**Pipeline integration** — Phase 5d Track B in tier-m and tier-l pipelines:
- `/migration-audit` runs when the block applies migrations
- `/skill-db` runs when the block changes schema or adds new tables
- New severity prefix `MIG-` in refactoring-backlog

**Tests** — 481 → 491 integration checks, 25 → 28 unit tests. All green.

**Docs** — README (12 → 13 skills), operational-guide (skill table + dedicated section), CHANGELOG (Added + Changed entries).

## Test plan

- [x] `node --test packages/cli/test/unit/skill-registry.test.js` — 28/28
- [x] `node packages/cli/test/integration/run.js` — 491/491
- [x] Scaffold smoke test: node-ts + Postgres project lists `/migration-audit` in Active Skills
- [x] Scaffold smoke test: native-only project (hasDatabase=false) excludes `/migration-audit`
- [x] Tier S excludes `/migration-audit` (minTier=m)

## Decision point after merge

Evaluate `/migration-audit` usage on 1-2 real projects before proceeding with #58 `/test-audit`. User approved deferred consolidation of `/accessibility-audit` (#60) and `/doc-audit` (#61) pending this spike's feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)