### PR TITLE
fix(drift-tracker): de-flake time-dependent test

### DIFF
--- a/.github/drift-tracker/check-drift.mjs
+++ b/.github/drift-tracker/check-drift.mjs
@@ -69,8 +69,8 @@ export function stripHtml(html) {
   return text.trim();
 }
 
-export function extractRecentChangelog(html, days = 7) {
-  const cutoff = new Date();
+export function extractRecentChangelog(html, days = 7, now = new Date()) {
+  const cutoff = new Date(now);
   cutoff.setDate(cutoff.getDate() - days);
   cutoff.setHours(0, 0, 0, 0);
 

--- a/.github/drift-tracker/test/check-drift.test.mjs
+++ b/.github/drift-tracker/test/check-drift.test.mjs
@@ -72,9 +72,9 @@ describe('extractRecentChangelog', () => {
   });
 
   it('filters entries older than N days', () => {
-    // Only entries from "today" perspective — fixture has April 11, April 5, March 20, Feb 15
-    // With days=10 from April 12 (test date), only April 5 and April 11 should pass
-    const entries = extractRecentChangelog(html, 10);
+    // Fixture has April 11, April 5, March 20, Feb 15 (2026)
+    // Reference date pinned to 2026-04-12 — with days=10, only April 5 and April 11 pass
+    const entries = extractRecentChangelog(html, 10, new Date('2026-04-12'));
     const versions = entries.map((e) => e.version);
     assert.ok(versions.includes('2.1.105'));
     // March 20 and Feb 15 should be filtered


### PR DESCRIPTION
## Summary

Fixes flaky CI failure on `CI / Drift tracker tests` caused by a time-dependent assertion in `extractRecentChangelog`. Not related to v1.10.3 - pre-existing latent bug that surfaced as the fixture dates (April–Feb 2026) aged out of the 10-day test window.

## Root cause

`extractRecentChangelog(html, days)` used `new Date()` internally as the cutoff reference. The test `filters entries older than N days` asserts `versions.includes('2.1.105')` (April 11 2026 entry) with `days=10`, which only holds if the test runs within 10 days of April 11. Once past that window, every fixture entry is filtered out and the assertion fails.

## Fix

- `check-drift.mjs:72` — accept `now` as the third parameter (default `new Date()`), matching the pattern already used by `currentWhatsNewUrl(now = new Date())` in the same file.
- `test/check-drift.test.mjs:77` — pin reference to `new Date('2026-04-12')`.

Production callers (scheduled workflow at line 242) unchanged since `now` defaults to `new Date()`.

## Test plan

- [x] `node --test .github/drift-tracker/test/check-drift.test.mjs` - 30/30 pass (previously 1 failing)
- [x] `npm test` - 828/828 integration
- [x] `npm run test:unit` - 270/270 unit
- [ ] Post-merge: CI `Drift tracker tests` green on main