### PR TITLE
docs: fix stale references after v1.10.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.10.0] — 2026-04-17
+
+### Added
+- `/skill-review` skill (Tier M lite, Tier L full) — quality review pipeline for skill portfolios. Includes 5 supporting documents: REVIEW_FRAMEWORK.md, SEVERITY_SCALE.md, SPEC_SNAPSHOT.md, SKILLS_INVENTORY.md, CALIBRATION_KIT.md. Tier M skips Phase 4 (external LLM) and Phase 9 (midpoint drift). Tier L runs full pipeline.
+- 19 reference files across 15 skills: PATTERNS.md (10), CHECKS.md (2), REPORT.md (6), DIMENSIONS.md (1) — stack-scaffolded patterns separated from skill body logic.
+
+### Changed
+- Pipeline v2 body purity: all 17 SKILL.md files reworked — framework-specific patterns (grep commands, CSS utilities, Tailwind classes, SwiftUI literals) extracted from bodies into reference files. Bodies contain only universal principles. Net -2009 lines.
+- Configuration sections added to security-audit (`[SITEMAP_OR_ROUTE_LIST]`), perf-audit (`[PERF_TOOL]`, `[PROFILER_COMMAND]`), skill-dev (`[LINT_COMMAND]`).
+- skill-dev: scope filter for stack-specific check exclusion, refactoring-backlog.md fallback for missing file, D8 native stack clarification.
+- Skill registry: 18 entries (added skill-review).
+- `add skill` command: 18 skills available.
+- Cross-validated by 4 LLMs (GPT-4.1, Gemini 2.5 Pro, Mistral Large, Sonar Pro) + 36 behavioral fixture cases across 6 high-risk skills.
+- Integration checks: 536 (was 533).
+
+---
+
 ## [Unreleased] — v1.9.1
 
 ### Added
@@ -16,17 +33,17 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `new skill` command - interactive wizard to scaffold custom skills with valid frontmatter, test fixture, and CLAUDE.md registration (#55)
 - `claudemd-update.js` shared utility - extracted CLAUDE.md Active Skills registration for reuse across commands
 - `.github/drift-tracker/` - weekly GitHub Action that scrapes Anthropic docs for native features overlapping with CDK, opens `anthropic-drift` issues when overlap detected (#56)
-- `add skill <name>` command - install a single skill without full scaffold (12 skills available)
+- `add skill <name>` command - install a single skill without full scaffold (18 skills available)
 - `add rule <name>` command - install a single rule with stack-specific security variants (`--stack swift|kotlin|rust|dotnet|java|go`)
 - `custom-*` skill convention - user-created skills preserved across `upgrade` and `init` operations
 - `docs/custom-skills.md` - SKILL.md authoring guide (frontmatter schema, model selection, body patterns)
-- `skill-registry.js` - single source of truth for skill applicability rules (12 entries, 3 query functions)
+- `skill-registry.js` - single source of truth for skill applicability rules (18 entries, 3 query functions)
 - `.github/FUNDING.yml` - GitHub Sponsors enabled
 - `.github/ISSUE_TEMPLATE/skill_request.md` - issue template for new skill requests (tier, stack, install condition)
 - `.github/ISSUE_TEMPLATE/config.yml` - issue chooser; blank issues disabled, support redirected to Discussions Q&A
 - `.github/workflows/discussion-monitor.yml` - weekly cron: finds unanswered Q&A discussions (>14 days), creates summary issue
 - GitHub Project board populated with Q1-Q2 roadmap deliverables (14 issues across 2 milestones)
-- Skill `description` field in all 12 SKILL.md frontmatter files (max 250 chars, used by Claude for auto-invocation)
+- Skill `description` field in all 18 SKILL.md frontmatter files (max 250 chars, used by Claude for auto-invocation)
 
 ### Fixed
 - Hook `timeout` values corrected from milliseconds to seconds per Anthropic JSON schema (Tier M: 300000→300, Tier L: 600000→600)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ After init, open Claude Code and start working. The scaffold is active immediate
 
 Start at Tier 0. Move up when you need more structure: `npx mg-claude-dev-kit upgrade --tier=m`
 
-### 15 audit skills
+### 16 audit skills
 
 Executable multi-step programs that run inside Claude Code. Not prompt instructions - structured audit workflows with model routing (haiku for mechanical checks, sonnet for analysis).
 
@@ -67,6 +67,7 @@ Executable multi-step programs that run inside Claude Code. Not prompt instructi
 | `/ui-audit` | M L | Design token compliance, component adoption, empty states. |
 | `/accessibility-audit` | M L | axe-core WCAG 2.2, APCA contrast, static a11y (aria, tabindex, focus, labels). |
 | `/test-audit` | M L | Coverage (lcov/Istanbul/Cobertura/go/tarpaulin/xcresult), pyramid shape, anti-patterns (`.only`, skipped, empty, no-assertion, sleeps). |
+| `/skill-review` | M L | Quality review pipeline for skill portfolios. Spec compliance, cross-tier coherence, behavioral fixtures. |
 
 Skills are conditionally installed based on your project: `hasApi`, `hasDatabase`, `hasFrontend`, `hasDesignSystem`.
 

--- a/docs/operational-guide.md
+++ b/docs/operational-guide.md
@@ -693,7 +693,7 @@ Defined in the `CLAUDE.md` template for Tier M/L. Governs how Claude handles non
 
 ## 10. Audit skills
 
-Fourteen audit skills are scaffolded across the tiers. Run them as slash commands in Claude Code at any time - no pipeline phase required. Skills are **conditionally installed** based on wizard answers at init time.
+Sixteen audit skills are scaffolded across the tiers. Run them as slash commands in Claude Code at any time - no pipeline phase required. Skills are **conditionally installed** based on wizard answers at init time.
 
 All skill applicability rules are managed by a central skill registry (`packages/cli/src/scaffold/skill-registry.js`). Each skill declares which tiers and project conditions it requires.
 
@@ -716,6 +716,7 @@ All skill applicability rules are managed by a central skill registry (`packages
 | `/ui-audit` | - | x | x | `hasFrontend=true` AND `hasDesignSystem=true` | - (static) |
 | `/accessibility-audit` | - | x | x | `hasFrontend=true` | Dev server + Playwright MCP (for full/wcag modes; static mode needs nothing) |
 | `/test-audit` | - | x | x | always (no `requires`) | - (static analysis) |
+| `/skill-review` | - | x | x | always | - (static analysis) |
 
 ### General rules
 
@@ -852,6 +853,12 @@ Checks:
 - **Anti-patterns (T1-T8, all stack-adapted)**: T1 `.only`/`fit`/`fdescribe` committed (Critical), T2 skipped tests (Medium; High if > 10% of suite), T3 `.todo` placeholders (Low), T4 empty test bodies (High), T5 tests without assertions (High), T6 hardcoded sleeps ≥ 500ms (Medium), T7 debug output left in tests (Low), T8 multi-file `.only` pattern (Critical).
 
 Universal gating: installed on every Tier M/L project regardless of feature flags (no `requires`). Backlog prefix: `TEST-`. Flaky-test detection and live re-run analysis are deferred - v1 is static-only.
+
+#### /skill-review
+
+**File**: `.claude/skills/skill-review/SKILL.md` | **Tier**: M (lite), L (full)
+
+Quality review pipeline for skill portfolios. Orchestrates Phase 1 preflight (C1-C8 spec compliance), Phase 2 structural review (fundamentals, cross-tier coherence, refinements, behavioral fixtures), Phase 3 fix + rollback, Phase 6 closeout. Tier M lite mode skips Phase 4 (external LLM review) and Phase 9 (midpoint drift check). Tier L full mode includes all phases. Includes 5 supporting documents: REVIEW_FRAMEWORK.md, SEVERITY_SCALE.md, SPEC_SNAPSHOT.md, SKILLS_INVENTORY.md, CALIBRATION_KIT.md.
 
 #### /simplify
 

--- a/packages/cli/templates/tier-l/.claude/skills/skill-review/CALIBRATION_KIT.md
+++ b/packages/cli/templates/tier-l/.claude/skills/skill-review/CALIBRATION_KIT.md
@@ -5,7 +5,7 @@
 **Bundled with**: `/skill-review` skill (for export to user projects)
 **Status**: reviewer-facing document. Read at cycle start and at Phase 9 midpoint.
 
-**Purpose**: prevent reviewer drift across a ~34-hour, 17-skill review cycle. Drift = unconscious deviation from the severity rubric when fatigue, repetition, or recent findings bias the next judgment.
+**Purpose**: prevent reviewer drift across a ~34-hour, 18-skill review cycle. Drift = unconscious deviation from the severity rubric when fatigue, repetition, or recent findings bias the next judgment.
 
 **When to read**:
 - Before starting skill #1 (cycle-start anchoring).

--- a/packages/cli/templates/tier-l/.claude/skills/skill-review/REVIEW_FRAMEWORK.md
+++ b/packages/cli/templates/tier-l/.claude/skills/skill-review/REVIEW_FRAMEWORK.md
@@ -5,7 +5,7 @@
 **Updated**: 2026-04-14 — cross-model review (Gemini 2.5 Pro + Mistral Large + GPT-4.1) integrated. 7 convergent structural fixes (C1-C7) + 3 single-model critical (T2.1 targeted / T2.3 / T2.4) applied.
 **Status**: Consolidated - ready for execution once pre-work artifacts P1-P5 are produced.
 
-**Purpose**: single source of truth for the quality review of all 17 CDK skills. Replaces any prior partial framework. Every check, decision point, and severity level lives here.
+**Purpose**: single source of truth for the quality review of all 18 CDK skills. Replaces any prior partial framework. Every check, decision point, and severity level lives here.
 
 ---
 
@@ -84,7 +84,7 @@ Five artifacts must exist before any skill review begins. Build in sequence with
 ### P3 - Canonical skills inventory
 
 **File**: `docs/reviews/skills-quality-review/skills-inventory.md`
-**Purpose**: reference table of all 17 skills with metadata. Enables cross-skill checks, conditional Phase 4 gating, stable baseline.
+**Purpose**: reference table of all 18 skills with metadata. Enables cross-skill checks, conditional Phase 4 gating, stable baseline.
 **Content**: name, tier, line count, model, allowed-tools, registry flags, placeholder list, subagent usage, effort field presence, supporting files, behavioral-fixture target (yes/no per D1), pre-existing LLM review (yes/no per O2).
 **Coverage check (T2.6)**: every skill under `packages/cli/templates/*/skills/` must have a P3 row. Missing rows block cycle start.
 **Status**: Pending.
@@ -421,7 +421,7 @@ Remaining before execution:
 - [ ] Retro-apply to ui-audit (Block C)
 
 Deferred to vNext (v1.3 or later):
-- T2.1 full — behavioral fixtures on all 17 skills (currently 6 only).
+- T2.1 full — behavioral fixtures on all 18 skills (currently 6 only).
 - T2.2 — bundle-level system behavior end-to-end check.
 - R3 — export mode split (lite / audit / portfolio).
 - Second-reviewer sample (D5 defer).

--- a/packages/cli/templates/tier-l/.claude/skills/skill-review/SKILLS_INVENTORY.md
+++ b/packages/cli/templates/tier-l/.claude/skills/skill-review/SKILLS_INVENTORY.md
@@ -52,7 +52,7 @@
 | 11 | simplify | ✓ | ✓ | ✓ | 3 | cross-tier | haiku model |
 | 12 | skill-db | - | ✓ | ✓ | 4 | cross-tier | live SQL verification; SKILL.md + REPORT.md per tier |
 | 13 | skill-dev | ✓ | ✓ | ✓ | 3 | cross-tier | code quality audit |
-| 14 | test-audit | - | ✓ | ✓ | 4 | cross-tier | recently added (v1.9.1); SKILL.md + REPORT.md per tier |
+| 14 | test-audit | - | ✓ | ✓ | 4 | cross-tier | SKILL.md + PATTERNS.md + REPORT.md per tier |
 | 15 | ui-audit | - | ✓ | ✓ | 4 | cross-tier | static grep, token compliance; SKILL.md + PATTERNS.md per tier |
 | 16 | ux-audit | - | ✓ | ✓ | 2 | cross-tier | Playwright, opus model |
 | 17 | visual-audit | - | ✓ | ✓ | 4 | cross-tier | Playwright, opus model; SKILL.md + DIMENSIONS.md per tier |

--- a/packages/cli/templates/tier-m/.claude/skills/skill-review/CALIBRATION_KIT.md
+++ b/packages/cli/templates/tier-m/.claude/skills/skill-review/CALIBRATION_KIT.md
@@ -5,7 +5,7 @@
 **Bundled with**: `/skill-review` skill (for export to user projects)
 **Status**: reviewer-facing document. Read at cycle start and at Phase 9 midpoint.
 
-**Purpose**: prevent reviewer drift across a ~34-hour, 17-skill review cycle. Drift = unconscious deviation from the severity rubric when fatigue, repetition, or recent findings bias the next judgment.
+**Purpose**: prevent reviewer drift across a ~34-hour, 18-skill review cycle. Drift = unconscious deviation from the severity rubric when fatigue, repetition, or recent findings bias the next judgment.
 
 **When to read**:
 - Before starting skill #1 (cycle-start anchoring).

--- a/packages/cli/templates/tier-m/.claude/skills/skill-review/REVIEW_FRAMEWORK.md
+++ b/packages/cli/templates/tier-m/.claude/skills/skill-review/REVIEW_FRAMEWORK.md
@@ -5,7 +5,7 @@
 **Updated**: 2026-04-14 — cross-model review (Gemini 2.5 Pro + Mistral Large + GPT-4.1) integrated. 7 convergent structural fixes (C1-C7) + 3 single-model critical (T2.1 targeted / T2.3 / T2.4) applied.
 **Status**: Consolidated - ready for execution once pre-work artifacts P1-P5 are produced.
 
-**Purpose**: single source of truth for the quality review of all 17 CDK skills. Replaces any prior partial framework. Every check, decision point, and severity level lives here.
+**Purpose**: single source of truth for the quality review of all 18 CDK skills. Replaces any prior partial framework. Every check, decision point, and severity level lives here.
 
 ---
 
@@ -84,7 +84,7 @@ Five artifacts must exist before any skill review begins. Build in sequence with
 ### P3 - Canonical skills inventory
 
 **File**: `docs/reviews/skills-quality-review/skills-inventory.md`
-**Purpose**: reference table of all 17 skills with metadata. Enables cross-skill checks, conditional Phase 4 gating, stable baseline.
+**Purpose**: reference table of all 18 skills with metadata. Enables cross-skill checks, conditional Phase 4 gating, stable baseline.
 **Content**: name, tier, line count, model, allowed-tools, registry flags, placeholder list, subagent usage, effort field presence, supporting files, behavioral-fixture target (yes/no per D1), pre-existing LLM review (yes/no per O2).
 **Coverage check (T2.6)**: every skill under `packages/cli/templates/*/skills/` must have a P3 row. Missing rows block cycle start.
 **Status**: Pending.
@@ -421,7 +421,7 @@ Remaining before execution:
 - [ ] Retro-apply to ui-audit (Block C)
 
 Deferred to vNext (v1.3 or later):
-- T2.1 full — behavioral fixtures on all 17 skills (currently 6 only).
+- T2.1 full — behavioral fixtures on all 18 skills (currently 6 only).
 - T2.2 — bundle-level system behavior end-to-end check.
 - R3 — export mode split (lite / audit / portfolio).
 - Second-reviewer sample (D5 defer).

--- a/packages/cli/templates/tier-m/.claude/skills/skill-review/SKILLS_INVENTORY.md
+++ b/packages/cli/templates/tier-m/.claude/skills/skill-review/SKILLS_INVENTORY.md
@@ -52,7 +52,7 @@
 | 11 | simplify | ✓ | ✓ | ✓ | 3 | cross-tier | haiku model |
 | 12 | skill-db | - | ✓ | ✓ | 4 | cross-tier | live SQL verification; SKILL.md + REPORT.md per tier |
 | 13 | skill-dev | ✓ | ✓ | ✓ | 3 | cross-tier | code quality audit |
-| 14 | test-audit | - | ✓ | ✓ | 4 | cross-tier | recently added (v1.9.1); SKILL.md + REPORT.md per tier |
+| 14 | test-audit | - | ✓ | ✓ | 4 | cross-tier | SKILL.md + PATTERNS.md + REPORT.md per tier |
 | 15 | ui-audit | - | ✓ | ✓ | 4 | cross-tier | static grep, token compliance; SKILL.md + PATTERNS.md per tier |
 | 16 | ux-audit | - | ✓ | ✓ | 2 | cross-tier | Playwright, opus model |
 | 17 | visual-audit | - | ✓ | ✓ | 4 | cross-tier | Playwright, opus model; SKILL.md + DIMENSIONS.md per tier |


### PR DESCRIPTION
## Summary

- CHANGELOG.md: add v1.10.0 section, update skill counts (12→18)
- README.md: add /skill-review to skills table (15→16 skills)
- operational-guide.md: add /skill-review to availability table and detail section (14→16 skills)
- REVIEW_FRAMEWORK.md: 17→18 CDK skills (tier-m + tier-l)
- CALIBRATION_KIT.md: 17→18 skill review cycle (tier-m + tier-l)
- SKILLS_INVENTORY.md: remove stale v1.9.1 reference (tier-m + tier-l)

## Test plan

- [x] Integration tests: 536/536 green
- [x] No code changes - docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)