### PR TITLE
feat(skills): add /accessibility-audit (#60)

### DIFF
--- a/.claude/rules/pipeline.md
+++ b/.claude/rules/pipeline.md
@@ -177,11 +177,12 @@ If either condition is false: **skip this phase and state so explicitly** — do
 ## Phase 5d — Block-scoped quality audit *(blocks with UI or API changes)*
 
 **Track A — UI audit** *(if block adds/modifies UI routes or components)*
-- Run `/ui-audit` scoped to the block's new/modified routes only (token compliance, component adoption, accessibility, empty states).
+- Run `/ui-audit` scoped to the block's new/modified routes only (token compliance, component adoption, empty states).
+- Run `/accessibility-audit` scoped to the block's new/modified routes (axe-core WCAG 2.2, APCA contrast, static a11y patterns).
 - Run `/visual-audit` scoped to the block's new/modified pages (typography, spacing, hierarchy, colour, density, dark-mode, micro-polish).
 - Run `/ux-audit` scoped to the block's user flows (task completion, feedback clarity, cognitive load).
 - Run `/responsive-audit` only if the block modifies routes used by non-admin roles.
-- **Execution order**: `/ui-audit` is static — launch it concurrently with the first Playwright-based skill. Then: `/visual-audit` → `/ux-audit` → `/responsive-audit` sequentially (they share the Playwright session).
+- **Execution order**: `/ui-audit` is static — launch it concurrently with the first Playwright-based skill. Then: `/accessibility-audit` → `/visual-audit` → `/ux-audit` → `/responsive-audit` sequentially (they share the Playwright session).
 
 **Track B — API/DB audit** *(if block creates/modifies API routes or applies migrations — static analysis, no dev server needed)*
 - Run `/security-audit` if the block creates or modifies any API route.
@@ -192,7 +193,7 @@ If either condition is false: **skip this phase and state so explicitly** — do
 **Severity handling — both tracks**:
 - **Critical**: fix before Phase 6. Do not proceed with open Critical issues.
 - **Major**: flag in Phase 6 checklist with planned resolution sprint.
-- **Minor**: append to `docs/refactoring-backlog.md` — assign ID prefix (`PERF-`, `API-`, `DB-`, `MIG-`, `DEV-`, `UX-`).
+- **Minor**: append to `docs/refactoring-backlog.md` — assign ID prefix (`PERF-`, `API-`, `DB-`, `MIG-`, `A11Y-`, `DEV-`, `UX-`).
 - Output per skill: one-paragraph summary only.
 
 ## Phase 6 — Outcome checklist ⏸ STOP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased] — v1.9.1
 
 ### Added
+- `/accessibility-audit` skill (Tier M/L, `hasFrontend=true`) - unified accessibility surface. Three modes: `static` (A1-A8 grep patterns: aria-label on icon buttons, positive tabindex, outline-none regression, img alt, form labels, focus ring size, onClick on non-interactive, nav keyboard access); `full` (adds APCA contrast probes C1-C3 via Playwright, both themes); `wcag` (adds axe-core 4.9.1 scan with `wcag2a + wcag2aa + wcag21aa + wcag22aa` tags, plus `best-practice`). Backlog prefix `A11Y-`. Pipeline Phase 5d Track A execution order: `/ui-audit` (static, concurrent) → `/accessibility-audit` → `/visual-audit` → `/ux-audit` → `/responsive-audit` (#60)
 - `/migration-audit` skill (Tier M/L, `hasDatabase=true`) - stack-aware static analysis of migration files. Detects Prisma, Drizzle, Supabase CLI, raw SQL; Rails/Django/Alembic/Flyway detected but pending support. 8 check families (M1-M8): lock-heavy DDL, missing rollback, unsafe backfills, constraint sequencing, data loss, unsafe type changes, unindexed FKs, ordering integrity. Backlog prefix `MIG-`. Pipeline Phase 5d Track B now runs `/migration-audit` when migrations are applied (#59)
 - `new skill` command - interactive wizard to scaffold custom skills with valid frontmatter, test fixture, and CLAUDE.md registration (#55)
 - `claudemd-update.js` shared utility - extracted CLAUDE.md Active Skills registration for reuse across commands
@@ -32,6 +33,8 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Doctor check #18 fix message now suggests correct value (`"timeout": 300`)
 
 ### Changed
+- `/ui-audit` scope narrowed to design-system compliance only. Extracted to `/accessibility-audit`: CHECK 11 (icon-only aria-label), CHECK 13 (positive tabindex), CHECK 14 (outline-none), CHECK 16 (img alt), CHECK 17 (form labels), S4 (nav keyboard), S6 (focus ring), S7 (onClick non-interactive), and Step 4 (axe-core WCAG scan). `/ui-audit` is now static-only (no Playwright). Check numbering preserves gaps to avoid breaking external references (#60)
+- `/visual-audit` narrowed from 11 to 10 dimensions. V8 (Contrast & legibility) and APCA Lc anchors in V4 extracted to `/accessibility-audit` (C1-C3). Page score denominator changed from `/55` to `/50`; bucket thresholds recalibrated proportionally (Excellent ≥40 / Good 30-39 / Needs work 20-29 / Poor <20). Scoring rules updated: `Score 3 on V1/V3/V4/V9/V10 → Major` (V8 removed) (#60)
 - `/skill-db` scope narrowed to live SQL verification (schema quality S1-S6 + N+1 query patterns Q1-Q3). Migration file analysis extracted to `/migration-audit` - single source of truth for migration safety across all database stacks. Pipeline Phase 5d Track B splits migration audit (`/migration-audit`) from schema audit (`/skill-db`). Affects projects invoking `/skill-db` for migration checks (#59)
 - Agents converted to on-demand skills: `dependency-scanner` → `/dependency-scan`, `context-reviewer` → `/context-review` — eliminates `.claude/agents/` directory from all templates (#62)
 - `pruneSkills()` rewritten from 37 to 5 lines (delegates to skill registry)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ After init, open Claude Code and start working. The scaffold is active immediate
 
 Start at Tier 0. Move up when you need more structure: `npx mg-claude-dev-kit upgrade --tier=m`
 
-### 13 audit skills
+### 14 audit skills
 
 Executable multi-step programs that run inside Claude Code. Not prompt instructions - structured audit workflows with model routing (haiku for mechanical checks, sonnet for analysis).
 
@@ -61,10 +61,11 @@ Executable multi-step programs that run inside Claude Code. Not prompt instructi
 | `/api-design` | M L | URL naming, HTTP verbs, response envelope, pagination. |
 | `/skill-db` | M L | Schema normalization, indexes, N+1 queries, RLS. |
 | `/migration-audit` | M L | Stack-aware migration safety: data loss, rollback, lock-heavy DDL. Prisma/Drizzle/Supabase/SQL. |
-| `/visual-audit` | M L | Typography, APCA contrast, spacing, dark-mode. |
+| `/visual-audit` | M L | Typography, spacing, hierarchy, dark-mode, micro-polish. |
 | `/ux-audit` | M L | ISO 9241-11, Nielsen heuristics, user confidence. |
 | `/responsive-audit` | M L | Layout at 320-1024px, tap targets, WCAG. |
-| `/ui-audit` | M L | Design token compliance, component adoption, accessibility. |
+| `/ui-audit` | M L | Design token compliance, component adoption, empty states. |
+| `/accessibility-audit` | M L | axe-core WCAG 2.2, APCA contrast, static a11y (aria, tabindex, focus, labels). |
 
 Skills are conditionally installed based on your project: `hasApi`, `hasDatabase`, `hasFrontend`, `hasDesignSystem`.
 

--- a/docs/operational-guide.md
+++ b/docs/operational-guide.md
@@ -40,7 +40,7 @@ Claude Code is a powerful CLI assistant that can read, write, and reason about y
 - A development pipeline Claude follows strictly - requirements reviewed before code is written, tests verified before declaring done
 - Pre-wired hooks that enforce the pipeline mechanically, not just as instructions
 - A tiered system matching process overhead to task complexity: a two-line bugfix does not go through the same process as a multi-week feature
-- 13 audit skills - executable multi-step programs with model routing (haiku for mechanical checks, sonnet for analysis)
+- 14 audit skills - executable multi-step programs with model routing (haiku for mechanical checks, sonnet for analysis)
 - Audit trails, commit attribution, secret scanning, and CODEOWNERS gates for full visibility over AI-generated changes
 - A discovery mechanism that teaches Claude about your existing codebase in a single structured session
 
@@ -400,7 +400,7 @@ npx mg-claude-dev-kit add skill commit
 
 This copies the SKILL.md file into `.claude/skills/<name>/` and appends it to the `## Active Skills` section in CLAUDE.md (if that section exists). No other files are modified.
 
-Available skills (13): `arch-audit`, `security-audit`, `perf-audit`, `skill-dev`, `simplify`, `commit`, `api-design`, `skill-db`, `migration-audit`, `visual-audit`, `ux-audit`, `responsive-audit`, `ui-audit`.
+Available skills (14): `arch-audit`, `security-audit`, `perf-audit`, `skill-dev`, `simplify`, `commit`, `api-design`, `skill-db`, `migration-audit`, `visual-audit`, `ux-audit`, `responsive-audit`, `ui-audit`, `accessibility-audit`.
 
 Options:
 - `--force` - overwrite if the skill already exists
@@ -693,7 +693,7 @@ Defined in the `CLAUDE.md` template for Tier M/L. Governs how Claude handles non
 
 ## 10. Audit skills
 
-Thirteen audit skills are scaffolded across the tiers. Run them as slash commands in Claude Code at any time - no pipeline phase required. Skills are **conditionally installed** based on wizard answers at init time.
+Fourteen audit skills are scaffolded across the tiers. Run them as slash commands in Claude Code at any time - no pipeline phase required. Skills are **conditionally installed** based on wizard answers at init time.
 
 All skill applicability rules are managed by a central skill registry (`packages/cli/src/scaffold/skill-registry.js`). Each skill declares which tiers and project conditions it requires.
 
@@ -713,12 +713,13 @@ All skill applicability rules are managed by a central skill registry (`packages
 | `/responsive-audit` | - | x | x | `hasFrontend=true` | Dev server + Playwright MCP |
 | `/ux-audit` | - | x | x | `hasFrontend=true` | Dev server + Playwright MCP |
 | `/visual-audit` | - | x | x | `hasFrontend=true` | Dev server + Playwright MCP |
-| `/ui-audit` | - | x | x | `hasFrontend=true` AND `hasDesignSystem=true` | Dev server + Playwright MCP |
+| `/ui-audit` | - | x | x | `hasFrontend=true` AND `hasDesignSystem=true` | - (static) |
+| `/accessibility-audit` | - | x | x | `hasFrontend=true` | Dev server + Playwright MCP (for full/wcag modes; static mode needs nothing) |
 
 ### General rules
 
-- Code-audit skills are **audit-only** - no code is modified (except `/simplify`, which applies changes directly). Findings go to `docs/refactoring-backlog.md` with severity-ranked IDs (`PERF-`, `API-`, `DB-`, `MIG-`, `DEV-`, `SEC-`, `UX-`).
-- Live-browser skills (`/responsive-audit`, `/ux-audit`, `/visual-audit`, `/ui-audit`) require the Playwright MCP server configured in `.claude/settings.json` and the dev server running.
+- Code-audit skills are **audit-only** - no code is modified (except `/simplify`, which applies changes directly). Findings go to `docs/refactoring-backlog.md` with severity-ranked IDs (`PERF-`, `API-`, `DB-`, `MIG-`, `DEV-`, `SEC-`, `UX-`, `A11Y-`).
+- Live-browser skills (`/responsive-audit`, `/ux-audit`, `/visual-audit`, `/accessibility-audit`) require the Playwright MCP server configured in `.claude/settings.json` and the dev server running. `/ui-audit` is static and does not require Playwright.
 - Each skill runs in an isolated context fork (`context: fork`) - it does not pollute the main session window.
 - Each skill delegates grep-heavy scanning to a Haiku Explore subagent to protect the main context window.
 - Before first run: fill in the `## Configuration` placeholders at the top of each `SKILL.md`.
@@ -729,7 +730,7 @@ All skill applicability rules are managed by a central skill registry (`packages
 After the smoke test and before the outcome checklist, two tracks run in parallel:
 
 **Track A - UI** (if the block touches UI routes):
-`/ui-audit` (static, concurrent with first Playwright skill) -> `/visual-audit` -> `/ux-audit` -> `/responsive-audit` (sequential, shared Playwright session).
+`/ui-audit` (static, concurrent with first Playwright skill) -> `/accessibility-audit` -> `/visual-audit` -> `/ux-audit` -> `/responsive-audit` (sequential, shared Playwright session).
 
 **Track B - API/DB** (if the block touches API routes or applies migrations):
 `/security-audit` and `/api-design` (concurrent, static); `/migration-audit` (if the block applies migrations); `/skill-db` (if the block changes schema or adds new tables).
@@ -809,7 +810,7 @@ Audits the governance layer itself - not your product code. Fetches Anthropic do
 
 **File**: `.claude/skills/visual-audit/SKILL.md` | **Tier**: M, L
 
-11-dimension visual evaluation (V1-V11): typographic hierarchy, spatial rhythm, visual focal point, colour discipline, information density, dark-mode polish, micro-polish, APCA contrast, Gestalt compliance, typographic quality, interaction state design. Per-page scoring out of 55.
+10-dimension aesthetic evaluation: typographic hierarchy, spatial rhythm, visual focal point, colour discipline, information density, dark-mode polish, micro-polish, Gestalt compliance, typographic quality, interaction state design. Per-page scoring out of 50. Accessibility contrast is covered by `/accessibility-audit`.
 
 #### /ux-audit
 
@@ -827,7 +828,13 @@ Static pre-checks (S1-S3: viewport-unit fonts, overflow hidden, non-responsive i
 
 **File**: `.claude/skills/ui-audit/SKILL.md` | **Tier**: M, L
 
-Design token compliance, component adoption rate, accessibility patterns, empty state coverage. Requires `hasDesignSystem=true`.
+Design token compliance, component adoption rate, empty state coverage. Static analysis only - no browser. Requires `hasDesignSystem=true`. Accessibility patterns are covered by `/accessibility-audit`.
+
+#### /accessibility-audit
+
+**File**: `.claude/skills/accessibility-audit/SKILL.md` | **Tier**: M, L
+
+Unified accessibility surface. Three modes: `static` (A1-A8 grep-based patterns: aria-label on icon buttons, positive tabindex, outline-none regression, img alt, form labels, focus ring size, onClick on non-interactive, nav keyboard access); `full` (adds APCA contrast probes C1-C3 via Playwright); `wcag` (adds axe-core 4.9.1 scan with wcag2a/aa + wcag21aa + wcag22aa tags). Backlog prefix: `A11Y-`. Requires `hasFrontend=true`.
 
 #### /simplify
 

--- a/packages/cli/src/scaffold/skill-registry.js
+++ b/packages/cli/src/scaffold/skill-registry.js
@@ -46,6 +46,7 @@ export const SKILL_REGISTRY = [
     requires: { hasFrontend: true, hasDesignSystem: true },
     cheatsheet: false,
   },
+  { name: 'accessibility-audit', minTier: 'm', requires: { hasFrontend: true }, cheatsheet: true },
   { name: 'dependency-scan', minTier: 'm', requires: {}, cheatsheet: false },
   { name: 'context-review', minTier: 'l', requires: {}, cheatsheet: false },
 ];

--- a/packages/cli/src/utils/print-plan.js
+++ b/packages/cli/src/utils/print-plan.js
@@ -226,9 +226,12 @@ function getSkillsSummary(config) {
   }
 
   if (config.hasDatabase !== false) {
-    included.push('skill-db');
+    included.push('skill-db', 'migration-audit');
   } else {
-    skipped.push({ name: 'skill-db', reason: 'no database' });
+    skipped.push(
+      { name: 'skill-db', reason: 'no database' },
+      { name: 'migration-audit', reason: 'no database' },
+    );
   }
 
   const isNative = NATIVE_STACKS.includes(config.techStack);
@@ -236,7 +239,7 @@ function getSkillsSummary(config) {
   if (config.hasFrontend !== false) {
     if (!isNative) included.push('responsive-audit');
     else skipped.push({ name: 'responsive-audit', reason: 'native UI' });
-    included.push('visual-audit', 'ux-audit');
+    included.push('visual-audit', 'ux-audit', 'accessibility-audit');
     if (config.hasDesignSystem !== false) {
       included.push('ui-audit');
     } else {
@@ -248,6 +251,7 @@ function getSkillsSummary(config) {
       { name: 'visual-audit', reason: 'no UI' },
       { name: 'ux-audit', reason: 'no UI' },
       { name: 'ui-audit', reason: 'no UI' },
+      { name: 'accessibility-audit', reason: 'no UI' },
     );
   }
 

--- a/packages/cli/templates/tier-l/.claude/cheatsheet.md
+++ b/packages/cli/templates/tier-l/.claude/cheatsheet.md
@@ -40,6 +40,7 @@ Run these on demand. Each skill reads the codebase, produces a structured report
 | `/migration-audit` | Migration file safety: lock-heavy DDL, missing rollback, data loss, unsafe ALTER TYPE | After writing a migration, before applying to staging |
 | `/api-design` | HTTP verb correctness, URL structure, response shape, error codes, pagination | After adding 3+ new routes; quarterly |
 | `/perf-audit` | Server/client boundaries, heavy imports, serial awaits, image optimization, N+1 | Before production releases; after major UI changes |
+| `/accessibility-audit` | axe-core WCAG 2.2 scan, APCA contrast, static a11y patterns (aria, tabindex, focus, labels) | After UI changes; before compliance milestones |
 | `/simplify` | Early returns, nesting depth, local duplication, dead code, magic values | After writing code (Phase 2); on demand |
 
 > **Before first run**: open each SKILL.md and replace the `[PLACEHOLDER]` values with the real paths for this project.

--- a/packages/cli/templates/tier-l/.claude/rules/pipeline.md
+++ b/packages/cli/templates/tier-l/.claude/rules/pipeline.md
@@ -202,11 +202,12 @@ If either condition is false: **skip this phase and state so explicitly** — do
 ## Phase 5d — Block-scoped quality audit *(blocks with UI or API changes)*
 
 **Track A — UI audit** *(if block adds/modifies UI routes or components — runs on localhost)*
-- Run `/ui-audit` scoped to the block's new/modified routes only (token compliance, component adoption, accessibility, empty states).
+- Run `/ui-audit` scoped to the block's new/modified routes only (token compliance, component adoption, empty states).
+- Run `/accessibility-audit` scoped to the block's new/modified routes (axe-core WCAG 2.2, APCA contrast, static a11y patterns).
 - Run `/visual-audit` scoped to the block's new/modified pages (typography, spacing, hierarchy, colour, density, dark-mode, micro-polish).
 - Run `/ux-audit` scoped to the block's user flows (task completion, feedback clarity, cognitive load).
 - Run `/responsive-audit` only if the block modifies routes used by non-admin roles.
-- **Execution order**: `/ui-audit` is static — launch it concurrently with the first Playwright-based skill. Then: `/visual-audit` → `/ux-audit` → `/responsive-audit` sequentially (they share the Playwright session).
+- **Execution order**: `/ui-audit` is static — launch it concurrently with the first Playwright-based skill. Then: `/accessibility-audit` → `/visual-audit` → `/ux-audit` → `/responsive-audit` sequentially (they share the Playwright session).
 
 **Track B — API/DB audit** *(if block creates/modifies API routes or applies migrations — static analysis, no dev server needed)*
 - Run `/security-audit` if the block creates or modifies any API route. Run `/api-design` if the block adds new API routes. Both are static — run them concurrently.
@@ -216,7 +217,7 @@ If either condition is false: **skip this phase and state so explicitly** — do
 **Severity handling — both tracks**:
 - **Critical**: fix before Phase 6. Do not proceed with open Critical issues.
 - **Major**: flag in Phase 6 checklist with planned resolution sprint.
-- **Minor**: append to `docs/refactoring-backlog.md` — assign ID prefix (`PERF-`, `API-`, `DB-`, `MIG-`, `DEV-`, `UX-`).
+- **Minor**: append to `docs/refactoring-backlog.md` — assign ID prefix (`PERF-`, `API-`, `DB-`, `MIG-`, `A11Y-`, `DEV-`, `UX-`).
 - Output per skill: one-paragraph summary only.
 
 ## Phase 6 — Outcome checklist ⏸ STOP

--- a/packages/cli/templates/tier-l/.claude/skills/accessibility-audit/SKILL.md
+++ b/packages/cli/templates/tier-l/.claude/skills/accessibility-audit/SKILL.md
@@ -1,0 +1,341 @@
+---
+name: accessibility-audit
+description: Unified accessibility audit - axe-core WCAG 2.2 scan, APCA contrast measurement, static a11y checks (aria-label, tabindex, form labels, focus visibility, onClick on non-interactive). Static and live modes.
+user-invocable: true
+model: sonnet
+context: fork
+argument-hint: [static|full|wcag] [target:route:<path>|target:file:<glob>|target:role:<role>]
+allowed-tools: Read, Glob, Grep, Bash, mcp__playwright__browser_navigate, mcp__playwright__browser_evaluate, mcp__playwright__browser_wait_for
+---
+
+Single source of truth for accessibility checks across the project. Combines static grep-based checks (run in all modes) with live browser checks (axe-core WCAG scan + APCA contrast measurement) when a dev server is available.
+
+**Scope boundary**:
+- Owns: static a11y patterns (aria, tabindex, labels, focus, keyboard), axe-core WCAG 2.2 scan, APCA contrast computation.
+- Not here: design token compliance and component adoption → `/ui-audit`. Typography and aesthetic polish → `/visual-audit`. Viewport-specific a11y (WCAG 1.4.4 resize, 1.4.10 reflow, tap targets) → `/responsive-audit`.
+
+**Two execution modes**:
+- **Static mode** (dev server not running): Steps 0-2, 5 only. Can run concurrently with Playwright-based skills per pipeline.md.
+- **Full mode** (dev server running): all steps including APCA contrast + axe-core scan. Sequential — shares the Playwright MCP session with other live audits.
+- **WCAG mode** (`wcag`): same as full, plus axe-core `best-practice` tag.
+
+---
+
+## Step 0 — Target resolution + mode selection
+
+Parse `$ARGUMENTS` for an optional mode keyword and a `target:` token.
+
+| Pattern | Meaning |
+|---|---|
+| `static` | Force static mode — skip Steps 3-4 even if dev server is available |
+| `full` | Force full mode — fail if dev server is unreachable |
+| `wcag` | Full mode + axe-core `best-practice` tag (more stringent) |
+| No mode keyword | **Auto** — full if dev server responds, else static with a warning |
+| `target:route:<path>` | Restrict live scan to a single route (e.g. `target:route:/dashboard`) |
+| `target:file:<glob>` | Restrict static checks to matching files (e.g. `target:file:app/**/page.tsx`) |
+| `target:role:<role>` | Restrict to routes accessible by that role (from `docs/sitemap.md`) |
+| No target argument | Full audit — all page/component files from sitemap.md |
+
+**STRICT PARSING — mandatory**: derive mode and target ONLY from explicit text in `$ARGUMENTS`. Do NOT infer from conversation context, recent blocks, or memory. Unknown tokens → treat as absent and announce ignored args in the banner.
+
+Announce: `Running accessibility-audit in [STATIC | FULL | WCAG] mode — scope: [FULL | target: <resolved>]`
+
+---
+
+## Step 1 — Mode detection (if mode is auto)
+
+Run:
+```bash
+curl -s -o /dev/null -w "%{http_code}" http://localhost:3000
+```
+
+- Response 200 or 302 → proceed in **full** mode.
+- Anything else → degrade to **static** mode and record in the report: `⚠️ Dev server not reachable on localhost:3000 — APCA + axe-core checks skipped. Re-run after starting [DEV_COMMAND] for full coverage.`
+
+If mode was forced (`static`/`full`/`wcag`), skip this step — but if `full`/`wcag` was forced and the server is unreachable, fail explicitly: `❌ Mode [full|wcag] requested but dev server not running. Start [DEV_COMMAND] or re-run with "static".`
+
+---
+
+## Step 2 — Static a11y checks (A1-A8)
+
+Read `docs/sitemap.md` (if present) to build the target file list — page files + component files. If no sitemap, fall back to `app/**/page.tsx` + `components/**/*.tsx` filtered by `target:` scope.
+
+Launch a **single Explore subagent** (model: haiku) with the full file list and the check definitions below. Pass file paths explicitly — do not ask the agent to discover them.
+
+> **Ripgrep note**: patterns are written for ripgrep (`rg`). Use `|` for alternation. Character classes work as-is.
+
+### Instructions for the Explore agent
+
+"Run all 8 checks below. For each check: report total match count, list every match as `file:line — excerpt`, and state PASS (0 matches) or FAIL (N matches). If 0 matches, explicitly state '0 matches — PASS'. Do not skip any check.
+
+File scope: use ONLY the files provided.
+
+---
+
+**A1 — Icon-only buttons missing aria-label** [Severity: Critical — WCAG 4.1.2]
+Pattern: `size="icon"|size=\{'icon'\}` then filter to lines NOT containing `aria-label`.
+Also: `<Button[^>]*>\s*<[A-Z][a-zA-Z]+Icon` or `<Button[^>]*>\s*\{[^}]*Icon` without `aria-label` on the same or preceding line.
+Expected: 0 matches. Icon-only interactive elements must have an accessible name.
+
+**A2 — Positive tabindex** [Severity: Critical — WCAG 2.4.3]
+Pattern: `tabIndex=[1-9]|tabindex="[1-9]`
+Exclude: lines with `//`, `{/*`.
+Expected: 0 matches. Positive tabindex breaks natural tab order. Only `tabIndex={0}` or `tabIndex={-1}` are valid.
+
+**A3 — outline-none without focus-ring compensation** [Severity: High — WCAG 2.4.7, Tailwind v4 regression]
+Pattern: lines containing `outline-none` that do NOT also contain any of: `focus-visible:ring`, `focus:ring`, `focus-visible:outline`, `focus:outline`.
+Method: grep `outline-none`, then filter out lines that also contain any of the focus restoration patterns.
+Expected: 0 matches. In Tailwind v4, `outline-none` strips the focus indicator in forced-color / high-contrast mode. Replace with `outline-hidden` for decorative suppression, or add explicit `focus-visible:ring-*` compensation.
+
+**A4 — Native `<img>` without alt** [Severity: Medium — WCAG 1.1.1]
+Pattern: `<img\s`
+Exclude: lines containing `//`, `{/*`, `alt=`, `.svg`, `data:`, `role="presentation"`.
+Expected: 0 matches. Every raster image must have an `alt` attribute (empty string allowed for decorative use with `role="presentation"`).
+
+**A5 — Form inputs without accessible labels** [Severity: Critical — WCAG 1.3.1, 3.3.2, 4.1.2]
+Method: grep `<input`, `<Input`, `<textarea`, `<Textarea`, `<Select`. For each match, check within ±5 lines for a `<Label` containing `htmlFor` matching the input's `id`, OR an `aria-label`/`aria-labelledby` on the element.
+Exclude: inputs inside `<FormField>` (react-hook-form pattern) with a sibling `<FormLabel>` — these are valid.
+Expected: 0 matches. Every form control must have an accessible name.
+
+**A6 — Bare focus ring without explicit size** [Severity: High — WCAG 1.4.11]
+Pattern: `focus:ring[^-]|focus-visible:ring[^-]` (bare `ring` without a size modifier like `ring-2`).
+In Tailwind v4, the default `ring` changed from 3px to 1px. A bare `focus-visible:ring` relying on the 3px default is now too thin to meet WCAG 1.4.11 (3:1 non-text contrast for focus indicators).
+Expected: 0 matches on interactive elements. Recommend `ring-2` or `ring-[3px]` explicitly.
+
+**A7 — onClick on non-interactive elements** [Severity: Critical — WCAG 2.1.1]
+Pattern: `<div.*onClick|<span.*onClick|<li.*onClick|<p.*onClick`.
+For each match, the element must also have `role="button"` (or equivalent interactive role) AND `onKeyDown` (or `onKeyPress`). Missing either = keyboard users cannot activate it.
+Exclude: lines inside `{/* ... */}` comments; Radix `asChild` wrappers.
+Expected: 0 matches missing keyboard support.
+
+**A8 — Sidebar/nav trigger keyboard accessibility** [Severity: High — WCAG 2.1.1]
+Scope: `app/(app)/layout.tsx`, `components/Sidebar*.tsx`, or equivalent layout entry points.
+Verify: the primary sidebar / navigation trigger is reachable on BOTH mobile and desktop — not hidden inside an `md:hidden` wrapper with no desktop alternative.
+Flag: `SidebarTrigger` or equivalent wrapped only in `md:hidden` without a matching non-mobile trigger.
+Expected: every layout exposes a keyboard-reachable nav trigger at every breakpoint."
+
+---
+
+## Step 3 — APCA contrast measurement (full/wcag mode only — live)
+
+Pick 3 representative pages from the target scope:
+1. The dashboard or root route (`/`)
+2. One data-list page (first list route in scope)
+3. One form/write page (first form or wizard route in scope)
+
+For each page:
+
+```
+1. mcp__playwright__browser_navigate → http://localhost:3000/<route>
+2. Ensure logged in with the role from the route's sitemap entry (if auth required).
+3. browser_wait_for network idle (2000ms max).
+4. For each theme (light, dark):
+   - Toggle theme via sidebar Switch (or apply class="dark" on <html>).
+   - browser_wait_for 500ms.
+   - Run the APCA probe below via browser_evaluate.
+```
+
+### APCA probe
+
+```js
+// Returns computed color + background for the three C-checks.
+// APCA Lc is NOT computed here — we capture the raw rgb pairs and flag qualitatively.
+// The skill's report narrates the pair against Lc thresholds documented below.
+const byClass = (sel) => document.querySelector(sel);
+
+const muted = byClass('[class*="muted-foreground"]');
+const card = byClass('[data-slot="card"], [class*="rounded"][class*="border"], main > div');
+const cta = byClass('button[class*="bg-brand"], button[class*="bg-primary"], [data-slot="button"][class*="primary"]');
+const border = byClass('[class*="border-border"], [class*="rounded"][class*="border"]');
+
+const style = (el) => el ? getComputedStyle(el) : null;
+return {
+  theme: document.documentElement.classList.contains('dark') ? 'dark' : 'light',
+  mutedOnCard: {
+    color: muted ? style(muted).color : null,
+    background: card ? style(card).backgroundColor : null
+  },
+  ctaOnBrand: {
+    color: cta ? style(cta).color : null,
+    background: cta ? style(cta).backgroundColor : null
+  },
+  borderOnBg: {
+    color: border ? style(border).borderColor : null,
+    background: card ? style(card).backgroundColor : null
+  }
+};
+```
+
+### APCA thresholds (source: APCA / WCAG 3 working draft)
+
+- **Lc 75** — preferred body text
+- **Lc 60** — minimum body text
+- **Lc 45** — label / large text (≥ 24px or bold ≥ 18px)
+- **Lc 15** — non-text (borders, icons, dividers)
+
+Record each pair. The report narrates against thresholds qualitatively (getComputedStyle returns resolved rgb, not Lc — final verdict combines the rgb with visible contrast in the screenshot when available).
+
+### Check definitions
+
+| ID | Severity | Target |
+|---|---|---|
+| **C1** | High if body text appears below Lc 45; Critical if below Lc 30 | `text-muted-foreground` on `bg-card`, both themes. Silent dark-mode failure point. |
+| **C2** | High | Primary CTA text on brand background — frequent regression after token tweaks. |
+| **C3** | Medium | Border / icon contrast vs card background — must reach Lc 15. |
+
+---
+
+## Step 4 — axe-core browser scan (full/wcag mode only — live)
+
+For each of the 3 pages from Step 3:
+
+```js
+// Inject axe-core from CDN
+await new Promise((resolve, reject) => {
+  const s = document.createElement('script');
+  s.src = 'https://cdnjs.cloudflare.com/ajax/libs/axe-core/4.9.1/axe.min.js';
+  s.onload = resolve;
+  s.onerror = reject;
+  document.head.appendChild(s);
+});
+
+// WCAG 2a / 2aa / 2.1aa / 2.2aa (+ best-practice in wcag mode)
+const tags = ['wcag2a', 'wcag2aa', 'wcag21aa', 'wcag22aa'];
+// In wcag mode, also push 'best-practice'
+
+const results = await axe.run(document, {
+  runOnly: { type: 'tag', values: tags },
+  reporter: 'v2'
+});
+
+return {
+  violations: results.violations.map(v => ({
+    id: v.id,
+    impact: v.impact,
+    description: v.description,
+    nodes: v.nodes.length,
+    example: v.nodes[0]?.html?.slice(0, 120)
+  })),
+  passes: results.passes.length,
+  incomplete: results.incomplete.length
+};
+```
+
+### Severity mapping
+
+| ID | axe impact | Report severity |
+|---|---|---|
+| **X1** | `critical` or `serious` | Critical |
+| **X2** | `moderate` | High |
+| **X3** | `minor` | Medium |
+
+### Known false positives to suppress (document, not fix)
+
+- `color-contrast` on `text-muted-foreground` inside a Radix Portal overlay — axe measures the portal layer, not the semantic background. Verify manually against Step 3 C1 data.
+- `aria-hidden-focus` inside a closed Dialog/Sheet — Radix manages this via the `inert` attribute in v1.1+. Verify the installed Radix version before flagging.
+
+---
+
+## Step 5 — Report and backlog decision gate
+
+### Output format
+
+```
+## Accessibility Audit — [DATE] — [MODE] — [TARGET]
+
+### Executive summary
+[2-5 bullets — Critical and High findings only. Write concrete facts: file:line, check ID, impact.
+If nothing Critical/High: "No Critical or High findings — a11y posture is clean for the audited scope."
+Examples:
+- "A5 Critical: 3 form inputs in app/(app)/settings/page.tsx have no accessible label"
+- "C1 High: text-muted-foreground on bg-card rgb(…) on dark theme — likely below Lc 45"
+- "X1 Critical: 'button-name' axe violation on /dashboard — 2 nodes"]
+
+### A11y maturity assessment
+| Dimension | Rating | Notes |
+|---|---|---|
+| Keyboard access | strong / adequate / weak | [A2, A3, A6, A7, A8 results] |
+| Accessible naming | strong / adequate / weak | [A1, A4, A5 results] |
+| Contrast posture | strong / adequate / weak | [C1, C2, C3 — or "skipped, static mode"] |
+| WCAG conformance | strong / adequate / weak | [axe-core X1/X2/X3 counts, or "skipped"] |
+| Coverage | full / partial / static-only | [which steps ran] |
+
+### Per-check verdicts
+
+Static (all modes):
+| # | Check | Matches | Severity | Verdict |
+|---|---|---|---|---|
+| A1 | Icon-only buttons missing aria-label | N | Critical | ✅/❌ |
+| A2 | Positive tabindex | N | Critical | ✅/❌ |
+| A3 | outline-none without focus-ring compensation | N | High | ✅/❌ |
+| A4 | Native <img> without alt | N | Medium | ✅/❌ |
+| A5 | Form inputs without accessible labels | N | Critical | ✅/❌ |
+| A6 | Bare focus ring without explicit size | N | High | ✅/❌ |
+| A7 | onClick on non-interactive elements | N | Critical | ✅/❌ |
+| A8 | Sidebar/nav trigger accessibility | N | High | ✅/❌ |
+
+Live (full/wcag mode only — else "Skipped — static mode"):
+| # | Check | Result | Severity | Verdict |
+|---|---|---|---|---|
+| C1 | muted-foreground on bg-card (both themes) | [rgb pair / Lc estimate] | High / Critical | ✅/⚠️/❌ |
+| C2 | CTA text on brand background | [rgb pair] | High | ✅/❌ |
+| C3 | Border / icon vs card bg | [rgb pair] | Medium | ✅/❌ |
+
+axe-core (full/wcag mode only):
+| Page | Critical | Serious | Moderate | Minor | Passes |
+|---|---|---|---|---|---|
+| / | N | N | N | N | N |
+| /[list-page] | N | N | N | N | N |
+| /[form-page] | N | N | N | N | N |
+
+Top axe violations:
+[id — description — N nodes — example HTML]
+
+### Prioritized findings
+For each finding with severity Medium or above:
+[SEVERITY] [A11Y-?] [check ID] — [file:line or route] — [evidence] — [fix] — [effort: S=<1h / M=half day / L=day+]
+
+### Quick wins
+[Findings that meet all three: (a) Medium or High, (b) effort S, (c) single-file fix]
+Format: "A11Y-[n]: [one-line description]"
+If no quick wins: state explicitly.
+```
+
+### Backlog decision gate
+
+Present all findings with severity Medium or above as a numbered decision list, sorted Critical → High → Medium:
+
+```
+Found N a11y findings at Medium or above. Which to add to backlog?
+
+[1] [CRITICAL] A11Y-? — [check ID] — file:line — one-line description
+[2] [HIGH]     A11Y-? — [check ID] — file:line — one-line description
+[3] [MEDIUM]   A11Y-? — [check ID] — file:line — one-line description
+...
+
+Reply with numbers to include (e.g. "1 2 4"), "all", or "none".
+```
+
+**Wait for explicit user response before writing anything.**
+
+Then write ONLY the approved entries to `docs/refactoring-backlog.md`:
+- Assign ID: `A11Y-[n]` (next available after existing A11Y entries)
+- Add row to priority index
+- Add full detail section with: issue, evidence (file:line or rgb pair), check ID, fix suggestion, effort, WCAG reference
+
+### Severity guide
+
+- **Critical**: keyboard trap or missing accessible name on an interactive element (A1, A2, A5, A7); axe `critical`/`serious` violations (X1); APCA indicates body text falls below Lc 30 (C1).
+- **High**: focus indicator degraded (A3, A6); sidebar/nav unreachable at a breakpoint (A8); axe `moderate` (X2); APCA muted text or CTA below Lc 45 (C1, C2).
+- **Medium**: decorative image missing alt (A4); axe `minor` (X3); non-text contrast below Lc 15 (C3).
+
+---
+
+## Execution notes
+
+- Do NOT apply a11y fixes during this skill. Audit only.
+- The Explore agent in Step 2 handles all static grep work. Do not duplicate searches in the main context.
+- **Concurrent execution**: when invoked from pipeline.md Phase 5d Track A, this skill runs sequentially with `/visual-audit` → `/ux-audit` → `/responsive-audit` — they share the Playwright MCP session. `/ui-audit` still launches concurrently first.
+- **Static mode degradation**: if the dev server is unreachable and mode was auto, the report must state explicitly which steps were skipped. Never silently omit checks.
+- **axe-core false positives**: document suppressed false positives explicitly in the report. Do not flag known Radix-managed patterns (inert Dialog children, Portal color-contrast measurements) as violations without manual verification.
+- **Complementary skills**: `/accessibility-audit` is the single source of truth for accessibility. For design-token compliance and component adoption see `/ui-audit`; for aesthetic contrast and polish see `/visual-audit`; for viewport-specific WCAG checks (1.4.4 resize, 1.4.10 reflow, tap targets) see `/responsive-audit`.

--- a/packages/cli/templates/tier-l/.claude/skills/ui-audit/SKILL.md
+++ b/packages/cli/templates/tier-l/.claude/skills/ui-audit/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: ui-audit
-description: Audit UI for design token compliance, component adoption, and accessibility via axe-core. Static mode analyzes code without a server; full mode runs browser checks on live pages.
+description: Audit UI for design token compliance and component adoption. Static grep-based analysis against the sitemap's page and component files.
 user-invocable: true
 model: sonnet
 context: fork
 argument-hint: [target:page:<route>|target:role:<role>|target:section:<section>]
-allowed-tools: mcp__playwright__browser_navigate, mcp__playwright__browser_evaluate
+allowed-tools: Read, Glob, Grep
 ---
 
 **Critical constraint**: `docs/sitemap.md` is the authoritative inventory of every page file and key component. Read it first and derive the file target list from it. Do NOT run free-form `grep -r` across all of `app/` or `components/` — scope every check to the files listed in the sitemap.
 
-**Two execution modes**:
-- **Static mode** (dev server not running): Steps 1–3 only. Can run concurrently with Playwright-based skills per pipeline.md.
-- **Full mode** (dev server running): Steps 1–4 including axe-core browser scan. Must run sequentially (Playwright MCP session shared).
+**Scope boundary**: this skill covers design-token compliance and component adoption only. Accessibility (aria, tabindex, focus, labels, axe-core WCAG scan, APCA contrast) lives in `/accessibility-audit` — run it alongside `/ui-audit` for any UI change.
+
+Static-only skill — no dev server required. Can run concurrently with Playwright-based skills per pipeline.md.
 
 ---
 
@@ -52,7 +52,7 @@ Launch a **single Explore subagent** (model: haiku) with the following instructi
 
 ### Instructions for the Explore agent:
 
-"Run all 17 checks below. For each check: report the total match count, list every match as `file:line — excerpt`, and state PASS (0 matches) or FAIL (N matches). If a check returns 0 matches, explicitly state '0 matches — PASS'. Do not skip any check.
+"Run all 12 checks below (numbering preserves gaps — checks 11, 13, 14, 16, 17 moved to `/accessibility-audit`). For each check: report the total match count, list every match as `file:line — excerpt`, and state PASS (0 matches) or FAIL (N matches). If a check returns 0 matches, explicitly state '0 matches — PASS'. Do not skip any check.
 
 File scope: use ONLY the page files and component files provided. Do not search outside this list.
 
@@ -110,42 +110,25 @@ Additionally: find any `<Table` element lines that contain neither `w-auto` nor 
 Flag: any `<Table` with `w-full`, and any `<Table` with no explicit width class.
 Expected: 0 matches. `<Table>` must always have `w-auto`.
 
-**CHECK 11 — Icon-only buttons missing aria-label** [Severity: Critical]
-Pattern: lines containing `size="icon"` or `size={'icon'}` that do NOT also contain `aria-label`
-Method: grep for `size="icon"|size=\{'icon'\}`, then filter to keep only lines that do NOT contain `aria-label`.
-Also check: `IconButton` and `Button` with only an icon child (no visible text) — grep for `<Button[^>]*>\s*<[A-Z][a-zA-Z]+Icon` or `<Button[^>]*>\s*{[^}]*Icon` without `aria-label` on the same or preceding line.
-Expected: 0 matches. Icon-only buttons must always have aria-label.
+**CHECK 11** — moved to `/accessibility-audit` as A1 (icon-only buttons missing aria-label).
 
 **CHECK 12 — overflow-x-auto on table wrappers (PERMANENT RULE violation)** [Severity: Critical]
 Pattern: `overflow-x-auto`
 Exclude: lines containing `<pre`, `<code`, `// `, `{/*`
 Expected: 0 matches in non-pre containers. Table wrappers must use `overflow-hidden`, not `overflow-x-auto`.
 
-**CHECK 13 — Positive tabindex (WCAG 2.4.3 violation)** [Severity: Critical]
-Pattern: `tabIndex=[1-9]|tabindex="[1-9]`
-Exclude: lines with `//`, `{/*`
-Expected: 0 matches. Positive tabindex breaks natural tab order. Only `tabIndex={0}` or `tabIndex={-1}` are valid.
+**CHECK 13** — moved to `/accessibility-audit` as A2 (positive tabindex, WCAG 2.4.3).
 
-**CHECK 14 — outline-none without focus ring (Tailwind v4 forced-color regression)** [Severity: High]
-Pattern: lines containing `outline-none` that do NOT also contain at least one of: `focus-visible:ring`, `focus:ring`, `focus-visible:outline`, `focus:outline`
-Method: grep for `outline-none`, then filter out lines that also contain any of the above focus restoration patterns.
-Expected: 0 matches. In Tailwind v4, `outline-none` strips the focus indicator in forced-color / high-contrast mode. Replace with `outline-hidden` for decorative suppression, or add explicit `focus-visible:ring-*` compensation.
+**CHECK 14** — moved to `/accessibility-audit` as A3 (outline-none without focus-ring compensation).
 
 **CHECK 15 — Deprecated opacity utility syntax (Tailwind v4 breaking change)** [Severity: High]
 Pattern: `bg-opacity-|text-opacity-|border-opacity-|divide-opacity-|placeholder-opacity-|ring-opacity-`
 Exclude: lines with `//`, `{/*`
 Expected: 0 matches. Tailwind v4 removed these utilities. Use slash syntax: `bg-black/50`, `text-foreground/80`, etc.
 
-**CHECK 16 — Native <img> tag (use Next.js <Image>)** [Severity: Medium]
-Pattern: `<img\s`
-Exclude: lines containing `//`, `{/*`, `alt=`, `.svg`, `data:`, `role="presentation"`
-Flag: any `<img` that does not appear to be a decorative/SVG use.
-Expected: 0 matches. All raster images must use `<Image>` from `next/image` for optimization and LCP.
+**CHECK 16** — moved to `/accessibility-audit` as A4 (native `<img>` without alt).
 
-**CHECK 17 — Form inputs without accessible labels** [Severity: Critical]
-Method: for each match, check within ±5 lines for a `<Label` containing `htmlFor` matching the input's `id`. If no `<Label htmlFor` and no `aria-label`/`aria-labelledby` on the component line: flag it.
-Note: inputs inside `<FormField>` (react-hook-form pattern) with a sibling `<FormLabel>` are valid — exclude lines inside a `<FormField>` wrapper.
-Expected: 0 matches. Every form control must have an accessible name."
+**CHECK 17** — moved to `/accessibility-audit` as A5 (form inputs without accessible labels)."
 
 ---
 
@@ -165,27 +148,15 @@ Read `components/Sidebar.tsx` lines containing "Esci" or "sign" or "red".
 Verify: uses `bg-destructive` (semantic) not `bg-red-600` (hardcoded).
 Expected: `bg-destructive hover:bg-destructive/90`.
 
-**S4 — Responsive sidebar trigger accessibility**
-Read `app/(app)/layout.tsx`.
-Verify: SidebarTrigger is reachable on BOTH mobile (in mobile header) and desktop (always accessible, not hidden when sidebar is open).
-Flag if trigger is inside an `md:hidden` wrapper with no desktop alternative.
+**S4** — moved to `/accessibility-audit` as A8 (sidebar/nav trigger keyboard accessibility).
 
 **S5 — w-fit on table container wrappers**
 For each file in scope that contains `<Table`, check whether its immediate parent container (Card, div) uses `w-fit`. Files that contain `<Table` but no `w-fit` anywhere → flag.
 Expected: all table wrappers use `w-fit` or `w-auto`.
 
-**S6 — Tailwind v4 bare `ring` on focus styles**
-Grep the scoped files for `focus:ring[^-]|focus-visible:ring[^-]` (bare `ring` without an explicit size modifier like `ring-2`).
-In Tailwind v4, the default `ring` changed from 3px to 1px. A bare `focus-visible:ring` that was relying on the 3px default is now too thin to meet WCAG 1.4.11 (3:1 non-text contrast for focus indicators).
-Flag any bare `ring` usage on interactive elements. Recommend `ring-2` or `ring-[3px]` explicitly.
-Severity: Medium.
+**S6** — moved to `/accessibility-audit` as A6 (bare focus ring without explicit size, WCAG 1.4.11).
 
-**S7 — onClick on non-interactive elements**
-Grep the scoped files for `<div.*onClick|<span.*onClick|<li.*onClick`.
-For each match, verify the element also has `role="button"` (or equivalent) AND `onKeyDown` (or `onKeyPress`).
-Missing either = keyboard users cannot activate the element (WCAG 2.1.1).
-Exclude: lines inside `{/* ... */}` comments, or where the element is a Radix `asChild` wrapper.
-Severity: Critical if the element is a primary action, High otherwise.
+**S7** — moved to `/accessibility-audit` as A7 (onClick on non-interactive elements, WCAG 2.1.1).
 
 **S8 — 'use client' placement depth**
 Read `app/(app)/layout.tsx`.
@@ -194,66 +165,7 @@ Severity: Medium (performance — prevents RSC streaming).
 
 ---
 
-## Step 4 — Browser accessibility scan (conditional — Playwright MCP)
-
-**First: check if dev server is reachable.**
-Run: `curl -s -o /dev/null -w "%{http_code}" http://localhost:3000`
-- If response is NOT 200 or 302: output `⚠️ Browser scan skipped — dev server not running on localhost:3000. Re-run after starting npm run dev for full axe-core coverage.` Then skip to Step 5.
-- If response is 200 or 302: proceed.
-
-**Select 3 representative pages** from the target scope (resolved from sitemap.md):
-1. The dashboard or root route (`/`)
-2. One data-list page (first `full-list` route in scope)
-3. One form/write page (first `form` or `wizard` route in scope, or a detail page with edit capability)
-
-**For each page, execute the following sequence:**
-
-```
-1. mcp__playwright__browser_navigate to http://localhost:3000/<route>
-   (If redirected to /login: read test account credentials from the "Test accounts" section
-
-2. mcp__playwright__browser_evaluate:
-   // Inject axe-core from CDN
-   await new Promise((resolve, reject) => {
-     const s = document.createElement('script');
-     s.src = 'https://cdnjs.cloudflare.com/ajax/libs/axe-core/4.9.1/axe.min.js';
-     s.onload = resolve;
-     s.onerror = reject;
-     document.head.appendChild(s);
-   });
-   // Run WCAG 2a / 2aa / 2.1aa / 2.2aa tags
-   const results = await axe.run(document, {
-     runOnly: { type: 'tag', values: ['wcag2a', 'wcag2aa', 'wcag21aa', 'wcag22aa'] },
-     reporter: 'v2'
-   });
-   return {
-     violations: results.violations.map(v => ({
-       id: v.id,
-       impact: v.impact,
-       description: v.description,
-       nodes: v.nodes.length,
-       example: v.nodes[0]?.html?.slice(0, 120)
-     })),
-     passes: results.passes.length,
-     incomplete: results.incomplete.length
-   };
-```
-
-3. Record violations grouped by impact: critical → serious → moderate → minor.
-```
-
-**Severity mapping for pipeline.md**:
-- `critical` / `serious` axe violations → **Critical** (fix before Phase 6)
-- `moderate` axe violations → **High** (flag in Phase 6 checklist)
-- `minor` axe violations → **Medium** (append to `docs/refactoring-backlog.md` with `UI-[n]` prefix)
-
-**Known false-positives to suppress** (document, not fix):
-- `color-contrast` on `text-muted-foreground` within Radix Portal overlay — axe measures the portal layer, not the semantic background. Verify manually.
-- `aria-hidden-focus` inside closed Dialog/Sheet — Radix manages this via `inert` attribute in v1.1+. Verify version before flagging.
-
----
-
-## Step 5 — Produce audit report
+## Step 4 — Produce audit report
 
 Output in this exact format:
 
@@ -261,7 +173,8 @@ Output in this exact format:
 ## UI Audit — [DATE]
 ### Scope: [N] page files from sitemap.md + [N] component files
 ### Target: [FULL | target:<value>]
-### Mode: [Static | Full (axe-core scan included)]
+
+> For accessibility checks (axe-core WCAG scan, APCA contrast, aria/tabindex/label patterns), run `/accessibility-audit`.
 
 ### Grep Checks
 | # | Check | Matches | Severity | Verdict |
@@ -276,35 +189,20 @@ Output in this exact format:
 | 8 | Content status badges hardcoded | N | Medium | ✅/❌ |
 | 9 | Tab bars missing whitespace-nowrap | N | Medium | ✅/❌ |
 | 10 | Table w-full violation | N | Critical | ✅/❌ |
-| 11 | Icon buttons missing aria-label | N | Critical | ✅/❌ |
 | 12 | overflow-x-auto on table wrappers | N | Critical | ✅/❌ |
-| 13 | Positive tabindex | N | Critical | ✅/❌ |
-| 14 | outline-none without focus ring | N | High | ✅/❌ |
 | 15 | Deprecated opacity syntax | N | High | ✅/❌ |
-| 16 | Native <img> tag | N | Medium | ✅/❌ |
-| 17 | Form inputs without labels | N | Critical | ✅/❌ |
+
+*(Gaps 11, 13, 14, 16, 17 moved to `/accessibility-audit`.)*
 
 ### Supplemental Checks
 | # | Check | Verdict | Notes |
 |---|---|---|---|
 | S2 | NotificationBell placement | ✅/❌ | |
 | S3 | Sign-out semantic color | ✅/❌ | |
-| S4 | Sidebar trigger accessibility | ✅/❌ | |
 | S5 | Table container w-fit | ✅/❌ | |
-| S6 | Bare ring on focus styles | ✅/❌ | |
-| S7 | onClick on non-interactive elements | ✅/❌ | |
 | S8 | 'use client' placement depth | ✅/❌ | |
 
-### Browser Accessibility Scan (axe-core)
-[Only if Step 4 ran — otherwise: "Skipped — dev server not running"]
-| Page | Critical | Serious | Moderate | Minor | Passes |
-|---|---|---|---|---|---|
-| / | N | N | N | N | N |
-| /[list-page] | N | N | N | N | N |
-| /[form-page] | N | N | N | N | N |
-
-Top violations:
-[id — description — N nodes — example HTML]
+*(Gaps S4, S6, S7 moved to `/accessibility-audit`.)*
 
 ### ❌ Failures requiring action ([N] total — by severity)
 
@@ -323,7 +221,6 @@ Top violations:
 ### Coverage
 Page files checked: N/N from sitemap.md
 Component files checked: N
-Axe-core pages scanned: N (or: skipped)
 ```
 
 If all checks pass: output `UI Audit CLEAN — [DATE]. No violations found.`
@@ -336,5 +233,5 @@ If all checks pass: output `UI Audit CLEAN — [DATE]. No violations found.`
 - Do NOT re-read files already in context from Step 1.
 - The Explore agent in Step 2 handles all grep work. Do not duplicate searches in the main context.
 - **Pipeline integration**: for Critical findings, ask the user: "Vuoi che implementi i fix identificati?" before touching any file. Medium/Low findings go directly to `docs/refactoring-backlog.md` without asking.
-- **Concurrent execution**: when invoked from pipeline.md Phase 5d, this skill runs concurrently with the first Playwright-based skill ONLY in Static mode (Step 4 skipped). If the dev server is running and Step 4 executes, the Playwright MCP session is in use — do not overlap.
-- **axe-core false positives**: document suppressed false positives explicitly in the report. Do not flag known Radix-managed patterns (inert Dialog children, Portal color-contrast measurements) as violations without manual verification.
+- **Concurrent execution**: when invoked from pipeline.md Phase 5d Track A, this skill launches concurrently with the first Playwright-based skill. It is fully static — no dev server required.
+- **Complementary skill**: run `/accessibility-audit` alongside `/ui-audit` for any UI change. It owns axe-core WCAG 2.2 scan, APCA contrast, and the static a11y patterns formerly numbered here as CHECK 11/13/14/16/17 and S4/S6/S7.

--- a/packages/cli/templates/tier-l/.claude/skills/visual-audit/SKILL.md
+++ b/packages/cli/templates/tier-l/.claude/skills/visual-audit/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: visual-audit
-description: Visual audit: typography, spacing, colour discipline, dark-mode polish, contrast, info density. Scores pages on 11 dimensions via Playwright screenshots.
+description: Visual audit - typography, spacing, colour discipline, dark-mode polish, info density. Scores pages on 10 aesthetic dimensions via Playwright screenshots.
 user-invocable: true
 model: opus
 context: fork
 argument-hint: [quick|full] [target:page:<route>|target:role:<role>|target:section:<section>]
 allowed-tools: Read, Glob, Grep, Bash, mcp__playwright__browser_navigate, mcp__playwright__browser_take_screenshot, mcp__playwright__browser_snapshot, mcp__playwright__browser_click, mcp__playwright__browser_type, mcp__playwright__browser_wait_for, mcp__playwright__browser_resize, mcp__playwright__browser_evaluate
 ---
+
+**Scope boundary**: this skill covers aesthetic quality only. Accessibility contrast (APCA measurement, WCAG contrast thresholds, axe-core scan) lives in `/accessibility-audit` — run it for any contrast or accessibility concern. Design-token compliance → `/ui-audit`. Viewport fit → `/responsive-audit`.
 
 ## Step 0 — Mode + target detection
 
@@ -70,10 +72,9 @@ Apply these 11 dimensions to every screenshot captured.
 | **V1** | Typographic hierarchy | H1 vs body weight contrast; label vs value distinction; font size spread; muted-foreground on secondary text. **Quantitative anchor**: ≤ 5 distinct font sizes in use (from computed check); 2 font weights (semibold for headings, regular for body). Flag if computed check reveals > 5 sizes. | ≥ 4 |
 | **V2** | Spatial rhythm | Consistent padding inside similar components; visual breathing room; margin harmony between sections; card internal padding uniformity. **Quantitative anchor**: padding values should be multiples of 4px (8px preferred). Flag non-grid values (14px, 6px, 10px) from the 3-element spot check in computed checks. | ≥ 4 |
 | **V3** | Visual focal point | Primary CTA is the most prominent element; user's eye is guided to the most important content; no competing elements of equal weight | ≥ 4 |
-| **V4** | Colour discipline | Brand colour used sparingly and intentionally; status colours follow semantic convention (green=done, amber=pending, red=destructive); no arbitrary colour decoration; `bg-brand` reserved for primary CTAs not row-level buttons. **APCA anchors** (source: APCA/WCAG 3 working draft): body text on card background should achieve APCA Lc ≥ 60 equivalent; label/muted text ≥ Lc 45 for large font sizes; non-text contrast (borders, icons) ≥ Lc 15. Evaluate in both themes. | ≥ 4 |
+| **V4** | Colour discipline | Brand colour used sparingly and intentionally; status colours follow semantic convention (green=done, amber=pending, red=destructive); no arbitrary colour decoration; `bg-brand` reserved for primary CTAs not row-level buttons. Evaluate in both themes. *(Contrast thresholds moved to `/accessibility-audit` C1-C3.)* | ≥ 4 |
 | **V5** | Information density | Appropriate density for the page type (list = dense, form = airy); tables scannable at a glance; no cognitive overload; no empty visual regions | ≥ 3 |
 | **V7** | Micro-polish | Hover/focus states visible; transitions not jarring; empty states and skeletons look professional; icon–text alignment clean; status badges correct size relative to surrounding text. **Timing anchor**: transitions < 100ms are imperceptible (no feedback value); > 400ms feels sluggish. Flag when computed check reveals out-of-range transition durations on interactive elements. | ≥ 3 |
-| **V8** | Contrast & legibility | Computed contrast ratios for key text elements against their backgrounds in both light and dark themes. References APCA thresholds: Lc 75 preferred for body text, Lc 60 minimum, Lc 45 for large/label text, Lc 15 for non-text (borders, icons). Specifically checks `text-muted-foreground` on `bg-card` — a common silent failure in dark mode. Uses computed style values from browser_evaluate. | ≥ 4 |
 | **V9** | Gestalt compliance | Evaluate 4 Gestalt principles: (1) **Proximity** — related elements grouped with tighter spacing than unrelated ones; flag if label↔value gap ≥ gap between distinct sections; (2) **Figure/ground** — content distinguishable from chrome without effort; flag dark mode text indistinguishable from bg; (3) **Similarity** — components with same function look the same cross-section; flag Badge same state with different colour/size on different pages; (4) **Continuity** — lists, columns, card grids guide the eye linearly; flag variable card sizes or inconsistent column widths. **Score anchors**: 5 = all 4 respected; 3 = 1-2 localised violations; 1 = disorienting layout. | ≥ 4 |
 | **V10** | Typographic quality | From code inspection + computed check: flag `lineHeight/fontSize` ratio < 1.4 or > 1.8 on body/label text; flag negative `letterSpacing` on font < 14px; flag paragraph or td width > 680px (≈75 chars). **Score anchors**: 5 = all in range; 3 = 1 value out of range; 1 = text in conditions that impair legibility. | ≥ 4 |
 | **V11** | Interaction state design | From code inspection (Step 5a) + screenshots: for every interactive element, verify: (1) hover — bg change ≥ 10 lightness points or border appearance; (2) focus-visible — ring visible on all backgrounds including bg-brand contexts; (3) active/pressed — visually distinct from hover; (4) disabled — desaturated colour + opacity, not just opacity; (5) loading skeleton — shape matches expected content layout. **Score anchors**: 5 = all 5 states designed; 3 = 2-3 states absent or indistinguishable; 1 = no interaction feedback. | ≥ 3 |
@@ -82,7 +83,7 @@ Score scale: **1** = poor · **2** = needs work · **3** = acceptable · **4** =
 
 **Scoring rules:**
 - Score 1–2 on any dimension → Critical finding
-- Score 3 on V1, V3, V4, V8, V9, V10 → Major finding (highest visual and accessibility impact)
+- Score 3 on V1, V3, V4, V9, V10 → Major finding (highest visual impact)
 - Score 3 on V2, V5, V6, V7, V11 → Minor finding
 - Write one concrete, actionable observation per dimension per page (not just a number)
 - **Never write a vague observation like "good overall"** — every line must name what specifically works or what specifically is wrong
@@ -198,40 +199,22 @@ For each page in roster:
      .filter(d => d && d !== '0s')
      .map(d => parseFloat(d) * 1000); // convert to ms
 
-   // Contrast spot check — text-muted-foreground on bg-card (light mode)
-   const mutedEl = document.querySelector('[class*="muted-foreground"]');
-   const mutedColor = mutedEl ? getComputedStyle(mutedEl).color : null;
-   const cardBg = card ? getComputedStyle(card).backgroundColor : null;
-
    return {
      fontSizeCount: fontSizes.length,
      fontSizes,
      paddingSpotCheck: paddings,
      paddingMisaligned: misaligned,
      transitionCount: transitions.length,
-     transitionsOutOfRange: transitions.filter(ms => ms > 0 && (ms < 100 || ms > 400)),
-     mutedForegroundColor: mutedColor,
-     cardBackgroundColor: cardBg
+     transitionsOutOfRange: transitions.filter(ms => ms > 0 && (ms < 100 || ms > 400))
    };
    ```
-   Record results. Use to inform V1 (font scale), V2 (padding spot-check + misaligned), V7 (transition timing), V8 (contrast).
+   Record results. Use to inform V1 (font scale), V2 (padding spot-check + misaligned), V7 (transition timing). *(Contrast measurement moved to `/accessibility-audit` Step 3.)*
 
 7. **Light mode screenshot**: ensure sidebar theme toggle shows "Light mode" (click to switch if needed)
 
-8. **Dark mode**: click sidebar theme toggle → `browser_wait_for` 500ms
-   - Run the contrast portion of computed checks again in dark mode:
-     ```js
-     const mutedEl = document.querySelector('[class*="muted-foreground"]');
-     const card = document.querySelector('[data-slot="card"], [class*="rounded"][class*="border"], main > div');
-     return {
-       mutedForegroundColor: mutedEl ? getComputedStyle(mutedEl).color : null,
-       cardBackgroundColor: card ? getComputedStyle(card).backgroundColor : null,
-       bodyColor: getComputedStyle(document.body).color,
-       bodyBg: getComputedStyle(document.body).backgroundColor
-     };
-     ```
+8. **Dark mode**: click sidebar theme toggle → `browser_wait_for` 500ms → capture screenshot. *(Dark-mode contrast measurement moved to `/accessibility-audit`.)*
 
-9. **Immediately analyse** both screenshots + computed data against V1–V8 using the code context from Step 5a
+9. **Immediately analyse** both screenshots + computed data against V1-V7, V9-V11 using the code context from Step 5a
 
 > Do not batch all screenshots then analyse. Analyse immediately after each pair — avoids context overload and produces sharper observations.
 
@@ -256,26 +239,21 @@ For each page, produce:
 - Font sizes: [N distinct values — list]
 - Padding spot-check: [{tag: tagName, pad: Npx}] · Misaligned: [list or "none"]
 - Transitions out of range: [list ms values, or "none"]
-- Muted foreground (light): [rgb value]
-- Card background (light): [rgb value]
-- Muted foreground (dark): [rgb value]
-- Card background (dark): [rgb value]
 
 | Dim | Score | Observation | Action needed |
 |---|---|---|---|
 | V1 Typographic hierarchy | N/5 | [specific observation — reference fontSizeCount from computed data] | [fix or "none"] |
 | V2 Spatial rhythm | N/5 | [specific observation — reference paddingMisaligned from computed data] | [fix or "none"] |
 | V3 Visual focal point | N/5 | [specific observation] | [fix or "none"] |
-| V4 Colour discipline | N/5 | [specific observation — note if bg-brand on row buttons; note APCA-level concern if muted text appears low-contrast] | [fix or "none"] |
+| V4 Colour discipline | N/5 | [specific observation — note if bg-brand on row buttons] | [fix or "none"] |
 | V5 Information density | N/5 | [specific observation] | [fix or "none"] |
 | V6 Dark-mode polish | N/5 | [specific observation from dark screenshot — reference score anchors; note OKLCH hue shifts, washed-out tones, badge legibility] | [fix or "none"] |
 | V7 Micro-polish | N/5 | [specific observation — reference transitionsOutOfRange; note empty state CTA quality from Step 5a] | [fix or "none"] |
-| V8 Contrast & legibility | N/5 | [specific observation — reference computed muted/card color pairs for both themes; flag if muted text appears to fall below Lc 45 anchor] | [fix or "none"] |
 | V9 Gestalt compliance | N/5 | [proximity grouping, figure/ground distinction, similarity across sections, continuity of lists/grids — specific observation] | [fix or "none"] |
 | V10 Typographic quality | N/5 | [line-height ratio, letter-spacing on small fonts, line length on text/td — reference computed data if available] | [fix or "none"] |
 | V11 Interaction state design | N/5 | [hover/focus/active/disabled/loading states — reference code inspection from Step 5a] | [fix or "none"] |
 
-**Page score**: [sum]/55 — [label: Excellent ≥44 | Good 33–43 | Needs work 22–32 | Poor <22]
+**Page score**: [sum]/50 — [label: Excellent ≥40 | Good 30-39 | Needs work 20-29 | Poor <20]
 **Critical findings on this page**: [list or "none"]
 ```
 
@@ -289,11 +267,10 @@ After all pages, identify:
 2. **Best-in-class pages**: the 2 pages with highest scores → what patterns make them work?
 3. **Worst offenders**: the 2 pages with lowest scores → highest ROI for improvement
 4. **Theme gap**: average V6 score vs average of V1–V5 → if V6 is ≥ 1 point lower, dark mode needs dedicated attention
-5. **Contrast gap**: average V8 score vs V6 → if V8 is lower in dark mode, OKLCH conversion or token values need review
-6. **Typography discipline**: pages where fontSizeCount > 5 → systemic type scale violation; pages where V10 scores ≤ 3 → line-height or line-length issues
-7. **Gestalt patterns**: pages where V9 scores ≤ 3 → proximity or similarity violations across sections
-8. **Interaction debt**: pages where V11 scores ≤ 3 → missing hover/focus/loading states (cross-reference with V7)
-9. **Code pattern violations**: list any systematic code patterns observed across pages that cause visual problems (e.g., "bg-brand on row buttons appears on 4 pages: [list]")
+5. **Typography discipline**: pages where fontSizeCount > 5 → systemic type scale violation; pages where V10 scores ≤ 3 → line-height or line-length issues
+6. **Gestalt patterns**: pages where V9 scores ≤ 3 → proximity or similarity violations across sections
+7. **Interaction debt**: pages where V11 scores ≤ 3 → missing hover/focus/loading states (cross-reference with V7)
+8. **Code pattern violations**: list any systematic code patterns observed across pages that cause visual problems (e.g., "bg-brand on row buttons appears on 4 pages: [list]")
 
 ---
 
@@ -302,8 +279,8 @@ After all pages, identify:
 ```
 ## Visual Audit — [DATE] — [MODE] — [TARGET]
 ### Reference: docs/sitemap.md · app/globals.css · app/themes.css
-### Scope: aesthetic quality · typography · spacing · visual hierarchy · colour · dark mode · polish · contrast
-### Out of scope: token compliance → /ui-audit | UX flows → /ux-audit | Responsiveness → /responsive-audit
+### Scope: aesthetic quality · typography · spacing · visual hierarchy · colour · dark mode · polish
+### Out of scope: token compliance → /ui-audit | Accessibility + contrast → /accessibility-audit | UX flows → /ux-audit | Responsiveness → /responsive-audit
 
 ---
 
@@ -318,7 +295,6 @@ After all pages, identify:
 | V5 Information density | N.N/5 | ↑/→/↓ |
 | V6 Dark-mode polish | N.N/5 | ↑/→/↓ |
 | V7 Micro-polish | N.N/5 | ↑/→/↓ |
-| V8 Contrast & legibility | N.N/5 | ↑/→/↓ |
 | V9 Gestalt compliance | N.N/5 | ↑/→/↓ |
 | V10 Typographic quality | N.N/5 | ↑/→/↓ |
 | V11 Interaction state design | N.N/5 | ↑/→/↓ |
@@ -330,7 +306,7 @@ After all pages, identify:
 
 | Page | Route | Score | Weakest dim | Critical? |
 |---|---|---|---|---|
-| P01 Login | /login | N/55 | V[N] | yes/no |
+| P01 Login | /login | N/50 | V[N] | yes/no |
 ...
 
 ---
@@ -379,8 +355,8 @@ Critical first, then by impact (pages affected × dimension weight):
 
 ### Worst offenders (highest ROI)
 
-1. [Page]: score N/55 — [top 3 fixes that would most improve it]
-2. [Page]: score N/55 — [top 3 fixes]
+1. [Page]: score N/50 — [top 3 fixes that would most improve it]
+2. [Page]: score N/50 — [top 3 fixes]
 ```
 
 ---
@@ -395,8 +371,9 @@ After the report:
 > - **Mockup standalone**: invocare `/frontend-design` per generare un'alternativa migliorata (HTML standalone, fedele ai token del progetto)
 > - **Fix mirato**: applicare direttamente i miglioramenti che non richiedono decisioni di design (es. spaziatura padding, pesi tipografici, token mancanti)
 > - **Dark mode pass**: concentrarmi esclusivamente sul miglioramento del tema scuro su tutte le pagine
-> - **Contrast pass**: verificare e correggere i valori token per `text-muted-foreground` e `border-border` su entrambi i temi alla luce dei risultati V8
-> - **Gestalt pass**: analisi approfondita V9 su tutte le pagine con fix concreti per proximity e similarity violations"
+> - **Gestalt pass**: analisi approfondita V9 su tutte le pagine con fix concreti per proximity e similarity violations
+
+For contrast verification and axe-core WCAG coverage, run `/accessibility-audit` separately — it owns both APCA measurement and the full WCAG 2.2 scan."
 
 **Do NOT apply visual changes without confirmation.** Many of the fixes touch spacing and typography — they affect multiple components and require design decision, not just code.
 
@@ -415,8 +392,7 @@ Run this unconditionally at session end — screenshots are only needed during a
 ## Notes for interpretation
 
 - **V4 brand colour overuse**: if `bg-brand` appears on row-level buttons (not just primary CTAs), flag it even if each individual use seems minor. This is a PERMANENT RULE violation.
-- **V8 computed contrast is indicative, not definitive**: `getComputedStyle` returns resolved CSS values but does not compute APCA Lc scores directly. Use the colour values as evidence to support or flag concerns — the final contrast verdict is qualitative based on what's visible in the screenshot combined with the computed colours.
 - **V7 micro-polish on mobile**: not in scope for this skill — use `/responsive-audit` for that.
 - **Screenshots must be analysed fresh** — do not rely on memory from previous sessions. If a screenshot shows unexpected content (wrong role, empty state when data expected), note it and analyse what's visible.
 - **Preflight failures**: if more than 2 pages fail preflight, stop and report the issue before continuing — likely a dev server or auth problem, not a page-specific issue.
-- **Score denominator is /55** (11 dimensions × 5) — update any stored baselines accordingly.
+- **Score denominator is /50** (10 dimensions × 5). Bucket labels: Excellent ≥40 | Good 30-39 | Needs work 20-29 | Poor <20. Previous /55 baseline is no longer comparable — contrast is now scored by `/accessibility-audit`.

--- a/packages/cli/templates/tier-m/.claude/cheatsheet.md
+++ b/packages/cli/templates/tier-m/.claude/cheatsheet.md
@@ -40,6 +40,7 @@ Run these on demand. Each skill reads the codebase, produces a structured report
 | `/migration-audit` | Migration file safety: lock-heavy DDL, missing rollback, data loss, unsafe ALTER TYPE | After writing a migration, before applying to staging |
 | `/api-design` | HTTP verb correctness, URL structure, response shape, error codes, pagination | After adding 3+ new routes; quarterly |
 | `/perf-audit` | Server/client boundaries, heavy imports, serial awaits, image optimization, N+1 | Before production releases; after major UI changes |
+| `/accessibility-audit` | axe-core WCAG 2.2 scan, APCA contrast, static a11y patterns (aria, tabindex, focus, labels) | After UI changes; before compliance milestones |
 | `/simplify` | Early returns, nesting depth, local duplication, dead code, magic values | After writing code (Phase 2); on demand |
 
 > **Before first run**: open each SKILL.md and replace the `[PLACEHOLDER]` values with the real paths for this project.

--- a/packages/cli/templates/tier-m/.claude/rules/pipeline.md
+++ b/packages/cli/templates/tier-m/.claude/rules/pipeline.md
@@ -177,11 +177,12 @@ If either condition is false: **skip this phase and state so explicitly** — do
 ## Phase 5d — Block-scoped quality audit *(blocks with UI or API changes)*
 
 **Track A — UI audit** *(if block adds/modifies UI routes or components)*
-- Run `/ui-audit` scoped to the block's new/modified routes only (token compliance, component adoption, accessibility, empty states).
+- Run `/ui-audit` scoped to the block's new/modified routes only (token compliance, component adoption, empty states).
+- Run `/accessibility-audit` scoped to the block's new/modified routes (axe-core WCAG 2.2, APCA contrast, static a11y patterns).
 - Run `/visual-audit` scoped to the block's new/modified pages (typography, spacing, hierarchy, colour, density, dark-mode, micro-polish).
 - Run `/ux-audit` scoped to the block's user flows (task completion, feedback clarity, cognitive load).
 - Run `/responsive-audit` only if the block modifies routes used by non-admin roles.
-- **Execution order**: `/ui-audit` is static — launch it concurrently with the first Playwright-based skill. Then: `/visual-audit` → `/ux-audit` → `/responsive-audit` sequentially (they share the Playwright session).
+- **Execution order**: `/ui-audit` is static — launch it concurrently with the first Playwright-based skill. Then: `/accessibility-audit` → `/visual-audit` → `/ux-audit` → `/responsive-audit` sequentially (they share the Playwright session).
 
 **Track B — API/DB audit** *(if block creates/modifies API routes or applies migrations — static analysis, no dev server needed)*
 - Run `/security-audit` if the block creates or modifies any API route.
@@ -192,7 +193,7 @@ If either condition is false: **skip this phase and state so explicitly** — do
 **Severity handling — both tracks**:
 - **Critical**: fix before Phase 6. Do not proceed with open Critical issues.
 - **Major**: flag in Phase 6 checklist with planned resolution sprint.
-- **Minor**: append to `docs/refactoring-backlog.md` — assign ID prefix (`PERF-`, `API-`, `DB-`, `MIG-`, `DEV-`, `UX-`).
+- **Minor**: append to `docs/refactoring-backlog.md` — assign ID prefix (`PERF-`, `API-`, `DB-`, `MIG-`, `A11Y-`, `DEV-`, `UX-`).
 - Output per skill: one-paragraph summary only.
 
 ## Phase 6 — Outcome checklist ⏸ STOP

--- a/packages/cli/templates/tier-m/.claude/skills/accessibility-audit/SKILL.md
+++ b/packages/cli/templates/tier-m/.claude/skills/accessibility-audit/SKILL.md
@@ -1,0 +1,341 @@
+---
+name: accessibility-audit
+description: Unified accessibility audit - axe-core WCAG 2.2 scan, APCA contrast measurement, static a11y checks (aria-label, tabindex, form labels, focus visibility, onClick on non-interactive). Static and live modes.
+user-invocable: true
+model: sonnet
+context: fork
+argument-hint: [static|full|wcag] [target:route:<path>|target:file:<glob>|target:role:<role>]
+allowed-tools: Read, Glob, Grep, Bash, mcp__playwright__browser_navigate, mcp__playwright__browser_evaluate, mcp__playwright__browser_wait_for
+---
+
+Single source of truth for accessibility checks across the project. Combines static grep-based checks (run in all modes) with live browser checks (axe-core WCAG scan + APCA contrast measurement) when a dev server is available.
+
+**Scope boundary**:
+- Owns: static a11y patterns (aria, tabindex, labels, focus, keyboard), axe-core WCAG 2.2 scan, APCA contrast computation.
+- Not here: design token compliance and component adoption → `/ui-audit`. Typography and aesthetic polish → `/visual-audit`. Viewport-specific a11y (WCAG 1.4.4 resize, 1.4.10 reflow, tap targets) → `/responsive-audit`.
+
+**Two execution modes**:
+- **Static mode** (dev server not running): Steps 0-2, 5 only. Can run concurrently with Playwright-based skills per pipeline.md.
+- **Full mode** (dev server running): all steps including APCA contrast + axe-core scan. Sequential — shares the Playwright MCP session with other live audits.
+- **WCAG mode** (`wcag`): same as full, plus axe-core `best-practice` tag.
+
+---
+
+## Step 0 — Target resolution + mode selection
+
+Parse `$ARGUMENTS` for an optional mode keyword and a `target:` token.
+
+| Pattern | Meaning |
+|---|---|
+| `static` | Force static mode — skip Steps 3-4 even if dev server is available |
+| `full` | Force full mode — fail if dev server is unreachable |
+| `wcag` | Full mode + axe-core `best-practice` tag (more stringent) |
+| No mode keyword | **Auto** — full if dev server responds, else static with a warning |
+| `target:route:<path>` | Restrict live scan to a single route (e.g. `target:route:/dashboard`) |
+| `target:file:<glob>` | Restrict static checks to matching files (e.g. `target:file:app/**/page.tsx`) |
+| `target:role:<role>` | Restrict to routes accessible by that role (from `docs/sitemap.md`) |
+| No target argument | Full audit — all page/component files from sitemap.md |
+
+**STRICT PARSING — mandatory**: derive mode and target ONLY from explicit text in `$ARGUMENTS`. Do NOT infer from conversation context, recent blocks, or memory. Unknown tokens → treat as absent and announce ignored args in the banner.
+
+Announce: `Running accessibility-audit in [STATIC | FULL | WCAG] mode — scope: [FULL | target: <resolved>]`
+
+---
+
+## Step 1 — Mode detection (if mode is auto)
+
+Run:
+```bash
+curl -s -o /dev/null -w "%{http_code}" http://localhost:3000
+```
+
+- Response 200 or 302 → proceed in **full** mode.
+- Anything else → degrade to **static** mode and record in the report: `⚠️ Dev server not reachable on localhost:3000 — APCA + axe-core checks skipped. Re-run after starting [DEV_COMMAND] for full coverage.`
+
+If mode was forced (`static`/`full`/`wcag`), skip this step — but if `full`/`wcag` was forced and the server is unreachable, fail explicitly: `❌ Mode [full|wcag] requested but dev server not running. Start [DEV_COMMAND] or re-run with "static".`
+
+---
+
+## Step 2 — Static a11y checks (A1-A8)
+
+Read `docs/sitemap.md` (if present) to build the target file list — page files + component files. If no sitemap, fall back to `app/**/page.tsx` + `components/**/*.tsx` filtered by `target:` scope.
+
+Launch a **single Explore subagent** (model: haiku) with the full file list and the check definitions below. Pass file paths explicitly — do not ask the agent to discover them.
+
+> **Ripgrep note**: patterns are written for ripgrep (`rg`). Use `|` for alternation. Character classes work as-is.
+
+### Instructions for the Explore agent
+
+"Run all 8 checks below. For each check: report total match count, list every match as `file:line — excerpt`, and state PASS (0 matches) or FAIL (N matches). If 0 matches, explicitly state '0 matches — PASS'. Do not skip any check.
+
+File scope: use ONLY the files provided.
+
+---
+
+**A1 — Icon-only buttons missing aria-label** [Severity: Critical — WCAG 4.1.2]
+Pattern: `size="icon"|size=\{'icon'\}` then filter to lines NOT containing `aria-label`.
+Also: `<Button[^>]*>\s*<[A-Z][a-zA-Z]+Icon` or `<Button[^>]*>\s*\{[^}]*Icon` without `aria-label` on the same or preceding line.
+Expected: 0 matches. Icon-only interactive elements must have an accessible name.
+
+**A2 — Positive tabindex** [Severity: Critical — WCAG 2.4.3]
+Pattern: `tabIndex=[1-9]|tabindex="[1-9]`
+Exclude: lines with `//`, `{/*`.
+Expected: 0 matches. Positive tabindex breaks natural tab order. Only `tabIndex={0}` or `tabIndex={-1}` are valid.
+
+**A3 — outline-none without focus-ring compensation** [Severity: High — WCAG 2.4.7, Tailwind v4 regression]
+Pattern: lines containing `outline-none` that do NOT also contain any of: `focus-visible:ring`, `focus:ring`, `focus-visible:outline`, `focus:outline`.
+Method: grep `outline-none`, then filter out lines that also contain any of the focus restoration patterns.
+Expected: 0 matches. In Tailwind v4, `outline-none` strips the focus indicator in forced-color / high-contrast mode. Replace with `outline-hidden` for decorative suppression, or add explicit `focus-visible:ring-*` compensation.
+
+**A4 — Native `<img>` without alt** [Severity: Medium — WCAG 1.1.1]
+Pattern: `<img\s`
+Exclude: lines containing `//`, `{/*`, `alt=`, `.svg`, `data:`, `role="presentation"`.
+Expected: 0 matches. Every raster image must have an `alt` attribute (empty string allowed for decorative use with `role="presentation"`).
+
+**A5 — Form inputs without accessible labels** [Severity: Critical — WCAG 1.3.1, 3.3.2, 4.1.2]
+Method: grep `<input`, `<Input`, `<textarea`, `<Textarea`, `<Select`. For each match, check within ±5 lines for a `<Label` containing `htmlFor` matching the input's `id`, OR an `aria-label`/`aria-labelledby` on the element.
+Exclude: inputs inside `<FormField>` (react-hook-form pattern) with a sibling `<FormLabel>` — these are valid.
+Expected: 0 matches. Every form control must have an accessible name.
+
+**A6 — Bare focus ring without explicit size** [Severity: High — WCAG 1.4.11]
+Pattern: `focus:ring[^-]|focus-visible:ring[^-]` (bare `ring` without a size modifier like `ring-2`).
+In Tailwind v4, the default `ring` changed from 3px to 1px. A bare `focus-visible:ring` relying on the 3px default is now too thin to meet WCAG 1.4.11 (3:1 non-text contrast for focus indicators).
+Expected: 0 matches on interactive elements. Recommend `ring-2` or `ring-[3px]` explicitly.
+
+**A7 — onClick on non-interactive elements** [Severity: Critical — WCAG 2.1.1]
+Pattern: `<div.*onClick|<span.*onClick|<li.*onClick|<p.*onClick`.
+For each match, the element must also have `role="button"` (or equivalent interactive role) AND `onKeyDown` (or `onKeyPress`). Missing either = keyboard users cannot activate it.
+Exclude: lines inside `{/* ... */}` comments; Radix `asChild` wrappers.
+Expected: 0 matches missing keyboard support.
+
+**A8 — Sidebar/nav trigger keyboard accessibility** [Severity: High — WCAG 2.1.1]
+Scope: `app/(app)/layout.tsx`, `components/Sidebar*.tsx`, or equivalent layout entry points.
+Verify: the primary sidebar / navigation trigger is reachable on BOTH mobile and desktop — not hidden inside an `md:hidden` wrapper with no desktop alternative.
+Flag: `SidebarTrigger` or equivalent wrapped only in `md:hidden` without a matching non-mobile trigger.
+Expected: every layout exposes a keyboard-reachable nav trigger at every breakpoint."
+
+---
+
+## Step 3 — APCA contrast measurement (full/wcag mode only — live)
+
+Pick 3 representative pages from the target scope:
+1. The dashboard or root route (`/`)
+2. One data-list page (first list route in scope)
+3. One form/write page (first form or wizard route in scope)
+
+For each page:
+
+```
+1. mcp__playwright__browser_navigate → http://localhost:3000/<route>
+2. Ensure logged in with the role from the route's sitemap entry (if auth required).
+3. browser_wait_for network idle (2000ms max).
+4. For each theme (light, dark):
+   - Toggle theme via sidebar Switch (or apply class="dark" on <html>).
+   - browser_wait_for 500ms.
+   - Run the APCA probe below via browser_evaluate.
+```
+
+### APCA probe
+
+```js
+// Returns computed color + background for the three C-checks.
+// APCA Lc is NOT computed here — we capture the raw rgb pairs and flag qualitatively.
+// The skill's report narrates the pair against Lc thresholds documented below.
+const byClass = (sel) => document.querySelector(sel);
+
+const muted = byClass('[class*="muted-foreground"]');
+const card = byClass('[data-slot="card"], [class*="rounded"][class*="border"], main > div');
+const cta = byClass('button[class*="bg-brand"], button[class*="bg-primary"], [data-slot="button"][class*="primary"]');
+const border = byClass('[class*="border-border"], [class*="rounded"][class*="border"]');
+
+const style = (el) => el ? getComputedStyle(el) : null;
+return {
+  theme: document.documentElement.classList.contains('dark') ? 'dark' : 'light',
+  mutedOnCard: {
+    color: muted ? style(muted).color : null,
+    background: card ? style(card).backgroundColor : null
+  },
+  ctaOnBrand: {
+    color: cta ? style(cta).color : null,
+    background: cta ? style(cta).backgroundColor : null
+  },
+  borderOnBg: {
+    color: border ? style(border).borderColor : null,
+    background: card ? style(card).backgroundColor : null
+  }
+};
+```
+
+### APCA thresholds (source: APCA / WCAG 3 working draft)
+
+- **Lc 75** — preferred body text
+- **Lc 60** — minimum body text
+- **Lc 45** — label / large text (≥ 24px or bold ≥ 18px)
+- **Lc 15** — non-text (borders, icons, dividers)
+
+Record each pair. The report narrates against thresholds qualitatively (getComputedStyle returns resolved rgb, not Lc — final verdict combines the rgb with visible contrast in the screenshot when available).
+
+### Check definitions
+
+| ID | Severity | Target |
+|---|---|---|
+| **C1** | High if body text appears below Lc 45; Critical if below Lc 30 | `text-muted-foreground` on `bg-card`, both themes. Silent dark-mode failure point. |
+| **C2** | High | Primary CTA text on brand background — frequent regression after token tweaks. |
+| **C3** | Medium | Border / icon contrast vs card background — must reach Lc 15. |
+
+---
+
+## Step 4 — axe-core browser scan (full/wcag mode only — live)
+
+For each of the 3 pages from Step 3:
+
+```js
+// Inject axe-core from CDN
+await new Promise((resolve, reject) => {
+  const s = document.createElement('script');
+  s.src = 'https://cdnjs.cloudflare.com/ajax/libs/axe-core/4.9.1/axe.min.js';
+  s.onload = resolve;
+  s.onerror = reject;
+  document.head.appendChild(s);
+});
+
+// WCAG 2a / 2aa / 2.1aa / 2.2aa (+ best-practice in wcag mode)
+const tags = ['wcag2a', 'wcag2aa', 'wcag21aa', 'wcag22aa'];
+// In wcag mode, also push 'best-practice'
+
+const results = await axe.run(document, {
+  runOnly: { type: 'tag', values: tags },
+  reporter: 'v2'
+});
+
+return {
+  violations: results.violations.map(v => ({
+    id: v.id,
+    impact: v.impact,
+    description: v.description,
+    nodes: v.nodes.length,
+    example: v.nodes[0]?.html?.slice(0, 120)
+  })),
+  passes: results.passes.length,
+  incomplete: results.incomplete.length
+};
+```
+
+### Severity mapping
+
+| ID | axe impact | Report severity |
+|---|---|---|
+| **X1** | `critical` or `serious` | Critical |
+| **X2** | `moderate` | High |
+| **X3** | `minor` | Medium |
+
+### Known false positives to suppress (document, not fix)
+
+- `color-contrast` on `text-muted-foreground` inside a Radix Portal overlay — axe measures the portal layer, not the semantic background. Verify manually against Step 3 C1 data.
+- `aria-hidden-focus` inside a closed Dialog/Sheet — Radix manages this via the `inert` attribute in v1.1+. Verify the installed Radix version before flagging.
+
+---
+
+## Step 5 — Report and backlog decision gate
+
+### Output format
+
+```
+## Accessibility Audit — [DATE] — [MODE] — [TARGET]
+
+### Executive summary
+[2-5 bullets — Critical and High findings only. Write concrete facts: file:line, check ID, impact.
+If nothing Critical/High: "No Critical or High findings — a11y posture is clean for the audited scope."
+Examples:
+- "A5 Critical: 3 form inputs in app/(app)/settings/page.tsx have no accessible label"
+- "C1 High: text-muted-foreground on bg-card rgb(…) on dark theme — likely below Lc 45"
+- "X1 Critical: 'button-name' axe violation on /dashboard — 2 nodes"]
+
+### A11y maturity assessment
+| Dimension | Rating | Notes |
+|---|---|---|
+| Keyboard access | strong / adequate / weak | [A2, A3, A6, A7, A8 results] |
+| Accessible naming | strong / adequate / weak | [A1, A4, A5 results] |
+| Contrast posture | strong / adequate / weak | [C1, C2, C3 — or "skipped, static mode"] |
+| WCAG conformance | strong / adequate / weak | [axe-core X1/X2/X3 counts, or "skipped"] |
+| Coverage | full / partial / static-only | [which steps ran] |
+
+### Per-check verdicts
+
+Static (all modes):
+| # | Check | Matches | Severity | Verdict |
+|---|---|---|---|---|
+| A1 | Icon-only buttons missing aria-label | N | Critical | ✅/❌ |
+| A2 | Positive tabindex | N | Critical | ✅/❌ |
+| A3 | outline-none without focus-ring compensation | N | High | ✅/❌ |
+| A4 | Native <img> without alt | N | Medium | ✅/❌ |
+| A5 | Form inputs without accessible labels | N | Critical | ✅/❌ |
+| A6 | Bare focus ring without explicit size | N | High | ✅/❌ |
+| A7 | onClick on non-interactive elements | N | Critical | ✅/❌ |
+| A8 | Sidebar/nav trigger accessibility | N | High | ✅/❌ |
+
+Live (full/wcag mode only — else "Skipped — static mode"):
+| # | Check | Result | Severity | Verdict |
+|---|---|---|---|---|
+| C1 | muted-foreground on bg-card (both themes) | [rgb pair / Lc estimate] | High / Critical | ✅/⚠️/❌ |
+| C2 | CTA text on brand background | [rgb pair] | High | ✅/❌ |
+| C3 | Border / icon vs card bg | [rgb pair] | Medium | ✅/❌ |
+
+axe-core (full/wcag mode only):
+| Page | Critical | Serious | Moderate | Minor | Passes |
+|---|---|---|---|---|---|
+| / | N | N | N | N | N |
+| /[list-page] | N | N | N | N | N |
+| /[form-page] | N | N | N | N | N |
+
+Top axe violations:
+[id — description — N nodes — example HTML]
+
+### Prioritized findings
+For each finding with severity Medium or above:
+[SEVERITY] [A11Y-?] [check ID] — [file:line or route] — [evidence] — [fix] — [effort: S=<1h / M=half day / L=day+]
+
+### Quick wins
+[Findings that meet all three: (a) Medium or High, (b) effort S, (c) single-file fix]
+Format: "A11Y-[n]: [one-line description]"
+If no quick wins: state explicitly.
+```
+
+### Backlog decision gate
+
+Present all findings with severity Medium or above as a numbered decision list, sorted Critical → High → Medium:
+
+```
+Found N a11y findings at Medium or above. Which to add to backlog?
+
+[1] [CRITICAL] A11Y-? — [check ID] — file:line — one-line description
+[2] [HIGH]     A11Y-? — [check ID] — file:line — one-line description
+[3] [MEDIUM]   A11Y-? — [check ID] — file:line — one-line description
+...
+
+Reply with numbers to include (e.g. "1 2 4"), "all", or "none".
+```
+
+**Wait for explicit user response before writing anything.**
+
+Then write ONLY the approved entries to `docs/refactoring-backlog.md`:
+- Assign ID: `A11Y-[n]` (next available after existing A11Y entries)
+- Add row to priority index
+- Add full detail section with: issue, evidence (file:line or rgb pair), check ID, fix suggestion, effort, WCAG reference
+
+### Severity guide
+
+- **Critical**: keyboard trap or missing accessible name on an interactive element (A1, A2, A5, A7); axe `critical`/`serious` violations (X1); APCA indicates body text falls below Lc 30 (C1).
+- **High**: focus indicator degraded (A3, A6); sidebar/nav unreachable at a breakpoint (A8); axe `moderate` (X2); APCA muted text or CTA below Lc 45 (C1, C2).
+- **Medium**: decorative image missing alt (A4); axe `minor` (X3); non-text contrast below Lc 15 (C3).
+
+---
+
+## Execution notes
+
+- Do NOT apply a11y fixes during this skill. Audit only.
+- The Explore agent in Step 2 handles all static grep work. Do not duplicate searches in the main context.
+- **Concurrent execution**: when invoked from pipeline.md Phase 5d Track A, this skill runs sequentially with `/visual-audit` → `/ux-audit` → `/responsive-audit` — they share the Playwright MCP session. `/ui-audit` still launches concurrently first.
+- **Static mode degradation**: if the dev server is unreachable and mode was auto, the report must state explicitly which steps were skipped. Never silently omit checks.
+- **axe-core false positives**: document suppressed false positives explicitly in the report. Do not flag known Radix-managed patterns (inert Dialog children, Portal color-contrast measurements) as violations without manual verification.
+- **Complementary skills**: `/accessibility-audit` is the single source of truth for accessibility. For design-token compliance and component adoption see `/ui-audit`; for aesthetic contrast and polish see `/visual-audit`; for viewport-specific WCAG checks (1.4.4 resize, 1.4.10 reflow, tap targets) see `/responsive-audit`.

--- a/packages/cli/templates/tier-m/.claude/skills/ui-audit/SKILL.md
+++ b/packages/cli/templates/tier-m/.claude/skills/ui-audit/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: ui-audit
-description: Audit UI for design token compliance, component adoption, and accessibility via axe-core. Static mode analyzes code without a server; full mode runs browser checks on live pages.
+description: Audit UI for design token compliance and component adoption. Static grep-based analysis against the sitemap's page and component files.
 user-invocable: true
 model: sonnet
 context: fork
 argument-hint: [target:page:<route>|target:role:<role>|target:section:<section>]
-allowed-tools: mcp__playwright__browser_navigate, mcp__playwright__browser_evaluate
+allowed-tools: Read, Glob, Grep
 ---
 
 **Critical constraint**: `docs/sitemap.md` is the authoritative inventory of every page file and key component. Read it first and derive the file target list from it. Do NOT run free-form `grep -r` across all of `app/` or `components/` — scope every check to the files listed in the sitemap.
 
-**Two execution modes**:
-- **Static mode** (dev server not running): Steps 1–3 only. Can run concurrently with Playwright-based skills per pipeline.md.
-- **Full mode** (dev server running): Steps 1–4 including axe-core browser scan. Must run sequentially (Playwright MCP session shared).
+**Scope boundary**: this skill covers design-token compliance and component adoption only. Accessibility (aria, tabindex, focus, labels, axe-core WCAG scan, APCA contrast) lives in `/accessibility-audit` — run it alongside `/ui-audit` for any UI change.
+
+Static-only skill — no dev server required. Can run concurrently with Playwright-based skills per pipeline.md.
 
 ---
 
@@ -52,7 +52,7 @@ Launch a **single Explore subagent** (model: haiku) with the following instructi
 
 ### Instructions for the Explore agent:
 
-"Run all 17 checks below. For each check: report the total match count, list every match as `file:line — excerpt`, and state PASS (0 matches) or FAIL (N matches). If a check returns 0 matches, explicitly state '0 matches — PASS'. Do not skip any check.
+"Run all 12 checks below (numbering preserves gaps — checks 11, 13, 14, 16, 17 moved to `/accessibility-audit`). For each check: report the total match count, list every match as `file:line — excerpt`, and state PASS (0 matches) or FAIL (N matches). If a check returns 0 matches, explicitly state '0 matches — PASS'. Do not skip any check.
 
 File scope: use ONLY the page files and component files provided. Do not search outside this list.
 
@@ -110,42 +110,25 @@ Additionally: find any `<Table` element lines that contain neither `w-auto` nor 
 Flag: any `<Table` with `w-full`, and any `<Table` with no explicit width class.
 Expected: 0 matches. `<Table>` must always have `w-auto`.
 
-**CHECK 11 — Icon-only buttons missing aria-label** [Severity: Critical]
-Pattern: lines containing `size="icon"` or `size={'icon'}` that do NOT also contain `aria-label`
-Method: grep for `size="icon"|size=\{'icon'\}`, then filter to keep only lines that do NOT contain `aria-label`.
-Also check: `IconButton` and `Button` with only an icon child (no visible text) — grep for `<Button[^>]*>\s*<[A-Z][a-zA-Z]+Icon` or `<Button[^>]*>\s*{[^}]*Icon` without `aria-label` on the same or preceding line.
-Expected: 0 matches. Icon-only buttons must always have aria-label.
+**CHECK 11** — moved to `/accessibility-audit` as A1 (icon-only buttons missing aria-label).
 
 **CHECK 12 — overflow-x-auto on table wrappers (PERMANENT RULE violation)** [Severity: Critical]
 Pattern: `overflow-x-auto`
 Exclude: lines containing `<pre`, `<code`, `// `, `{/*`
 Expected: 0 matches in non-pre containers. Table wrappers must use `overflow-hidden`, not `overflow-x-auto`.
 
-**CHECK 13 — Positive tabindex (WCAG 2.4.3 violation)** [Severity: Critical]
-Pattern: `tabIndex=[1-9]|tabindex="[1-9]`
-Exclude: lines with `//`, `{/*`
-Expected: 0 matches. Positive tabindex breaks natural tab order. Only `tabIndex={0}` or `tabIndex={-1}` are valid.
+**CHECK 13** — moved to `/accessibility-audit` as A2 (positive tabindex, WCAG 2.4.3).
 
-**CHECK 14 — outline-none without focus ring (Tailwind v4 forced-color regression)** [Severity: High]
-Pattern: lines containing `outline-none` that do NOT also contain at least one of: `focus-visible:ring`, `focus:ring`, `focus-visible:outline`, `focus:outline`
-Method: grep for `outline-none`, then filter out lines that also contain any of the above focus restoration patterns.
-Expected: 0 matches. In Tailwind v4, `outline-none` strips the focus indicator in forced-color / high-contrast mode. Replace with `outline-hidden` for decorative suppression, or add explicit `focus-visible:ring-*` compensation.
+**CHECK 14** — moved to `/accessibility-audit` as A3 (outline-none without focus-ring compensation).
 
 **CHECK 15 — Deprecated opacity utility syntax (Tailwind v4 breaking change)** [Severity: High]
 Pattern: `bg-opacity-|text-opacity-|border-opacity-|divide-opacity-|placeholder-opacity-|ring-opacity-`
 Exclude: lines with `//`, `{/*`
 Expected: 0 matches. Tailwind v4 removed these utilities. Use slash syntax: `bg-black/50`, `text-foreground/80`, etc.
 
-**CHECK 16 — Native <img> tag (use Next.js <Image>)** [Severity: Medium]
-Pattern: `<img\s`
-Exclude: lines containing `//`, `{/*`, `alt=`, `.svg`, `data:`, `role="presentation"`
-Flag: any `<img` that does not appear to be a decorative/SVG use.
-Expected: 0 matches. All raster images must use `<Image>` from `next/image` for optimization and LCP.
+**CHECK 16** — moved to `/accessibility-audit` as A4 (native `<img>` without alt).
 
-**CHECK 17 — Form inputs without accessible labels** [Severity: Critical]
-Method: for each match, check within ±5 lines for a `<Label` containing `htmlFor` matching the input's `id`. If no `<Label htmlFor` and no `aria-label`/`aria-labelledby` on the component line: flag it.
-Note: inputs inside `<FormField>` (react-hook-form pattern) with a sibling `<FormLabel>` are valid — exclude lines inside a `<FormField>` wrapper.
-Expected: 0 matches. Every form control must have an accessible name."
+**CHECK 17** — moved to `/accessibility-audit` as A5 (form inputs without accessible labels)."
 
 ---
 
@@ -165,27 +148,15 @@ Read `components/Sidebar.tsx` lines containing "Esci" or "sign" or "red".
 Verify: uses `bg-destructive` (semantic) not `bg-red-600` (hardcoded).
 Expected: `bg-destructive hover:bg-destructive/90`.
 
-**S4 — Responsive sidebar trigger accessibility**
-Read `app/(app)/layout.tsx`.
-Verify: SidebarTrigger is reachable on BOTH mobile (in mobile header) and desktop (always accessible, not hidden when sidebar is open).
-Flag if trigger is inside an `md:hidden` wrapper with no desktop alternative.
+**S4** — moved to `/accessibility-audit` as A8 (sidebar/nav trigger keyboard accessibility).
 
 **S5 — w-fit on table container wrappers**
 For each file in scope that contains `<Table`, check whether its immediate parent container (Card, div) uses `w-fit`. Files that contain `<Table` but no `w-fit` anywhere → flag.
 Expected: all table wrappers use `w-fit` or `w-auto`.
 
-**S6 — Tailwind v4 bare `ring` on focus styles**
-Grep the scoped files for `focus:ring[^-]|focus-visible:ring[^-]` (bare `ring` without an explicit size modifier like `ring-2`).
-In Tailwind v4, the default `ring` changed from 3px to 1px. A bare `focus-visible:ring` that was relying on the 3px default is now too thin to meet WCAG 1.4.11 (3:1 non-text contrast for focus indicators).
-Flag any bare `ring` usage on interactive elements. Recommend `ring-2` or `ring-[3px]` explicitly.
-Severity: Medium.
+**S6** — moved to `/accessibility-audit` as A6 (bare focus ring without explicit size, WCAG 1.4.11).
 
-**S7 — onClick on non-interactive elements**
-Grep the scoped files for `<div.*onClick|<span.*onClick|<li.*onClick`.
-For each match, verify the element also has `role="button"` (or equivalent) AND `onKeyDown` (or `onKeyPress`).
-Missing either = keyboard users cannot activate the element (WCAG 2.1.1).
-Exclude: lines inside `{/* ... */}` comments, or where the element is a Radix `asChild` wrapper.
-Severity: Critical if the element is a primary action, High otherwise.
+**S7** — moved to `/accessibility-audit` as A7 (onClick on non-interactive elements, WCAG 2.1.1).
 
 **S8 — 'use client' placement depth**
 Read `app/(app)/layout.tsx`.
@@ -194,66 +165,7 @@ Severity: Medium (performance — prevents RSC streaming).
 
 ---
 
-## Step 4 — Browser accessibility scan (conditional — Playwright MCP)
-
-**First: check if dev server is reachable.**
-Run: `curl -s -o /dev/null -w "%{http_code}" http://localhost:3000`
-- If response is NOT 200 or 302: output `⚠️ Browser scan skipped — dev server not running on localhost:3000. Re-run after starting npm run dev for full axe-core coverage.` Then skip to Step 5.
-- If response is 200 or 302: proceed.
-
-**Select 3 representative pages** from the target scope (resolved from sitemap.md):
-1. The dashboard or root route (`/`)
-2. One data-list page (first `full-list` route in scope)
-3. One form/write page (first `form` or `wizard` route in scope, or a detail page with edit capability)
-
-**For each page, execute the following sequence:**
-
-```
-1. mcp__playwright__browser_navigate to http://localhost:3000/<route>
-   (If redirected to /login: read test account credentials from the "Test accounts" section
-
-2. mcp__playwright__browser_evaluate:
-   // Inject axe-core from CDN
-   await new Promise((resolve, reject) => {
-     const s = document.createElement('script');
-     s.src = 'https://cdnjs.cloudflare.com/ajax/libs/axe-core/4.9.1/axe.min.js';
-     s.onload = resolve;
-     s.onerror = reject;
-     document.head.appendChild(s);
-   });
-   // Run WCAG 2a / 2aa / 2.1aa / 2.2aa tags
-   const results = await axe.run(document, {
-     runOnly: { type: 'tag', values: ['wcag2a', 'wcag2aa', 'wcag21aa', 'wcag22aa'] },
-     reporter: 'v2'
-   });
-   return {
-     violations: results.violations.map(v => ({
-       id: v.id,
-       impact: v.impact,
-       description: v.description,
-       nodes: v.nodes.length,
-       example: v.nodes[0]?.html?.slice(0, 120)
-     })),
-     passes: results.passes.length,
-     incomplete: results.incomplete.length
-   };
-```
-
-3. Record violations grouped by impact: critical → serious → moderate → minor.
-```
-
-**Severity mapping for pipeline.md**:
-- `critical` / `serious` axe violations → **Critical** (fix before Phase 6)
-- `moderate` axe violations → **High** (flag in Phase 6 checklist)
-- `minor` axe violations → **Medium** (append to `docs/refactoring-backlog.md` with `UI-[n]` prefix)
-
-**Known false-positives to suppress** (document, not fix):
-- `color-contrast` on `text-muted-foreground` within Radix Portal overlay — axe measures the portal layer, not the semantic background. Verify manually.
-- `aria-hidden-focus` inside closed Dialog/Sheet — Radix manages this via `inert` attribute in v1.1+. Verify version before flagging.
-
----
-
-## Step 5 — Produce audit report
+## Step 4 — Produce audit report
 
 Output in this exact format:
 
@@ -261,7 +173,8 @@ Output in this exact format:
 ## UI Audit — [DATE]
 ### Scope: [N] page files from sitemap.md + [N] component files
 ### Target: [FULL | target:<value>]
-### Mode: [Static | Full (axe-core scan included)]
+
+> For accessibility checks (axe-core WCAG scan, APCA contrast, aria/tabindex/label patterns), run `/accessibility-audit`.
 
 ### Grep Checks
 | # | Check | Matches | Severity | Verdict |
@@ -276,35 +189,20 @@ Output in this exact format:
 | 8 | Content status badges hardcoded | N | Medium | ✅/❌ |
 | 9 | Tab bars missing whitespace-nowrap | N | Medium | ✅/❌ |
 | 10 | Table w-full violation | N | Critical | ✅/❌ |
-| 11 | Icon buttons missing aria-label | N | Critical | ✅/❌ |
 | 12 | overflow-x-auto on table wrappers | N | Critical | ✅/❌ |
-| 13 | Positive tabindex | N | Critical | ✅/❌ |
-| 14 | outline-none without focus ring | N | High | ✅/❌ |
 | 15 | Deprecated opacity syntax | N | High | ✅/❌ |
-| 16 | Native <img> tag | N | Medium | ✅/❌ |
-| 17 | Form inputs without labels | N | Critical | ✅/❌ |
+
+*(Gaps 11, 13, 14, 16, 17 moved to `/accessibility-audit`.)*
 
 ### Supplemental Checks
 | # | Check | Verdict | Notes |
 |---|---|---|---|
 | S2 | NotificationBell placement | ✅/❌ | |
 | S3 | Sign-out semantic color | ✅/❌ | |
-| S4 | Sidebar trigger accessibility | ✅/❌ | |
 | S5 | Table container w-fit | ✅/❌ | |
-| S6 | Bare ring on focus styles | ✅/❌ | |
-| S7 | onClick on non-interactive elements | ✅/❌ | |
 | S8 | 'use client' placement depth | ✅/❌ | |
 
-### Browser Accessibility Scan (axe-core)
-[Only if Step 4 ran — otherwise: "Skipped — dev server not running"]
-| Page | Critical | Serious | Moderate | Minor | Passes |
-|---|---|---|---|---|---|
-| / | N | N | N | N | N |
-| /[list-page] | N | N | N | N | N |
-| /[form-page] | N | N | N | N | N |
-
-Top violations:
-[id — description — N nodes — example HTML]
+*(Gaps S4, S6, S7 moved to `/accessibility-audit`.)*
 
 ### ❌ Failures requiring action ([N] total — by severity)
 
@@ -323,7 +221,6 @@ Top violations:
 ### Coverage
 Page files checked: N/N from sitemap.md
 Component files checked: N
-Axe-core pages scanned: N (or: skipped)
 ```
 
 If all checks pass: output `UI Audit CLEAN — [DATE]. No violations found.`
@@ -336,5 +233,5 @@ If all checks pass: output `UI Audit CLEAN — [DATE]. No violations found.`
 - Do NOT re-read files already in context from Step 1.
 - The Explore agent in Step 2 handles all grep work. Do not duplicate searches in the main context.
 - **Pipeline integration**: for Critical findings, ask the user: "Vuoi che implementi i fix identificati?" before touching any file. Medium/Low findings go directly to `docs/refactoring-backlog.md` without asking.
-- **Concurrent execution**: when invoked from pipeline.md Phase 5d, this skill runs concurrently with the first Playwright-based skill ONLY in Static mode (Step 4 skipped). If the dev server is running and Step 4 executes, the Playwright MCP session is in use — do not overlap.
-- **axe-core false positives**: document suppressed false positives explicitly in the report. Do not flag known Radix-managed patterns (inert Dialog children, Portal color-contrast measurements) as violations without manual verification.
+- **Concurrent execution**: when invoked from pipeline.md Phase 5d Track A, this skill launches concurrently with the first Playwright-based skill. It is fully static — no dev server required.
+- **Complementary skill**: run `/accessibility-audit` alongside `/ui-audit` for any UI change. It owns axe-core WCAG 2.2 scan, APCA contrast, and the static a11y patterns formerly numbered here as CHECK 11/13/14/16/17 and S4/S6/S7.

--- a/packages/cli/templates/tier-m/.claude/skills/visual-audit/SKILL.md
+++ b/packages/cli/templates/tier-m/.claude/skills/visual-audit/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: visual-audit
-description: Visual audit: typography, spacing, colour discipline, dark-mode polish, contrast, info density. Scores pages on 11 dimensions via Playwright screenshots.
+description: Visual audit - typography, spacing, colour discipline, dark-mode polish, info density. Scores pages on 10 aesthetic dimensions via Playwright screenshots.
 user-invocable: true
 model: opus
 context: fork
 argument-hint: [quick|full] [target:page:<route>|target:role:<role>|target:section:<section>]
 allowed-tools: Read, Glob, Grep, Bash, mcp__playwright__browser_navigate, mcp__playwright__browser_take_screenshot, mcp__playwright__browser_snapshot, mcp__playwright__browser_click, mcp__playwright__browser_type, mcp__playwright__browser_wait_for, mcp__playwright__browser_resize, mcp__playwright__browser_evaluate
 ---
+
+**Scope boundary**: this skill covers aesthetic quality only. Accessibility contrast (APCA measurement, WCAG contrast thresholds, axe-core scan) lives in `/accessibility-audit` — run it for any contrast or accessibility concern. Design-token compliance → `/ui-audit`. Viewport fit → `/responsive-audit`.
 
 ## Step 0 — Mode + target detection
 
@@ -70,10 +72,9 @@ Apply these 11 dimensions to every screenshot captured.
 | **V1** | Typographic hierarchy | H1 vs body weight contrast; label vs value distinction; font size spread; muted-foreground on secondary text. **Quantitative anchor**: ≤ 5 distinct font sizes in use (from computed check); 2 font weights (semibold for headings, regular for body). Flag if computed check reveals > 5 sizes. | ≥ 4 |
 | **V2** | Spatial rhythm | Consistent padding inside similar components; visual breathing room; margin harmony between sections; card internal padding uniformity. **Quantitative anchor**: padding values should be multiples of 4px (8px preferred). Flag non-grid values (14px, 6px, 10px) from the 3-element spot check in computed checks. | ≥ 4 |
 | **V3** | Visual focal point | Primary CTA is the most prominent element; user's eye is guided to the most important content; no competing elements of equal weight | ≥ 4 |
-| **V4** | Colour discipline | Brand colour used sparingly and intentionally; status colours follow semantic convention (green=done, amber=pending, red=destructive); no arbitrary colour decoration; `bg-brand` reserved for primary CTAs not row-level buttons. **APCA anchors** (source: APCA/WCAG 3 working draft): body text on card background should achieve APCA Lc ≥ 60 equivalent; label/muted text ≥ Lc 45 for large font sizes; non-text contrast (borders, icons) ≥ Lc 15. Evaluate in both themes. | ≥ 4 |
+| **V4** | Colour discipline | Brand colour used sparingly and intentionally; status colours follow semantic convention (green=done, amber=pending, red=destructive); no arbitrary colour decoration; `bg-brand` reserved for primary CTAs not row-level buttons. Evaluate in both themes. *(Contrast thresholds moved to `/accessibility-audit` C1-C3.)* | ≥ 4 |
 | **V5** | Information density | Appropriate density for the page type (list = dense, form = airy); tables scannable at a glance; no cognitive overload; no empty visual regions | ≥ 3 |
 | **V7** | Micro-polish | Hover/focus states visible; transitions not jarring; empty states and skeletons look professional; icon–text alignment clean; status badges correct size relative to surrounding text. **Timing anchor**: transitions < 100ms are imperceptible (no feedback value); > 400ms feels sluggish. Flag when computed check reveals out-of-range transition durations on interactive elements. | ≥ 3 |
-| **V8** | Contrast & legibility | Computed contrast ratios for key text elements against their backgrounds in both light and dark themes. References APCA thresholds: Lc 75 preferred for body text, Lc 60 minimum, Lc 45 for large/label text, Lc 15 for non-text (borders, icons). Specifically checks `text-muted-foreground` on `bg-card` — a common silent failure in dark mode. Uses computed style values from browser_evaluate. | ≥ 4 |
 | **V9** | Gestalt compliance | Evaluate 4 Gestalt principles: (1) **Proximity** — related elements grouped with tighter spacing than unrelated ones; flag if label↔value gap ≥ gap between distinct sections; (2) **Figure/ground** — content distinguishable from chrome without effort; flag dark mode text indistinguishable from bg; (3) **Similarity** — components with same function look the same cross-section; flag Badge same state with different colour/size on different pages; (4) **Continuity** — lists, columns, card grids guide the eye linearly; flag variable card sizes or inconsistent column widths. **Score anchors**: 5 = all 4 respected; 3 = 1-2 localised violations; 1 = disorienting layout. | ≥ 4 |
 | **V10** | Typographic quality | From code inspection + computed check: flag `lineHeight/fontSize` ratio < 1.4 or > 1.8 on body/label text; flag negative `letterSpacing` on font < 14px; flag paragraph or td width > 680px (≈75 chars). **Score anchors**: 5 = all in range; 3 = 1 value out of range; 1 = text in conditions that impair legibility. | ≥ 4 |
 | **V11** | Interaction state design | From code inspection (Step 5a) + screenshots: for every interactive element, verify: (1) hover — bg change ≥ 10 lightness points or border appearance; (2) focus-visible — ring visible on all backgrounds including bg-brand contexts; (3) active/pressed — visually distinct from hover; (4) disabled — desaturated colour + opacity, not just opacity; (5) loading skeleton — shape matches expected content layout. **Score anchors**: 5 = all 5 states designed; 3 = 2-3 states absent or indistinguishable; 1 = no interaction feedback. | ≥ 3 |
@@ -82,7 +83,7 @@ Score scale: **1** = poor · **2** = needs work · **3** = acceptable · **4** =
 
 **Scoring rules:**
 - Score 1–2 on any dimension → Critical finding
-- Score 3 on V1, V3, V4, V8, V9, V10 → Major finding (highest visual and accessibility impact)
+- Score 3 on V1, V3, V4, V9, V10 → Major finding (highest visual impact)
 - Score 3 on V2, V5, V6, V7, V11 → Minor finding
 - Write one concrete, actionable observation per dimension per page (not just a number)
 - **Never write a vague observation like "good overall"** — every line must name what specifically works or what specifically is wrong
@@ -198,40 +199,22 @@ For each page in roster:
      .filter(d => d && d !== '0s')
      .map(d => parseFloat(d) * 1000); // convert to ms
 
-   // Contrast spot check — text-muted-foreground on bg-card (light mode)
-   const mutedEl = document.querySelector('[class*="muted-foreground"]');
-   const mutedColor = mutedEl ? getComputedStyle(mutedEl).color : null;
-   const cardBg = card ? getComputedStyle(card).backgroundColor : null;
-
    return {
      fontSizeCount: fontSizes.length,
      fontSizes,
      paddingSpotCheck: paddings,
      paddingMisaligned: misaligned,
      transitionCount: transitions.length,
-     transitionsOutOfRange: transitions.filter(ms => ms > 0 && (ms < 100 || ms > 400)),
-     mutedForegroundColor: mutedColor,
-     cardBackgroundColor: cardBg
+     transitionsOutOfRange: transitions.filter(ms => ms > 0 && (ms < 100 || ms > 400))
    };
    ```
-   Record results. Use to inform V1 (font scale), V2 (padding spot-check + misaligned), V7 (transition timing), V8 (contrast).
+   Record results. Use to inform V1 (font scale), V2 (padding spot-check + misaligned), V7 (transition timing). *(Contrast measurement moved to `/accessibility-audit` Step 3.)*
 
 7. **Light mode screenshot**: ensure sidebar theme toggle shows "Light mode" (click to switch if needed)
 
-8. **Dark mode**: click sidebar theme toggle → `browser_wait_for` 500ms
-   - Run the contrast portion of computed checks again in dark mode:
-     ```js
-     const mutedEl = document.querySelector('[class*="muted-foreground"]');
-     const card = document.querySelector('[data-slot="card"], [class*="rounded"][class*="border"], main > div');
-     return {
-       mutedForegroundColor: mutedEl ? getComputedStyle(mutedEl).color : null,
-       cardBackgroundColor: card ? getComputedStyle(card).backgroundColor : null,
-       bodyColor: getComputedStyle(document.body).color,
-       bodyBg: getComputedStyle(document.body).backgroundColor
-     };
-     ```
+8. **Dark mode**: click sidebar theme toggle → `browser_wait_for` 500ms → capture screenshot. *(Dark-mode contrast measurement moved to `/accessibility-audit`.)*
 
-9. **Immediately analyse** both screenshots + computed data against V1–V8 using the code context from Step 5a
+9. **Immediately analyse** both screenshots + computed data against V1-V7, V9-V11 using the code context from Step 5a
 
 > Do not batch all screenshots then analyse. Analyse immediately after each pair — avoids context overload and produces sharper observations.
 
@@ -256,26 +239,21 @@ For each page, produce:
 - Font sizes: [N distinct values — list]
 - Padding spot-check: [{tag: tagName, pad: Npx}] · Misaligned: [list or "none"]
 - Transitions out of range: [list ms values, or "none"]
-- Muted foreground (light): [rgb value]
-- Card background (light): [rgb value]
-- Muted foreground (dark): [rgb value]
-- Card background (dark): [rgb value]
 
 | Dim | Score | Observation | Action needed |
 |---|---|---|---|
 | V1 Typographic hierarchy | N/5 | [specific observation — reference fontSizeCount from computed data] | [fix or "none"] |
 | V2 Spatial rhythm | N/5 | [specific observation — reference paddingMisaligned from computed data] | [fix or "none"] |
 | V3 Visual focal point | N/5 | [specific observation] | [fix or "none"] |
-| V4 Colour discipline | N/5 | [specific observation — note if bg-brand on row buttons; note APCA-level concern if muted text appears low-contrast] | [fix or "none"] |
+| V4 Colour discipline | N/5 | [specific observation — note if bg-brand on row buttons] | [fix or "none"] |
 | V5 Information density | N/5 | [specific observation] | [fix or "none"] |
 | V6 Dark-mode polish | N/5 | [specific observation from dark screenshot — reference score anchors; note OKLCH hue shifts, washed-out tones, badge legibility] | [fix or "none"] |
 | V7 Micro-polish | N/5 | [specific observation — reference transitionsOutOfRange; note empty state CTA quality from Step 5a] | [fix or "none"] |
-| V8 Contrast & legibility | N/5 | [specific observation — reference computed muted/card color pairs for both themes; flag if muted text appears to fall below Lc 45 anchor] | [fix or "none"] |
 | V9 Gestalt compliance | N/5 | [proximity grouping, figure/ground distinction, similarity across sections, continuity of lists/grids — specific observation] | [fix or "none"] |
 | V10 Typographic quality | N/5 | [line-height ratio, letter-spacing on small fonts, line length on text/td — reference computed data if available] | [fix or "none"] |
 | V11 Interaction state design | N/5 | [hover/focus/active/disabled/loading states — reference code inspection from Step 5a] | [fix or "none"] |
 
-**Page score**: [sum]/55 — [label: Excellent ≥44 | Good 33–43 | Needs work 22–32 | Poor <22]
+**Page score**: [sum]/50 — [label: Excellent ≥40 | Good 30-39 | Needs work 20-29 | Poor <20]
 **Critical findings on this page**: [list or "none"]
 ```
 
@@ -289,11 +267,10 @@ After all pages, identify:
 2. **Best-in-class pages**: the 2 pages with highest scores → what patterns make them work?
 3. **Worst offenders**: the 2 pages with lowest scores → highest ROI for improvement
 4. **Theme gap**: average V6 score vs average of V1–V5 → if V6 is ≥ 1 point lower, dark mode needs dedicated attention
-5. **Contrast gap**: average V8 score vs V6 → if V8 is lower in dark mode, OKLCH conversion or token values need review
-6. **Typography discipline**: pages where fontSizeCount > 5 → systemic type scale violation; pages where V10 scores ≤ 3 → line-height or line-length issues
-7. **Gestalt patterns**: pages where V9 scores ≤ 3 → proximity or similarity violations across sections
-8. **Interaction debt**: pages where V11 scores ≤ 3 → missing hover/focus/loading states (cross-reference with V7)
-9. **Code pattern violations**: list any systematic code patterns observed across pages that cause visual problems (e.g., "bg-brand on row buttons appears on 4 pages: [list]")
+5. **Typography discipline**: pages where fontSizeCount > 5 → systemic type scale violation; pages where V10 scores ≤ 3 → line-height or line-length issues
+6. **Gestalt patterns**: pages where V9 scores ≤ 3 → proximity or similarity violations across sections
+7. **Interaction debt**: pages where V11 scores ≤ 3 → missing hover/focus/loading states (cross-reference with V7)
+8. **Code pattern violations**: list any systematic code patterns observed across pages that cause visual problems (e.g., "bg-brand on row buttons appears on 4 pages: [list]")
 
 ---
 
@@ -302,8 +279,8 @@ After all pages, identify:
 ```
 ## Visual Audit — [DATE] — [MODE] — [TARGET]
 ### Reference: docs/sitemap.md · app/globals.css · app/themes.css
-### Scope: aesthetic quality · typography · spacing · visual hierarchy · colour · dark mode · polish · contrast
-### Out of scope: token compliance → /ui-audit | UX flows → /ux-audit | Responsiveness → /responsive-audit
+### Scope: aesthetic quality · typography · spacing · visual hierarchy · colour · dark mode · polish
+### Out of scope: token compliance → /ui-audit | Accessibility + contrast → /accessibility-audit | UX flows → /ux-audit | Responsiveness → /responsive-audit
 
 ---
 
@@ -318,7 +295,6 @@ After all pages, identify:
 | V5 Information density | N.N/5 | ↑/→/↓ |
 | V6 Dark-mode polish | N.N/5 | ↑/→/↓ |
 | V7 Micro-polish | N.N/5 | ↑/→/↓ |
-| V8 Contrast & legibility | N.N/5 | ↑/→/↓ |
 | V9 Gestalt compliance | N.N/5 | ↑/→/↓ |
 | V10 Typographic quality | N.N/5 | ↑/→/↓ |
 | V11 Interaction state design | N.N/5 | ↑/→/↓ |
@@ -330,7 +306,7 @@ After all pages, identify:
 
 | Page | Route | Score | Weakest dim | Critical? |
 |---|---|---|---|---|
-| P01 Login | /login | N/55 | V[N] | yes/no |
+| P01 Login | /login | N/50 | V[N] | yes/no |
 ...
 
 ---
@@ -379,8 +355,8 @@ Critical first, then by impact (pages affected × dimension weight):
 
 ### Worst offenders (highest ROI)
 
-1. [Page]: score N/55 — [top 3 fixes that would most improve it]
-2. [Page]: score N/55 — [top 3 fixes]
+1. [Page]: score N/50 — [top 3 fixes that would most improve it]
+2. [Page]: score N/50 — [top 3 fixes]
 ```
 
 ---
@@ -395,8 +371,9 @@ After the report:
 > - **Mockup standalone**: invocare `/frontend-design` per generare un'alternativa migliorata (HTML standalone, fedele ai token del progetto)
 > - **Fix mirato**: applicare direttamente i miglioramenti che non richiedono decisioni di design (es. spaziatura padding, pesi tipografici, token mancanti)
 > - **Dark mode pass**: concentrarmi esclusivamente sul miglioramento del tema scuro su tutte le pagine
-> - **Contrast pass**: verificare e correggere i valori token per `text-muted-foreground` e `border-border` su entrambi i temi alla luce dei risultati V8
-> - **Gestalt pass**: analisi approfondita V9 su tutte le pagine con fix concreti per proximity e similarity violations"
+> - **Gestalt pass**: analisi approfondita V9 su tutte le pagine con fix concreti per proximity e similarity violations
+
+For contrast verification and axe-core WCAG coverage, run `/accessibility-audit` separately — it owns both APCA measurement and the full WCAG 2.2 scan."
 
 **Do NOT apply visual changes without confirmation.** Many of the fixes touch spacing and typography — they affect multiple components and require design decision, not just code.
 
@@ -415,8 +392,7 @@ Run this unconditionally at session end — screenshots are only needed during a
 ## Notes for interpretation
 
 - **V4 brand colour overuse**: if `bg-brand` appears on row-level buttons (not just primary CTAs), flag it even if each individual use seems minor. This is a PERMANENT RULE violation.
-- **V8 computed contrast is indicative, not definitive**: `getComputedStyle` returns resolved CSS values but does not compute APCA Lc scores directly. Use the colour values as evidence to support or flag concerns — the final contrast verdict is qualitative based on what's visible in the screenshot combined with the computed colours.
 - **V7 micro-polish on mobile**: not in scope for this skill — use `/responsive-audit` for that.
 - **Screenshots must be analysed fresh** — do not rely on memory from previous sessions. If a screenshot shows unexpected content (wrong role, empty state when data expected), note it and analyse what's visible.
 - **Preflight failures**: if more than 2 pages fail preflight, stop and report the issue before continuing — likely a dev server or auth problem, not a page-specific issue.
-- **Score denominator is /55** (11 dimensions × 5) — update any stored baselines accordingly.
+- **Score denominator is /50** (10 dimensions × 5). Bucket labels: Excellent ≥40 | Good 30-39 | Needs work 20-29 | Poor <20. Previous /55 baseline is no longer comparable — contrast is now scored by `/accessibility-audit`.

--- a/packages/cli/test/integration/run.js
+++ b/packages/cli/test/integration/run.js
@@ -302,6 +302,7 @@ async function scenarioTierS_full() {
   assertNotExists(dir, '.claude/skills/skill-db/SKILL.md');
   assertNotExists(dir, '.claude/skills/migration-audit/SKILL.md');
   assertNotExists(dir, '.claude/skills/responsive-audit/SKILL.md');
+  assertNotExists(dir, '.claude/skills/accessibility-audit/SKILL.md');
 
   // Active Skills section in CLAUDE.md
   const claudeS = fs.readFileSync(path.join(dir, 'CLAUDE.md'), 'utf8');
@@ -417,6 +418,7 @@ async function scenarioTierM() {
   assertExists(dir, '.claude/skills/simplify/SKILL.md');
   assertExists(dir, '.claude/skills/commit/SKILL.md');
   assertExists(dir, '.claude/skills/ui-audit/SKILL.md');
+  assertExists(dir, '.claude/skills/accessibility-audit/SKILL.md');
 
   assertStopHookPresent(dir);
   assertStopHookResolved(dir);
@@ -468,6 +470,7 @@ async function scenarioTierL() {
   assertExists(dir, '.claude/skills/visual-audit/SKILL.md');
   assertExists(dir, '.claude/skills/commit/SKILL.md');
   assertExists(dir, '.claude/skills/ui-audit/SKILL.md');
+  assertExists(dir, '.claude/skills/accessibility-audit/SKILL.md');
 
   assertStopHookPresent(dir);
   assertStopHookResolved(dir);
@@ -678,6 +681,7 @@ async function scenarioSkillPruning() {
   assertNotExists(dir, '.claude/skills/visual-audit/SKILL.md');
   assertNotExists(dir, '.claude/skills/ux-audit/SKILL.md');
   assertNotExists(dir, '.claude/skills/ui-audit/SKILL.md');
+  assertNotExists(dir, '.claude/skills/accessibility-audit/SKILL.md');
 
   // Skills that must always be present
   assertExists(dir, '.claude/skills/arch-audit/SKILL.md');
@@ -746,6 +750,7 @@ async function scenarioUiAuditPruning() {
   assertExists(dir, '.claude/skills/responsive-audit/SKILL.md');
   assertExists(dir, '.claude/skills/visual-audit/SKILL.md');
   assertExists(dir, '.claude/skills/ux-audit/SKILL.md');
+  assertExists(dir, '.claude/skills/accessibility-audit/SKILL.md');
 }
 
 async function scenarioCommitSkillAllTiers() {

--- a/packages/cli/test/unit/skill-registry.test.js
+++ b/packages/cli/test/unit/skill-registry.test.js
@@ -23,8 +23,8 @@ describe('NATIVE_STACKS', () => {
 // ---------------------------------------------------------------------------
 
 describe('SKILL_REGISTRY', () => {
-  it('has 15 entries', () => {
-    assert.equal(SKILL_REGISTRY.length, 15);
+  it('has 16 entries', () => {
+    assert.equal(SKILL_REGISTRY.length, 16);
   });
 
   it('every entry has required fields', () => {
@@ -72,12 +72,13 @@ describe('getSkillsToRemove', () => {
     assert.equal(result.length, 2);
   });
 
-  it('hasFrontend=false removes all 4 frontend skills', () => {
+  it('hasFrontend=false removes all 5 frontend skills', () => {
     const result = getSkillsToRemove({ techStack: 'node-ts', hasFrontend: false });
     assert.ok(result.includes('responsive-audit'));
     assert.ok(result.includes('visual-audit'));
     assert.ok(result.includes('ux-audit'));
     assert.ok(result.includes('ui-audit'));
+    assert.ok(result.includes('accessibility-audit'));
   });
 
   it('native stack removes responsive-audit but keeps visual and ux', () => {
@@ -101,6 +102,7 @@ describe('getSkillsToRemove', () => {
     assert.ok(result.includes('visual-audit'));
     assert.ok(result.includes('ux-audit'));
     assert.ok(result.includes('ui-audit'));
+    assert.ok(result.includes('accessibility-audit'));
     assert.ok(!result.includes('perf-audit'));
     assert.ok(!result.includes('skill-dev'));
   });
@@ -164,6 +166,7 @@ describe('getActiveSkills', () => {
     assert.ok(result.includes('visual-audit'));
     assert.ok(result.includes('ux-audit'));
     assert.ok(result.includes('ui-audit'));
+    assert.ok(result.includes('accessibility-audit'));
   });
 
   it('tier M hasDatabase=false excludes migration-audit', () => {
@@ -189,6 +192,22 @@ describe('getActiveSkills', () => {
     assert.ok(!result.includes('visual-audit'));
     assert.ok(!result.includes('ux-audit'));
     assert.ok(!result.includes('ui-audit'));
+    assert.ok(!result.includes('accessibility-audit'));
+  });
+
+  it('tier M hasFrontend=true includes accessibility-audit', () => {
+    const result = getActiveSkills({ tier: 'm', hasFrontend: true });
+    assert.ok(result.includes('accessibility-audit'));
+  });
+
+  it('tier S excludes accessibility-audit (minTier m)', () => {
+    const result = getActiveSkills({ tier: 's', hasFrontend: true });
+    assert.ok(!result.includes('accessibility-audit'));
+  });
+
+  it('tier L hasFrontend=true includes accessibility-audit', () => {
+    const result = getActiveSkills({ tier: 'l', hasFrontend: true });
+    assert.ok(result.includes('accessibility-audit'));
   });
 
   it('tier M hasDesignSystem=false excludes ui-audit but keeps other frontend', () => {
@@ -239,9 +258,10 @@ describe('getCheatsheetSkillsToRemove', () => {
     assert.equal(result.length, 2);
   });
 
-  it('only returns skills that have cheatsheet=true', () => {
+  it('hasFrontend=false removes accessibility-audit from cheatsheet (only frontend skill with cheatsheet=true)', () => {
     const result = getCheatsheetSkillsToRemove({ techStack: 'node-ts', hasFrontend: false });
-    // frontend skills have cheatsheet: false, so none returned
-    assert.equal(result.length, 0);
+    // Frontend skills with cheatsheet=false (responsive/visual/ux/ui-audit) are not returned;
+    // accessibility-audit has cheatsheet=true and requires hasFrontend → returned.
+    assert.deepEqual(result, ['accessibility-audit']);
   });
 });


### PR DESCRIPTION
## Summary

Consolidates accessibility concerns into a single skill. Extracts axe-core WCAG + APCA contrast + static a11y patterns from `/ui-audit` and `/visual-audit`.

- **New skill**: `/accessibility-audit` (Tier M/L, `hasFrontend=true`). Three modes: `static` (A1-A8 grep), `full` (+APCA C1-C3 via Playwright), `wcag` (+axe-core 4.9.1). Backlog prefix `A11Y-`.
- **Narrowed**: `/ui-audit` → design-system only (static, no Playwright). `/visual-audit` → 10 aesthetic dimensions, scoring `/50`.
- **Pipeline Phase 5d Track A**: `/ui-audit` (static, concurrent) → `/accessibility-audit` → `/visual-audit` → `/ux-audit` → `/responsive-audit`.

Closes #60. Follows #59 (`/migration-audit`) as the second of 4 Q1 skills.

## Why consolidate

A11y was scattered across 3 skills (ui-audit, visual-audit, responsive-audit) with no single source of truth. Extracting gives users one skill to run for a11y coverage and maps cleanly to SOC2/HIPAA checklists. Responsive a11y (tap targets, reflow) stays in `/responsive-audit` — viewport-specific by nature.

## Scope changes

| File | Change |
|---|---|
| `/ui-audit` SKILL.md | CHECK 11/13/14/16/17 + S4/S6/S7 + Step 4 (axe-core) moved out → gap markers with cross-ref. allowed-tools trimmed to Read/Glob/Grep. |
| `/visual-audit` SKILL.md | V8 removed; V4 APCA anchors removed; page score `/55 → /50` with recalibrated buckets; scoring rule updated. |
| `skill-registry.js` | +1 entry (`accessibility-audit`). Registry size 15 → 16. |
| Pipeline (tier-m, tier-l, live) | Phase 5d Track A order; `A11Y-` in prefix list. |

## Test plan

- [x] Unit tests: 278/278 pass (31 in `skill-registry.test.js`, new gating tests for M/L inclusion and Tier S exclusion)
- [x] Integration tests: 498/498 pass (assertions added in Tier S / Tier M full / Tier L full / pruning scenarios)
- [x] Dry-run node-ts-full (hasFrontend=true): `accessibility-audit` present
- [x] Dry-run swift (hasFrontend=true): `accessibility-audit` present (native stack, no excludeNative)
- [x] Grep verification: no stale `axe-core` / `APCA` references remain in `/ui-audit` or `/visual-audit` beyond intentional cross-refs
- [ ] Validate on 1-2 real projects before proceeding to #61 `/doc-audit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)