### PR TITLE
chore: v1.10.3 arch-audit findings resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.10.3] — 2026-04-23
+
+### Fixed
+- arch-audit H1a grep pattern missed 15 hook events (StopFailure, PostToolUseFailure, SubagentStart/Stop, TaskCreated, PermissionRequest/Denied, TeammateIdle, SessionEnd, FileChanged, CwdChanged, ConfigChange, UserPromptExpansion, Elicitation/Result) — would have falsely flagged StopFailure already in use.
+- arch-audit C17 regex false-positive on arch-audit itself (self-referential `mcp__` in grep pattern) — added skip-by-name + `^allowed-tools:` anchor.
+- tier-l cheatsheet out of sync with skills dir: 5 skills missing (arch-audit, commit, context-review, dependency-scan, skill-review) — restored to parity with tier-m + added context-review row (tier-l exclusive).
+- tier-l settings.json hook `model: "claude-haiku-4-5"` undocumented short-form → alias `haiku` (matches 41 SKILL.md frontmatter convention).
+- tier-s settings.json deny missing `Bash(git push origin main*)` — baseline main protection restored.
+- tier-l settings.json deny missing `Bash(DROP TABLE*)`, `Bash(TRUNCATE*)` — regression vs tier-m.
+
+### Updated
+- arch-audit "new events worth adding" catalogue refreshed with 6 events (UserPromptExpansion, SessionEnd, TeammateIdle, TaskCreated, PostToolUseFailure, PermissionRequest) + note on new `type: "mcp_tool"` hook type (v2.1.118).
+- claudemd-standards.md: hook events list v2.1.85 → v2.1.118 (22 → 27 events, `Last verified: 2026-04-23`).
+
+### Unchanged
+- No code changes in CLI source — template-only release. Integration 828/828, unit 270/270.
+
+---
+
 ## [1.10.2] — 2026-04-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Covers: file structure per tier, Stop hook presence, pipeline gate counts, place
 
 See [GitHub Milestones](https://github.com/marcoguillermaz/claude-dev-kit/milestones) for the 12-month plan.
 
-**Current**: v1.10.2 - Cross-stack audit fixes (Node-TS + Python), Opus 4.7 alignment, 828 integration + 270 unit tests across 29 scenarios.
+**Current**: v1.10.3 - arch-audit findings resolution: H1a grep covers 27 hook events, C17 regex false-positive fix, claudemd-standards refreshed to v2.1.118, tier-l cheatsheet/deny parity. 828 integration + 270 unit tests.
 
 **Next**: Q2 skills (`/compliance-audit`, `/api-contract-audit`, `/infra-audit`) and `/doc-audit` to close Q1 skill block.
 

--- a/docs/operational-guide.md
+++ b/docs/operational-guide.md
@@ -1,6 +1,6 @@
 # claude-dev-kit - Operational Guide
 
-**Version**: 1.10.2
+**Version**: 1.10.3
 **Audience**: Builder PMs, tech leads, and senior developers using Claude Code - from first exploration to structured, reviewable delivery
 **Format**: Reference + step-by-step. Read section 1 and your target tier section first, then use the rest as a lookup.
 
@@ -1231,4 +1231,4 @@ Nine example fixtures are in `packages/cli/test/fixtures/wizard-answers/`. Copy 
 
 ---
 
-*Last updated: 2026-04-19 - v1.10.2*
+*Last updated: 2026-04-23 - v1.10.3*

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mg-claude-dev-kit",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "description": "Scaffold for legible, reviewable AI-assisted development",
   "type": "module",
   "bin": {

--- a/packages/cli/templates/common/claudemd-standards.md
+++ b/packages/cli/templates/common/claudemd-standards.md
@@ -1,6 +1,6 @@
 # CLAUDE.md Standards Reference
 
-Last verified: 2026-03-27
+Last verified: 2026-04-23
 Update protocol: update only when `/arch-audit` detects a material change in official sources. Manual review required - no auto-update.
 
 ## Sources
@@ -92,8 +92,8 @@ Apply this test to every line: **"Would removing this cause Claude to make mista
 - **`InstructionsLoaded` hook**: use exclusively for debugging CLAUDE.md/rules load order - not for general logic. *(Source: 2)*
 - **Conditional `if` field** (v2.1.85+): `"if": "Bash(git *)"` uses permission rule syntax to filter hook activations. *(Source: 3)*
 
-**Available hook events (as of v2.1.85):**
-`SessionStart` · `UserPromptSubmit` · `PreToolUse` · `PostToolUse` · `PostToolUseFailure` · `PermissionRequest` · `Stop` · `SubagentStop` · `TaskCreated` · `TaskCompleted` · `InstructionsLoaded` · `CwdChanged` · `FileChanged` · `PreCompact` · `PostCompact` · `WorktreeCreate` · `ConfigChange` · `StopFailure` · `Elicitation` · `ElicitationResult` · `TeammateIdle` · `SessionEnd`
+**Available hook events (as of v2.1.118):**
+`SessionStart` · `SessionEnd` · `UserPromptSubmit` · `UserPromptExpansion` · `PreToolUse` · `PostToolUse` · `PostToolUseFailure` · `PermissionRequest` · `PermissionDenied` · `Stop` · `StopFailure` · `SubagentStart` · `SubagentStop` · `TaskCreated` · `TaskCompleted` · `InstructionsLoaded` · `CwdChanged` · `FileChanged` · `PreCompact` · `PostCompact` · `WorktreeCreate` · `WorktreeRemove` · `ConfigChange` · `Notification` · `Elicitation` · `ElicitationResult` · `TeammateIdle`
 
 ---
 

--- a/packages/cli/templates/tier-l/.claude/cheatsheet.md
+++ b/packages/cli/templates/tier-l/.claude/cheatsheet.md
@@ -34,6 +34,8 @@ Run these on demand. Each skill reads the codebase, produces a structured report
 
 | Skill | What it checks | When to run |
 |---|---|---|
+| `/arch-audit` | CLAUDE.md compliance, Anthropic docs drift, ecosystem consistency, hook config | Weekly; after upgrading Claude Code; after changing CLAUDE.md |
+| `/commit` | Classify staged changes, generate conventional commit message, execute commit | After every implementation phase to commit work |
 | `/security-audit` | Auth guards, input validation, sensitive data in responses, HTTP headers | Before production deploy; after adding new API routes |
 | `/skill-dev` | Coupling, duplication, dead code, magic strings, oversized components | Before major refactoring; quarterly review |
 | `/skill-db` | Missing indexes, access control gaps, constraint completeness, N+1 queries | After migration waves; before production releases |
@@ -47,6 +49,9 @@ Run these on demand. Each skill reads the codebase, produces a structured report
 | `/ui-audit` | Design system token compliance, component adoption, empty/error/loading states | After UI changes; when design system is configured |
 | `/test-audit` | Coverage (lcov/Istanbul/Cobertura/go/tarpaulin/xcresult), pyramid shape, anti-patterns (`.only`, skipped, empty, no-assertion, sleeps) | After Phase 3 tests green; every block |
 | `/simplify` | Early returns, nesting depth, local duplication, dead code, magic values | After writing code (Phase 2); on demand |
+| `/dependency-scan` | Route hrefs, import consumers, shared type consumers, test refs, FK refs, access control | Phase 1 mandatory; before finalizing file list |
+| `/skill-review` | Skill quality audit: structural review, severity calibration, fix verification | After modifying skills; quarterly review cycle |
+| `/context-review` | Phase 8.5 grep checks C1–C3: credential patterns, unresolved placeholders, field name staleness | Before `/compact` at end of block; C4–C12 judgment checks run in main session |
 
 > **Before first run**: open each SKILL.md and replace the `[PLACEHOLDER]` values with the real paths for this project.
 > **Prerequisites for screenshot-based skills**: dev server must be running (check your project's dev command for the URL).

--- a/packages/cli/templates/tier-l/.claude/settings.json
+++ b/packages/cli/templates/tier-l/.claude/settings.json
@@ -24,7 +24,9 @@
       "Bash(rm -rf /*)",
       "Bash(chmod 777*)",
       "Bash(npm publish*)",
-      "Bash(DROP DATABASE*)"
+      "Bash(DROP DATABASE*)",
+      "Bash(DROP TABLE*)",
+      "Bash(TRUNCATE*)"
     ]
   },
   "hooks": {
@@ -43,7 +45,7 @@
           {
             "type": "prompt",
             "prompt": "Review the code changes in this session. Check for: (1) hardcoded secrets or credentials, (2) missing input validation on API endpoints, (3) SQL injection or command injection patterns, (4) missing auth checks. If critical issues found, return {\"decision\": \"block\", \"reason\": \"...\"}. If clean, return {\"ok\": true}.",
-            "model": "claude-haiku-4-5"
+            "model": "haiku"
           }
         ]
       }

--- a/packages/cli/templates/tier-l/.claude/skills/arch-audit/SKILL.md
+++ b/packages/cli/templates/tier-l/.claude/skills/arch-audit/SKILL.md
@@ -114,7 +114,7 @@ Every RECOMMEND must include: (1) specific file path(s) to modify, (2) section o
 | C14   | `git check-ignore -q CLAUDE.md && echo "PASS" \|\| echo "FAIL"`                                                                                                                          | PASS             |
 | C15   | `wc -l CLAUDE.md \| awk '{print $1}'`                                                                                                                                                    | ≤200             |
 | C16   | `grep -rn "claude-3-haiku\|claude-3-5-haiku\|claude-3-opus\|claude-3-sonnet\|claude-3-5-sonnet\|claude-sonnet-4-20250514\|claude-opus-4-20250514" .claude/skills/ .claude/settings.json` | 0 matches        |
-| C17   | `for f in .claude/skills/*/SKILL.md; do if grep -q "mcp__" "$f" && ! grep -q "allowed-tools:" "$f"; then echo "MISSING allowed-tools: $f"; fi; done`                                     | 0 MISSING lines  |
+| C17   | `for f in .claude/skills/*/SKILL.md; do name=$(basename $(dirname "$f")); [ "$name" = "arch-audit" ] && continue; if grep -q "mcp__" "$f" && ! grep -q "^allowed-tools:" "$f"; then echo "MISSING allowed-tools: $f"; fi; done`                                     | 0 MISSING lines  |
 
 Collect batch results, then run judgment-tier checks below. For each FAIL: classify as AUTO-FIX or RECOMMEND using the same criteria as Step 3.
 
@@ -187,12 +187,17 @@ Also flag any of the following new events from recent Claude Code releases that 
 - `WorktreeCreate` / `WorktreeRemove` - auto-setup / teardown logic when worktrees change
 - `SubagentStart` / `SubagentStop` - logging or context injection for subagent calls
 - `PreCompact` - save critical in-progress state before context compression
-- `TaskCompleted` - post-completion summary or notification
+- `TaskCreated` / `TaskCompleted` - lifecycle hooks for task delegation (distinct events)
 - `FileChanged` - lint/format trigger on file write
-- `PermissionDenied` - auto-mode classifier denial handling (return `retry: true` for alternative approach)
+- `PermissionRequest` / `PermissionDenied` - permission flow interception (distinct events: request decides upfront, denied fires after rejection; return `retry: true` for alternative approach)
+- `PostToolUseFailure` - recovery logic when a tool call fails after execution
 - `Elicitation` / `ElicitationResult` - MCP server user-input request interception
 - `ConfigChange` - config source change detection
 - `CwdChanged` - working directory change handling
+- `SessionEnd` - session teardown / final logging
+- `UserPromptExpansion` - intercept prompt after macro/template expansion
+- `TeammateIdle` - multi-agent coordination (notify when a teammate agent is idle)
+- Hook type `type: "mcp_tool"` (v2.1.118+) - hooks can invoke MCP tools directly
   These are RECOMMEND, not AUTO-FIX.
 
 Additionally, verify awareness of these recent Claude Code capabilities:
@@ -234,7 +239,7 @@ AUTO-FIX: replace deprecated model IDs with the current equivalents:
 
 **C17 - `allowed-tools` frontmatter on MCP-dependent skills**
 Check: any SKILL.md that calls `mcp__*` tools in its instructions must declare those tools in `allowed-tools:` frontmatter. This ensures Claude requests the correct permissions upfront before the skill runs, preventing mid-execution permission prompts.
-Run: `for f in .claude/skills/*/SKILL.md; do if grep -q "mcp__" "$f" && ! grep -q "allowed-tools:" "$f"; then echo "MISSING allowed-tools: $f"; fi; done`
+Run: `for f in .claude/skills/*/SKILL.md; do name=$(basename $(dirname "$f")); [ "$name" = "arch-audit" ] && continue; if grep -q "mcp__" "$f" && ! grep -q "^allowed-tools:" "$f"; then echo "MISSING allowed-tools: $f"; fi; done`
 Expected: 0 MISSING lines. Any match = FAIL.
 AUTO-FIX: for each failing skill, read the `mcp__*` tool names from its body and add `allowed-tools: [mcp__tool1, mcp__tool2, ...]` to its frontmatter after the `context:` line.
 
@@ -435,7 +440,7 @@ Using hook documentation fetched in Step 1 (`https://code.claude.com/docs/en/hoo
 
 **H1a - Event name currency**
 Check: every event name in `settings.json` hooks matches the current official event list.
-Run: `grep -o '"SessionStart"\|"UserPromptSubmit"\|"PreToolUse"\|"PostToolUse"\|"Stop"\|"WorktreeCreate"\|"WorktreeRemove"\|"PostCompact"\|"PreCompact"\|"InstructionsLoaded"\|"Notification"\|"TaskCompleted"' .claude/settings.json | sort -u`
+Run: `grep -o '"SessionStart"\|"SessionEnd"\|"UserPromptSubmit"\|"UserPromptExpansion"\|"PreToolUse"\|"PostToolUse"\|"PostToolUseFailure"\|"Stop"\|"StopFailure"\|"PermissionRequest"\|"PermissionDenied"\|"SubagentStart"\|"SubagentStop"\|"TaskCreated"\|"TaskCompleted"\|"TeammateIdle"\|"FileChanged"\|"CwdChanged"\|"ConfigChange"\|"PreCompact"\|"PostCompact"\|"InstructionsLoaded"\|"Notification"\|"Elicitation"\|"ElicitationResult"\|"WorktreeCreate"\|"WorktreeRemove"' .claude/settings.json | sort -u`
 Pass: all events appear in the Step 1 documentation. Any unrecognized event → RECOMMEND removal or rename.
 
 **H1b - JSON response field compliance (prompt hooks)**

--- a/packages/cli/templates/tier-m/.claude/skills/arch-audit/SKILL.md
+++ b/packages/cli/templates/tier-m/.claude/skills/arch-audit/SKILL.md
@@ -114,7 +114,7 @@ Every RECOMMEND must include: (1) specific file path(s) to modify, (2) section o
 | C14   | `git check-ignore -q CLAUDE.md && echo "PASS" \|\| echo "FAIL"`                                                                                                                          | PASS             |
 | C15   | `wc -l CLAUDE.md \| awk '{print $1}'`                                                                                                                                                    | ≤200             |
 | C16   | `grep -rn "claude-3-haiku\|claude-3-5-haiku\|claude-3-opus\|claude-3-sonnet\|claude-3-5-sonnet\|claude-sonnet-4-20250514\|claude-opus-4-20250514" .claude/skills/ .claude/settings.json` | 0 matches        |
-| C17   | `for f in .claude/skills/*/SKILL.md; do if grep -q "mcp__" "$f" && ! grep -q "allowed-tools:" "$f"; then echo "MISSING allowed-tools: $f"; fi; done`                                     | 0 MISSING lines  |
+| C17   | `for f in .claude/skills/*/SKILL.md; do name=$(basename $(dirname "$f")); [ "$name" = "arch-audit" ] && continue; if grep -q "mcp__" "$f" && ! grep -q "^allowed-tools:" "$f"; then echo "MISSING allowed-tools: $f"; fi; done`                                     | 0 MISSING lines  |
 
 Collect batch results, then run judgment-tier checks below. For each FAIL: classify as AUTO-FIX or RECOMMEND using the same criteria as Step 3.
 
@@ -187,12 +187,17 @@ Also flag any of the following new events from recent Claude Code releases that 
 - `WorktreeCreate` / `WorktreeRemove` - auto-setup / teardown logic when worktrees change
 - `SubagentStart` / `SubagentStop` - logging or context injection for subagent calls
 - `PreCompact` - save critical in-progress state before context compression
-- `TaskCompleted` - post-completion summary or notification
+- `TaskCreated` / `TaskCompleted` - lifecycle hooks for task delegation (distinct events)
 - `FileChanged` - lint/format trigger on file write
-- `PermissionDenied` - auto-mode classifier denial handling (return `retry: true` for alternative approach)
+- `PermissionRequest` / `PermissionDenied` - permission flow interception (distinct events: request decides upfront, denied fires after rejection; return `retry: true` for alternative approach)
+- `PostToolUseFailure` - recovery logic when a tool call fails after execution
 - `Elicitation` / `ElicitationResult` - MCP server user-input request interception
 - `ConfigChange` - config source change detection
 - `CwdChanged` - working directory change handling
+- `SessionEnd` - session teardown / final logging
+- `UserPromptExpansion` - intercept prompt after macro/template expansion
+- `TeammateIdle` - multi-agent coordination (notify when a teammate agent is idle)
+- Hook type `type: "mcp_tool"` (v2.1.118+) - hooks can invoke MCP tools directly
   These are RECOMMEND, not AUTO-FIX.
 
 Additionally, verify awareness of these recent Claude Code capabilities:
@@ -234,7 +239,7 @@ AUTO-FIX: replace deprecated model IDs with the current equivalents:
 
 **C17 - `allowed-tools` frontmatter on MCP-dependent skills**
 Check: any SKILL.md that calls `mcp__*` tools in its instructions must declare those tools in `allowed-tools:` frontmatter. This ensures Claude requests the correct permissions upfront before the skill runs, preventing mid-execution permission prompts.
-Run: `for f in .claude/skills/*/SKILL.md; do if grep -q "mcp__" "$f" && ! grep -q "allowed-tools:" "$f"; then echo "MISSING allowed-tools: $f"; fi; done`
+Run: `for f in .claude/skills/*/SKILL.md; do name=$(basename $(dirname "$f")); [ "$name" = "arch-audit" ] && continue; if grep -q "mcp__" "$f" && ! grep -q "^allowed-tools:" "$f"; then echo "MISSING allowed-tools: $f"; fi; done`
 Expected: 0 MISSING lines. Any match = FAIL.
 AUTO-FIX: for each failing skill, read the `mcp__*` tool names from its body and add `allowed-tools: [mcp__tool1, mcp__tool2, ...]` to its frontmatter after the `context:` line.
 
@@ -435,7 +440,7 @@ Using hook documentation fetched in Step 1 (`https://code.claude.com/docs/en/hoo
 
 **H1a - Event name currency**
 Check: every event name in `settings.json` hooks matches the current official event list.
-Run: `grep -o '"SessionStart"\|"UserPromptSubmit"\|"PreToolUse"\|"PostToolUse"\|"Stop"\|"WorktreeCreate"\|"WorktreeRemove"\|"PostCompact"\|"PreCompact"\|"InstructionsLoaded"\|"Notification"\|"TaskCompleted"' .claude/settings.json | sort -u`
+Run: `grep -o '"SessionStart"\|"SessionEnd"\|"UserPromptSubmit"\|"UserPromptExpansion"\|"PreToolUse"\|"PostToolUse"\|"PostToolUseFailure"\|"Stop"\|"StopFailure"\|"PermissionRequest"\|"PermissionDenied"\|"SubagentStart"\|"SubagentStop"\|"TaskCreated"\|"TaskCompleted"\|"TeammateIdle"\|"FileChanged"\|"CwdChanged"\|"ConfigChange"\|"PreCompact"\|"PostCompact"\|"InstructionsLoaded"\|"Notification"\|"Elicitation"\|"ElicitationResult"\|"WorktreeCreate"\|"WorktreeRemove"' .claude/settings.json | sort -u`
 Pass: all events appear in the Step 1 documentation. Any unrecognized event → RECOMMEND removal or rename.
 
 **H1b - JSON response field compliance (prompt hooks)**

--- a/packages/cli/templates/tier-s/.claude/settings.json
+++ b/packages/cli/templates/tier-s/.claude/settings.json
@@ -14,6 +14,7 @@
     ],
     "deny": [
       "Bash(git push --force*)",
+      "Bash(git push origin main*)",
       "Bash(rm -rf /*)",
       "Bash(npm publish*)",
       "Bash(DROP DATABASE*)"

--- a/packages/cli/templates/tier-s/.claude/skills/arch-audit/SKILL.md
+++ b/packages/cli/templates/tier-s/.claude/skills/arch-audit/SKILL.md
@@ -114,7 +114,7 @@ Every RECOMMEND must include: (1) specific file path(s) to modify, (2) section o
 | C14   | `git check-ignore -q CLAUDE.md && echo "PASS" \|\| echo "FAIL"`                                                                                                                          | PASS             |
 | C15   | `wc -l CLAUDE.md \| awk '{print $1}'`                                                                                                                                                    | ≤200             |
 | C16   | `grep -rn "claude-3-haiku\|claude-3-5-haiku\|claude-3-opus\|claude-3-sonnet\|claude-3-5-sonnet\|claude-sonnet-4-20250514\|claude-opus-4-20250514" .claude/skills/ .claude/settings.json` | 0 matches        |
-| C17   | `for f in .claude/skills/*/SKILL.md; do if grep -q "mcp__" "$f" && ! grep -q "allowed-tools:" "$f"; then echo "MISSING allowed-tools: $f"; fi; done`                                     | 0 MISSING lines  |
+| C17   | `for f in .claude/skills/*/SKILL.md; do name=$(basename $(dirname "$f")); [ "$name" = "arch-audit" ] && continue; if grep -q "mcp__" "$f" && ! grep -q "^allowed-tools:" "$f"; then echo "MISSING allowed-tools: $f"; fi; done`                                     | 0 MISSING lines  |
 
 Collect batch results, then run judgment-tier checks below. For each FAIL: classify as AUTO-FIX or RECOMMEND using the same criteria as Step 3.
 
@@ -187,12 +187,17 @@ Also flag any of the following new events from recent Claude Code releases that 
 - `WorktreeCreate` / `WorktreeRemove` - auto-setup / teardown logic when worktrees change
 - `SubagentStart` / `SubagentStop` - logging or context injection for subagent calls
 - `PreCompact` - save critical in-progress state before context compression
-- `TaskCompleted` - post-completion summary or notification
+- `TaskCreated` / `TaskCompleted` - lifecycle hooks for task delegation (distinct events)
 - `FileChanged` - lint/format trigger on file write
-- `PermissionDenied` - auto-mode classifier denial handling (return `retry: true` for alternative approach)
+- `PermissionRequest` / `PermissionDenied` - permission flow interception (distinct events: request decides upfront, denied fires after rejection; return `retry: true` for alternative approach)
+- `PostToolUseFailure` - recovery logic when a tool call fails after execution
 - `Elicitation` / `ElicitationResult` - MCP server user-input request interception
 - `ConfigChange` - config source change detection
 - `CwdChanged` - working directory change handling
+- `SessionEnd` - session teardown / final logging
+- `UserPromptExpansion` - intercept prompt after macro/template expansion
+- `TeammateIdle` - multi-agent coordination (notify when a teammate agent is idle)
+- Hook type `type: "mcp_tool"` (v2.1.118+) - hooks can invoke MCP tools directly
   These are RECOMMEND, not AUTO-FIX.
 
 Additionally, verify awareness of these recent Claude Code capabilities:
@@ -234,7 +239,7 @@ AUTO-FIX: replace deprecated model IDs with the current equivalents:
 
 **C17 - `allowed-tools` frontmatter on MCP-dependent skills**
 Check: any SKILL.md that calls `mcp__*` tools in its instructions must declare those tools in `allowed-tools:` frontmatter. This ensures Claude requests the correct permissions upfront before the skill runs, preventing mid-execution permission prompts.
-Run: `for f in .claude/skills/*/SKILL.md; do if grep -q "mcp__" "$f" && ! grep -q "allowed-tools:" "$f"; then echo "MISSING allowed-tools: $f"; fi; done`
+Run: `for f in .claude/skills/*/SKILL.md; do name=$(basename $(dirname "$f")); [ "$name" = "arch-audit" ] && continue; if grep -q "mcp__" "$f" && ! grep -q "^allowed-tools:" "$f"; then echo "MISSING allowed-tools: $f"; fi; done`
 Expected: 0 MISSING lines. Any match = FAIL.
 AUTO-FIX: for each failing skill, read the `mcp__*` tool names from its body and add `allowed-tools: [mcp__tool1, mcp__tool2, ...]` to its frontmatter after the `context:` line.
 
@@ -435,7 +440,7 @@ Using hook documentation fetched in Step 1 (`https://code.claude.com/docs/en/hoo
 
 **H1a - Event name currency**
 Check: every event name in `settings.json` hooks matches the current official event list.
-Run: `grep -o '"SessionStart"\|"UserPromptSubmit"\|"PreToolUse"\|"PostToolUse"\|"Stop"\|"WorktreeCreate"\|"WorktreeRemove"\|"PostCompact"\|"PreCompact"\|"InstructionsLoaded"\|"Notification"\|"TaskCompleted"' .claude/settings.json | sort -u`
+Run: `grep -o '"SessionStart"\|"SessionEnd"\|"UserPromptSubmit"\|"UserPromptExpansion"\|"PreToolUse"\|"PostToolUse"\|"PostToolUseFailure"\|"Stop"\|"StopFailure"\|"PermissionRequest"\|"PermissionDenied"\|"SubagentStart"\|"SubagentStop"\|"TaskCreated"\|"TaskCompleted"\|"TeammateIdle"\|"FileChanged"\|"CwdChanged"\|"ConfigChange"\|"PreCompact"\|"PostCompact"\|"InstructionsLoaded"\|"Notification"\|"Elicitation"\|"ElicitationResult"\|"WorktreeCreate"\|"WorktreeRemove"' .claude/settings.json | sort -u`
 Pass: all events appear in the Step 1 documentation. Any unrecognized event → RECOMMEND removal or rename.
 
 **H1b - JSON response field compliance (prompt hooks)**


### PR DESCRIPTION
## Summary

Release v1.10.3 - template-only patch closing all findings from the 2026-04-23 arch-audit meta-audit (`docs/reviews/arch-audit-meta-2026-04-23.md`, local-only).

- Fixes 6 concrete gaps in `arch-audit` skill + `common/claudemd-standards.md` + tier-l/tier-s `settings.json` + tier-l `cheatsheet.md`
- Refreshes hook event list to Anthropic spec v2.1.118 (27 events)
- No CLI source changes - template patch only

## Findings closed

| ID | Area | Fix |
|---|---|---|
| M6.1 | `arch-audit/SKILL.md` H1a grep (x3 tier) | Pattern 12 → 27 hook events; catches `StopFailure` already in use |
| M6.2 | `arch-audit/SKILL.md` "new events" catalogue (x3 tier) | +6 events + `type: "mcp_tool"` hook type note |
| M4.1 | `arch-audit/SKILL.md` C17 regex (x3 tier) | Skip self-reference + `^allowed-tools:` anchor eliminates false positive |
| M7.1 | `common/claudemd-standards.md` | v2.1.85 → v2.1.118, 22 → 27 events, `Last verified: 2026-04-23` |
| M9.1 | `tier-l/cheatsheet.md` | +5 rows (arch-audit, commit, dependency-scan, skill-review, context-review) |
| M2.1 | `tier-l/settings.json:48` | `claude-haiku-4-5` undocumented → alias `haiku` |
| M9.2a | `tier-s/settings.json` deny | `+ Bash(git push origin main*)` (baseline main protection) |
| M9.2b | `tier-l/settings.json` deny | `+ Bash(DROP TABLE*)`, `+ Bash(TRUNCATE*)` (regression vs tier-m) |

## Deferred to v1.11.0

- M10.1 `effort: xhigh` on Opus skills - audience-dependent (Max subscribers only)
- M10.2 `paths:` conditional loading - requires stack-specific placeholder support
- M10.3 `if:` conditional hooks - requires validation against Claude Code runtime

## Test plan

- [x] `npm test` - 828/828 integration passed
- [x] `npm run test:unit` - 270/270 unit passed
- [x] C17 simulation on all 3 tiers - 0 MISSING (false positive eliminated)
- [x] JSON validity on all 3 `settings.json`
- [x] `arch-audit/SKILL.md` grep pattern contains all 15 previously-missing events
- [ ] Post-merge: tag `v1.10.3` + GitHub release with notes mirroring CHANGELOG
- [ ] Post-merge: verify `npm publish` (if applicable to mg-claude-dev-kit)