### PR TITLE
chore: remove stale roadmap reference from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,9 +79,8 @@ When work starts or completes on a roadmap item (any issue linked to a GitHub mi
 
 **On completion** (PR created, before merging):
 1. `.claude/initiatives/roadmap-status.md` — set status to `Done`, record end date and PR number
-2. `docs/reviews/roadmap-v1.9.1.md` — update the deliverable's Status column to **Done** with PR reference
-3. GitHub Project board — set status to Done, update start/target dates via `gh api graphql`
-4. Close the GitHub issue with implementation summary
+2. GitHub Project board — set status to Done, update start/target dates via `gh api graphql`
+3. Close the GitHub issue with implementation summary
 
 These updates are part of the commit sequence (docs commit), not a post-merge afterthought.
 


### PR DESCRIPTION
## Summary
- Removes dangling reference to deleted `docs/reviews/roadmap-v1.9.1.md` from CLAUDE.md "On completion" checklist
- Roadmap tracking is now consolidated in `.claude/initiatives/roadmap-status.md` (gitignored, local-only)

## Local-only changes (not in this PR)
- Deleted `docs/reviews/cross-model-synthesis-v1.9.1.md` and `agnosticity-synthesis.md` (historical, findings already applied)
- Added 3 new Q2 items to roadmap-status.md:
  - Anthropic spec compliance (`allowed-tools` syntax + progressive disclosure)
  - `doctor` expansion (cross-file scaffold validation)
  - External review prompt template update
- Preserved 3 source files in `docs/reviews/` for future roadmap work

## Test plan
- [ ] CI passes (no functional changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)