### PR TITLE
chore: v1.10.4 - post-audit fixes, refactor consolidation, detect-stack coverage

### DIFF
--- a/.github/drift-tracker/check-drift.mjs
+++ b/.github/drift-tracker/check-drift.mjs
@@ -69,8 +69,8 @@ export function stripHtml(html) {
   return text.trim();
 }
 
-export function extractRecentChangelog(html, days = 7) {
-  const cutoff = new Date();
+export function extractRecentChangelog(html, days = 7, now = new Date()) {
+  const cutoff = new Date(now);
   cutoff.setDate(cutoff.getDate() - days);
   cutoff.setHours(0, 0, 0, 0);
 

--- a/.github/drift-tracker/test/check-drift.test.mjs
+++ b/.github/drift-tracker/test/check-drift.test.mjs
@@ -72,9 +72,9 @@ describe('extractRecentChangelog', () => {
   });
 
   it('filters entries older than N days', () => {
-    // Only entries from "today" perspective — fixture has April 11, April 5, March 20, Feb 15
-    // With days=10 from April 12 (test date), only April 5 and April 11 should pass
-    const entries = extractRecentChangelog(html, 10);
+    // Fixture has April 11, April 5, March 20, Feb 15 (2026)
+    // Reference date pinned to 2026-04-12 — with days=10, only April 5 and April 11 pass
+    const entries = extractRecentChangelog(html, 10, new Date('2026-04-12'));
     const versions = entries.map((e) => e.version);
     assert.ok(versions.includes('2.1.105'));
     // March 20 and Feb 15 should be filtered

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,20 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - CLI `--version` now reads from `package.json` at runtime (was hard-coded `1.6.1` — 4 releases of drift vs actual 1.10.3). Identified by `skill-dev` audit (J4).
+- Wizard `AUDIT_MODELS` option list no longer offers `claude-opus-4-6` (Legacy per Anthropic models page); replaced with `claude-opus-4-7`. Fixes the root cause for the `operational-guide.md:166` doc drift below.
+- `scaffold/index.js` `patchSettingsPermissions` no longer silently swallows malformed settings.json during stack-permission patching — now logs a `console.warn` that names the file, the target stack, and the underlying error. Prevents scaffolds from shipping default JS/Node permissions on native stacks with no user-visible signal. Two new unit tests assert the warning is emitted and the file content is left unchanged.
 
 ### Changed
 - `CONTRIBUTING.md` test counts refreshed to 828 integration + 270 unit (were 464/243, stale vs `README.md` and `CHANGELOG.md [1.10.3]`).
 - `docs/operational-guide.md:166` wizard recommendation for deep-analysis model updated from `claude-opus-4-6` (Legacy per Anthropic models page) to `claude-opus-4-7`.
 - `docs/operational-guide.md:43` + `:403` audit skill count aligned to 16 (was 15); added missing `skill-review` to the available-skills enumeration (added in v1.10.0, #58).
+- Extracted three policy limits to named constants in `utils/constants.js`: `SKILL_DESC_MAX_CHARS` (250), `CLAUDE_MD_MAX_LINES` (200), `STOP_HOOK_MAX_TIMEOUT_SEC` (600). Removes magic numbers from `new-skill.js` and `doctor.js`.
+- Consolidated `NATIVE_STACKS` usage — 7 inline literal arrays in `init-greenfield.js`, `init-in-place.js`, `scaffold/index.js` replaced with the canonical import from `skill-registry.js`. Added `WEB_STACKS` export in the same module and replaced 3 `webStacks` locals.
+- Unified `STACK_CMD_DEFAULTS` (claude-md.js) and `stackCommandDefaults` (scaffold/index.js) into a single `STACK_COMMANDS` table in the new `utils/stack-commands.js` module. Install/dev/build/test values were byte-identical; `typeCheck` has two consumer-specific shapes (`typeCheck` for the CLAUDE.md commands block, `typeCheckPlaceholder` for `[TYPE_CHECK_COMMAND]` template interpolation).
+
+### Removed
+- Unused `AUDIT_MODEL_DEFAULT` constant (0 consumers — confirmed via grep).
+- `export` keyword on `scaffoldTier0` — it is only called internally from `scaffoldTier` and not listed in `_testHelpers`, so the public surface shrinks with no external impact.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [1.10.4] — 2026-04-23
+
+### Added
+- Smoke test suite for `detect-stack.js` (20 tests across 2 describe blocks) covering stack identification markers for all 11 supported stacks (package.json ± tsconfig, pyproject.toml, go.mod, Gemfile, pom.xml, build.gradle.kts, build.gradle, Package.swift, .csproj, Cargo.toml) plus `suggestedTier` thresholds for the three calibrated brackets. Prerequisite coverage for the tier-threshold extraction below.
+
 ### Fixed
 - CLI `--version` now reads from `package.json` at runtime (was hard-coded `1.6.1` — 4 releases of drift vs actual 1.10.3). Identified by `skill-dev` audit (J4).
 - Wizard `AUDIT_MODELS` option list no longer offers `claude-opus-4-6` (Legacy per Anthropic models page); replaced with `claude-opus-4-7`. Fixes the root cause for the `operational-guide.md:166` doc drift below.
@@ -21,6 +28,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Extracted three policy limits to named constants in `utils/constants.js`: `SKILL_DESC_MAX_CHARS` (250), `CLAUDE_MD_MAX_LINES` (200), `STOP_HOOK_MAX_TIMEOUT_SEC` (600). Removes magic numbers from `new-skill.js` and `doctor.js`.
 - Consolidated `NATIVE_STACKS` usage — 7 inline literal arrays in `init-greenfield.js`, `init-in-place.js`, `scaffold/index.js` replaced with the canonical import from `skill-registry.js`. Added `WEB_STACKS` export in the same module and replaced 3 `webStacks` locals.
 - Unified `STACK_CMD_DEFAULTS` (claude-md.js) and `stackCommandDefaults` (scaffold/index.js) into a single `STACK_COMMANDS` table in the new `utils/stack-commands.js` module. Install/dev/build/test values were byte-identical; `typeCheck` has two consumer-specific shapes (`typeCheck` for the CLAUDE.md commands block, `typeCheckPlaceholder` for `[TYPE_CHECK_COMMAND]` template interpolation).
+- Extracted tier-suggestion thresholds into `utils/tier-suggestion.js`: 3 calibrated brackets (nodeWeb 100/30, medium 80/20, compact 60/15) plus `suggestTier(fileCount, thresholds)` helper. `detect-stack.js` 11 inline ternaries now delegate to the helper; values unchanged, single source of truth.
 
 ### Removed
 - Unused `AUDIT_MODEL_DEFAULT` constant (0 consumers — confirmed via grep).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- CLI `--version` now reads from `package.json` at runtime (was hard-coded `1.6.1` — 4 releases of drift vs actual 1.10.3). Identified by `skill-dev` audit (J4).
+
+### Changed
+- `CONTRIBUTING.md` test counts refreshed to 828 integration + 270 unit (were 464/243, stale vs `README.md` and `CHANGELOG.md [1.10.3]`).
+- `docs/operational-guide.md:166` wizard recommendation for deep-analysis model updated from `claude-opus-4-6` (Legacy per Anthropic models page) to `claude-opus-4-7`.
+- `docs/operational-guide.md:43` + `:403` audit skill count aligned to 16 (was 15); added missing `skill-review` to the available-skills enumeration (added in v1.10.0, #58).
+
+---
+
 ## [1.10.3] — 2026-04-23
 
 ### Fixed
@@ -82,7 +94,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
-## [Unreleased] — v1.9.1
+## [Pre-1.10.0 development log] — targeted v1.9.1, shipped as part of v1.10.0
 
 ### Added
 - `/test-audit` skill (Tier M/L, universal - no `requires`) - static test-suite quality audit. Parses coverage reports in 5 supported formats (lcov.info, Istanbul JSON, Cobertura XML, go coverage.out, tarpaulin JSON; xcresult optional via `xcrun xccov`). Pyramid shape classification (unit/integration/e2e) by path convention + framework imports. 8 anti-pattern checks (T1-T8): `.only`/`fit`/`fdescribe` committed, skipped tests, `.todo` placeholders, empty test bodies, tests without assertions, hardcoded sleeps, debug output in tests, multi-file `.only` broken CI. Backlog prefix `TEST-`. New Pipeline Phase 5d Track C runs for every block after Phase 3 is green. Critical findings (`.only` committed, 0% coverage on a file changed in the block) block Phase 6. Stack-aware across all 11 supported stacks; checks without a stack-specific pattern return `N/A - skipped for <stack>`. Flaky-test detection deferred; v1 is static-only (#58)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,8 +35,8 @@ node packages/cli/src/index.js add rule security --stack swift
 **Run tests:**
 
 ```bash
-node packages/cli/test/integration/run.js       # 464 integration checks
-node --test packages/cli/test/unit/*.test.js      # 243 unit tests
+node packages/cli/test/integration/run.js       # 828 integration checks
+node --test packages/cli/test/unit/*.test.js      # 270 unit tests
 ```
 
 All tests must pass before submitting a PR.

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Covers: file structure per tier, Stop hook presence, pipeline gate counts, place
 
 See [GitHub Milestones](https://github.com/marcoguillermaz/claude-dev-kit/milestones) for the 12-month plan.
 
-**Current**: v1.10.3 - arch-audit findings resolution: H1a grep covers 27 hook events, C17 regex false-positive fix, claudemd-standards refreshed to v2.1.118, tier-l cheatsheet/deny parity. 828 integration + 270 unit tests.
+**Current**: v1.10.4 - post-audit Phase 1+2 consolidation: CLI `--version` drift resolved, doc references refreshed (test counts, wizard model ID, skill count), stack constants unified (NATIVE_STACKS / WEB_STACKS / STACK_COMMANDS), scaffold silent-catch hardened with console.warn, detect-stack smoke coverage + tier threshold extraction. 828 integration + 292 unit tests.
 
 **Next**: Q2 skills (`/compliance-audit`, `/api-contract-audit`, `/infra-audit`) and `/doc-audit` to close Q1 skill block.
 

--- a/docs/operational-guide.md
+++ b/docs/operational-guide.md
@@ -40,7 +40,7 @@ Claude Code is a powerful CLI assistant that can read, write, and reason about y
 - A development pipeline Claude follows strictly - requirements reviewed before code is written, tests verified before declaring done
 - Pre-wired hooks that enforce the pipeline mechanically, not just as instructions
 - A tiered system matching process overhead to task complexity: a two-line bugfix does not go through the same process as a multi-week feature
-- 15 audit skills - executable multi-step programs with model routing (haiku for mechanical checks, sonnet for analysis)
+- 16 audit skills - executable multi-step programs with model routing (haiku for mechanical checks, sonnet for analysis)
 - Audit trails, commit attribution, secret scanning, and CODEOWNERS gates for full visibility over AI-generated changes
 - A discovery mechanism that teaches Claude about your existing codebase in a single structured session
 
@@ -163,7 +163,7 @@ For experienced users, the wizard asks:
   - "Do you use a component library or design system?" -> installs `/ui-audit`
   - "Design system name?" -> populates `[DESIGN_SYSTEM_NAME]` placeholder
   - "Track a PRD per feature block?" -> determines if `docs/prd/prd.md` is referenced in context review
-  - "Preferred model for deep analysis skills?" -> `claude-sonnet-4-6` (faster) or `claude-opus-4-6` (thorough)
+  - "Preferred model for deep analysis skills?" -> `claude-sonnet-4-6` (faster) or `claude-opus-4-7` (thorough)
 - Whether to include pre-commit config and `.github/` files
 
 Output: a fully scaffolded project directory with `CLAUDE.md`, pipeline rules, settings, and docs - ready to open in Claude Code.
@@ -400,7 +400,7 @@ npx mg-claude-dev-kit add skill commit
 
 This copies the SKILL.md file into `.claude/skills/<name>/` and appends it to the `## Active Skills` section in CLAUDE.md (if that section exists). No other files are modified.
 
-Available skills (15): `arch-audit`, `security-audit`, `perf-audit`, `skill-dev`, `simplify`, `commit`, `api-design`, `skill-db`, `migration-audit`, `visual-audit`, `ux-audit`, `responsive-audit`, `ui-audit`, `accessibility-audit`, `test-audit`.
+Available skills (16): `arch-audit`, `security-audit`, `perf-audit`, `skill-dev`, `skill-review`, `simplify`, `commit`, `api-design`, `skill-db`, `migration-audit`, `visual-audit`, `ux-audit`, `responsive-audit`, `ui-audit`, `accessibility-audit`, `test-audit`.
 
 Options:
 - `--force` - overwrite if the skill already exists

--- a/docs/operational-guide.md
+++ b/docs/operational-guide.md
@@ -1,6 +1,6 @@
 # claude-dev-kit - Operational Guide
 
-**Version**: 1.10.3
+**Version**: 1.10.4
 **Audience**: Builder PMs, tech leads, and senior developers using Claude Code - from first exploration to structured, reviewable delivery
 **Format**: Reference + step-by-step. Read section 1 and your target tier section first, then use the rest as a lookup.
 
@@ -1231,4 +1231,4 @@ Nine example fixtures are in `packages/cli/test/fixtures/wizard-answers/`. Copy 
 
 ---
 
-*Last updated: 2026-04-23 - v1.10.3*
+*Last updated: 2026-04-23 - v1.10.4*

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mg-claude-dev-kit",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "description": "Scaffold for legible, reviewable AI-assisted development",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/doctor.js
+++ b/packages/cli/src/commands/doctor.js
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 import fs from 'fs-extra';
 import path from 'path';
 import { execSync } from 'child_process';
+import { CLAUDE_MD_MAX_LINES, STOP_HOOK_MAX_TIMEOUT_SEC } from '../utils/constants.js';
 
 const checks = [
   {
@@ -29,15 +30,15 @@ const checks = [
   },
   {
     id: 'claude-md-size',
-    label: 'CLAUDE.md under 200 lines',
+    label: `CLAUDE.md under ${CLAUDE_MD_MAX_LINES} lines`,
     check: (cwd) => {
       const p = path.join(cwd, 'CLAUDE.md');
       if (!fs.existsSync(p)) return { pass: true, skip: true };
       const lines = fs.readFileSync(p, 'utf8').split('\n').length;
       return {
-        pass: lines <= 200,
+        pass: lines <= CLAUDE_MD_MAX_LINES,
         info: `${lines} lines`,
-        fix: 'Trim CLAUDE.md to under 200 lines. Move stable patterns to .claude/rules/ with path-scoped files.',
+        fix: `Trim CLAUDE.md to under ${CLAUDE_MD_MAX_LINES} lines. Move stable patterns to .claude/rules/ with path-scoped files.`,
       };
     },
   },
@@ -290,9 +291,12 @@ const checks = [
         if (stopHooks.length === 0) return { pass: true, skip: true };
         const allHaveTimeout = stopHooks.every((entry) => {
           // Timeout can be at outer level (entry.timeout) or inner level (entry.hooks[].timeout)
-          if (typeof entry.timeout === 'number' && entry.timeout <= 600) return true;
+          if (typeof entry.timeout === 'number' && entry.timeout <= STOP_HOOK_MAX_TIMEOUT_SEC)
+            return true;
           const inner = entry.hooks || [];
-          return inner.every((h) => typeof h.timeout === 'number' && h.timeout <= 600);
+          return inner.every(
+            (h) => typeof h.timeout === 'number' && h.timeout <= STOP_HOOK_MAX_TIMEOUT_SEC,
+          );
         });
         return {
           pass: allHaveTimeout,

--- a/packages/cli/src/commands/init-greenfield.js
+++ b/packages/cli/src/commands/init-greenfield.js
@@ -8,6 +8,7 @@ import { generateReadme } from '../generators/readme.js';
 import { scaffoldTier } from '../scaffold/index.js';
 import { printPlan, printNextSteps } from '../utils/print-plan.js';
 import { AUDIT_MODELS } from '../utils/constants.js';
+import { NATIVE_STACKS, WEB_STACKS } from '../scaffold/skill-registry.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const TEMPLATES_DIR = path.resolve(__dirname, '../../templates');
@@ -158,7 +159,7 @@ export async function initGreenfield(options) {
         type: 'input',
         name: 'devCommand',
         message: (a) => {
-          const isNative = ['swift', 'kotlin', 'rust', 'dotnet', 'java'].includes(a.techStack);
+          const isNative = NATIVE_STACKS.includes(a.techStack);
           return isNative
             ? 'Launch command (optional, leave blank to skip):'
             : 'Dev server command:';
@@ -182,7 +183,7 @@ export async function initGreenfield(options) {
         type: 'input',
         name: 'e2eCommand',
         message: (a) => {
-          const webStacks = ['node-ts', 'node-js', 'python', 'ruby'];
+          const webStacks = WEB_STACKS;
           if (webStacks.includes(a.techStack)) {
             return 'E2E test command (Playwright/Cypress - leave blank to skip):';
           }
@@ -256,7 +257,7 @@ export async function initGreenfield(options) {
         type: 'list',
         name: 'hasDesignSystem',
         message: (a) => {
-          const isNative = ['swift', 'kotlin', 'rust', 'dotnet', 'java', 'other'].includes(
+          const isNative = [...NATIVE_STACKS, 'other'].includes(
             a.techStack,
           );
           return isNative

--- a/packages/cli/src/commands/init-greenfield.js
+++ b/packages/cli/src/commands/init-greenfield.js
@@ -257,9 +257,7 @@ export async function initGreenfield(options) {
         type: 'list',
         name: 'hasDesignSystem',
         message: (a) => {
-          const isNative = [...NATIVE_STACKS, 'other'].includes(
-            a.techStack,
-          );
+          const isNative = [...NATIVE_STACKS, 'other'].includes(a.techStack);
           return isNative
             ? 'Do you follow a design guideline? (Apple HIG, Material Design, other) (controls whether ui-audit is included)'
             : 'Do you use a component library or design system? (shadcn, MUI, Tailwind…) (controls whether ui-audit is included)';

--- a/packages/cli/src/commands/init-in-place.js
+++ b/packages/cli/src/commands/init-in-place.js
@@ -10,6 +10,7 @@ import { generateClaudeMd } from '../generators/claude-md.js';
 import { generateContextImport } from '../generators/context-import.js';
 import { printPlan, printNextSteps } from '../utils/print-plan.js';
 import { AUDIT_MODELS } from '../utils/constants.js';
+import { NATIVE_STACKS, WEB_STACKS } from '../scaffold/skill-registry.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const TEMPLATES_DIR = path.resolve(__dirname, '../../templates');
@@ -135,7 +136,7 @@ export async function initInPlace(options) {
         type: 'input',
         name: 'devCommand',
         message: (a) => {
-          const isNative = ['swift', 'kotlin', 'rust', 'dotnet', 'java'].includes(a.techStack);
+          const isNative = NATIVE_STACKS.includes(a.techStack);
           return isNative
             ? 'Launch command (optional, leave blank to skip):'
             : 'Dev server command:';
@@ -180,7 +181,7 @@ export async function initInPlace(options) {
         type: 'input',
         name: 'e2eCommand',
         message: (a) => {
-          const webStacks = ['node-ts', 'node-js', 'python', 'ruby'];
+          const webStacks = WEB_STACKS;
           if (webStacks.includes(a.techStack)) {
             return 'E2E test command (Playwright/Cypress - reference only, leave blank to skip):';
           }
@@ -229,7 +230,7 @@ export async function initInPlace(options) {
         type: 'confirm',
         name: 'hasFrontend',
         message: (a) => {
-          const isNative = ['swift', 'kotlin', 'rust', 'dotnet', 'java'].includes(a.techStack);
+          const isNative = NATIVE_STACKS.includes(a.techStack);
           return isNative
             ? 'Does your project have a UI? (controls whether visual-audit and ux-audit are included)'
             : 'Does your project have a UI? (controls whether visual-audit, ux-audit, responsive-audit are included)';
@@ -244,7 +245,7 @@ export async function initInPlace(options) {
         type: 'confirm',
         name: 'hasDesignSystem',
         message: (a) => {
-          const isNative = ['swift', 'kotlin', 'rust', 'dotnet', 'java', 'other'].includes(
+          const isNative = [...NATIVE_STACKS, 'other'].includes(
             a.techStack,
           );
           return isNative

--- a/packages/cli/src/commands/init-in-place.js
+++ b/packages/cli/src/commands/init-in-place.js
@@ -245,9 +245,7 @@ export async function initInPlace(options) {
         type: 'confirm',
         name: 'hasDesignSystem',
         message: (a) => {
-          const isNative = [...NATIVE_STACKS, 'other'].includes(
-            a.techStack,
-          );
+          const isNative = [...NATIVE_STACKS, 'other'].includes(a.techStack);
           return isNative
             ? 'Do you follow a design guideline? (Apple HIG, Material Design, other) (controls whether ui-audit is included)'
             : 'Do you use a component library or design system? (shadcn, MUI, Tailwind…) (controls whether ui-audit is included)';

--- a/packages/cli/src/commands/new-skill.js
+++ b/packages/cli/src/commands/new-skill.js
@@ -3,6 +3,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import inquirer from 'inquirer';
 import { registerSkillInClaudeMd } from '../utils/claudemd-update.js';
+import { SKILL_DESC_MAX_CHARS } from '../utils/constants.js';
 
 // Standard Playwright MCP tools (sourced from visual-audit SKILL.md)
 const PLAYWRIGHT_TOOLS = [
@@ -86,7 +87,7 @@ assert.ok(frontmatter.includes('description:'), 'frontmatter must include descri
 assert.ok(frontmatter.includes('context: fork'), 'context must be fork');
 
 const desc = frontmatter.match(/description:\\s*(.+)/)?.[1] || '';
-assert.ok(desc.length <= 250, \`description too long: \${desc.length}/250\`);
+assert.ok(desc.length <= ${SKILL_DESC_MAX_CHARS}, \`description too long: \${desc.length}/${SKILL_DESC_MAX_CHARS}\`);
 
 if (content.includes('browser_')) {
   assert.ok(frontmatter.includes('allowed-tools'), 'Playwright skills must declare allowed-tools');
@@ -119,8 +120,8 @@ function validateSkillMd(content, dirName) {
   const descMatch = fm.match(/^description:\s*(.+)/m);
   if (descMatch) {
     const desc = descMatch[1].trim();
-    if (desc.length > 250) {
-      errors.push(`Description too long: ${desc.length}/250 chars`);
+    if (desc.length > SKILL_DESC_MAX_CHARS) {
+      errors.push(`Description too long: ${desc.length}/${SKILL_DESC_MAX_CHARS} chars`);
     } else if (desc.length < 10) {
       warnings.push(`Description very short: ${desc.length} chars (min recommended: 10)`);
     }
@@ -182,10 +183,11 @@ export async function newSkill(options) {
       {
         type: 'input',
         name: 'description',
-        message: 'One-line description (max 250 chars):',
+        message: `One-line description (max ${SKILL_DESC_MAX_CHARS} chars):`,
         validate: (v) => {
           if (!v || v.trim().length < 10) return 'Description must be at least 10 characters.';
-          if (v.trim().length > 250) return `Too long: ${v.trim().length}/250 chars.`;
+          if (v.trim().length > SKILL_DESC_MAX_CHARS)
+            return `Too long: ${v.trim().length}/${SKILL_DESC_MAX_CHARS} chars.`;
           return true;
         },
       },

--- a/packages/cli/src/generators/claude-md.js
+++ b/packages/cli/src/generators/claude-md.js
@@ -3,6 +3,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { interpolate } from '../scaffold/index.js';
 import { getActiveSkills, NATIVE_STACKS } from '../scaffold/skill-registry.js';
+import { STACK_COMMANDS } from '../utils/stack-commands.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const TEMPLATES_DIR = path.resolve(__dirname, '../../templates');
@@ -82,67 +83,8 @@ export async function generateClaudeMd(config, targetDir) {
   await fs.writeFile(path.join(targetDir, 'CLAUDE.md'), content);
 }
 
-const STACK_CMD_DEFAULTS = {
-  swift: {
-    install: '# no install step',
-    dev: 'swift run',
-    build: 'xcodebuild build',
-    test: 'xcodebuild test',
-    typeCheck: '',
-  },
-  kotlin: {
-    install: '# no install step',
-    dev: './gradlew run',
-    build: './gradlew build',
-    test: './gradlew test',
-    typeCheck: '',
-  },
-  rust: {
-    install: '# no install step',
-    dev: 'cargo run',
-    build: 'cargo build --release',
-    test: 'cargo test',
-    typeCheck: '',
-  },
-  dotnet: {
-    install: 'dotnet restore',
-    dev: 'dotnet run',
-    build: 'dotnet build',
-    test: 'dotnet test',
-    typeCheck: '',
-  },
-  java: {
-    install: 'mvn install',
-    dev: 'mvn exec:java',
-    build: 'mvn package',
-    test: 'mvn test',
-    typeCheck: '',
-  },
-  python: {
-    install: 'pip install -r requirements.txt',
-    dev: '',
-    build: '',
-    test: 'pytest',
-    typeCheck: '',
-  },
-  go: {
-    install: 'go mod download',
-    dev: 'go run .',
-    build: 'go build ./...',
-    test: 'go test ./...',
-    typeCheck: '',
-  },
-  ruby: {
-    install: 'bundle install',
-    dev: 'rails server',
-    build: '',
-    test: 'bundle exec rspec',
-    typeCheck: '',
-  },
-};
-
 function buildCommandsBlock(config) {
-  const ncd = STACK_CMD_DEFAULTS[config.techStack] || {};
+  const ncd = STACK_COMMANDS[config.techStack] || {};
   // Swift xcodebuild commands need -scheme to target the correct scheme
   const swiftScheme =
     config.techStack === 'swift' && config.projectName ? ` -scheme ${config.projectName}` : '';

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { readFileSync } from 'node:fs';
 import { program } from 'commander';
 import { init } from './commands/init.js';
 import { doctor } from './commands/doctor.js';
@@ -8,10 +9,14 @@ import { addSkill, addRule } from './commands/add.js';
 import { newSkill } from './commands/new-skill.js';
 import chalk from 'chalk';
 
+const pkg = JSON.parse(
+  readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+);
+
 program
   .name('claude-dev-kit')
   .description('Scaffold for legible, reviewable AI-assisted development')
-  .version('1.6.1');
+  .version(pkg.version);
 
 program
   .command('init')

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -9,9 +9,7 @@ import { addSkill, addRule } from './commands/add.js';
 import { newSkill } from './commands/new-skill.js';
 import chalk from 'chalk';
 
-const pkg = JSON.parse(
-  readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
-);
+const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
 
 program
   .name('claude-dev-kit')

--- a/packages/cli/src/scaffold/index.js
+++ b/packages/cli/src/scaffold/index.js
@@ -719,7 +719,10 @@ function interpolate(content, config) {
     .replace(/\[E2E_TOOL_NAME\]/g, resolveE2eToolName(config))
     .replace(
       /\[FRAMEWORK\]/g,
-      ['swift', 'kotlin', 'rust', 'dotnet'].includes(config.techStack)
+      // Note: 'java' intentionally omitted here — Java Spring/Quarkus are
+      // common server-side web frameworks, so java should fall through to
+      // the hasFrontend branch rather than auto-resolving to 'N/A - native app'.
+      NATIVE_STACKS.filter((s) => s !== 'java').includes(config.techStack)
         ? 'N/A - native app'
         : config.hasFrontend === false
           ? 'N/A - no web frontend'
@@ -727,8 +730,7 @@ function interpolate(content, config) {
     )
     .replace(
       /\[SITEMAP_OR_ROUTE_LIST\]/g,
-      config.hasFrontend === false ||
-        ['swift', 'kotlin', 'rust', 'dotnet', 'java'].includes(config.techStack)
+      config.hasFrontend === false || NATIVE_STACKS.includes(config.techStack)
         ? 'N/A - no web frontend'
         : 'docs/sitemap.md',
     )
@@ -742,7 +744,7 @@ function interpolate(content, config) {
     )
     .replace(
       /\[BUNDLE_TOOL\]/g,
-      ['swift', 'kotlin', 'rust', 'dotnet', 'java'].includes(config.techStack)
+      NATIVE_STACKS.includes(config.techStack)
         ? 'N/A - native app'
         : "your build tool's bundle analyzer",
     )

--- a/packages/cli/src/scaffold/index.js
+++ b/packages/cli/src/scaffold/index.js
@@ -246,8 +246,16 @@ async function patchSettingsPermissions(targetDir, config) {
       settings.permissions.deny = [...settings.permissions.deny, ...stackDeny];
     }
     await fs.writeFile(settingsPath, JSON.stringify(settings, null, 2) + '\n');
-  } catch {
-    // If settings.json is malformed, skip patching silently
+  } catch (err) {
+    // Previously silent — but a scaffold that ships default JS/Node
+    // permissions on a native stack because settings.json was malformed
+    // is a subtle correctness failure. Surface the problem so the user
+    // can fix the template or re-run with --force.
+    console.warn(
+      `[claude-dev-kit] Warning: could not patch ${settingsPath} — ${err.message}. ` +
+        `Stack-specific permissions for "${config.techStack}" were NOT applied; ` +
+        `the file may be malformed JSON or read-only.`,
+    );
   }
 }
 

--- a/packages/cli/src/scaffold/index.js
+++ b/packages/cli/src/scaffold/index.js
@@ -7,7 +7,7 @@ import { NATIVE_STACKS, getSkillsToRemove, getCheatsheetSkillsToRemove } from '.
  * CLAUDE.md is generated separately by generateClaudeMd() - not copied here.
  * No pipeline, no docs folder, no pre-commit, no .github.
  */
-export async function scaffoldTier0(targetDir, config, templatesDir) {
+async function scaffoldTier0(targetDir, config, templatesDir) {
   const tierDir = path.join(templatesDir, 'tier-0');
 
   // Copy Tier 0 files with interpolation (CLAUDE.md handled by generateClaudeMd)

--- a/packages/cli/src/scaffold/index.js
+++ b/packages/cli/src/scaffold/index.js
@@ -1,6 +1,7 @@
 import fs from 'fs-extra';
 import path from 'path';
 import { NATIVE_STACKS, getSkillsToRemove, getCheatsheetSkillsToRemove } from './skill-registry.js';
+import { STACK_COMMANDS } from '../utils/stack-commands.js';
 
 /**
  * Scaffold Tier 0 (Discovery) - minimal: settings.json, GETTING_STARTED.md only.
@@ -629,65 +630,7 @@ function interpolate(content, config) {
     other: 'Mixed',
   };
 
-  const stackCommandDefaults = {
-    swift: {
-      install: '# no install step',
-      dev: 'swift run',
-      build: 'xcodebuild build',
-      test: 'xcodebuild test',
-      typeCheck: '# type checking handled by compiler',
-    },
-    kotlin: {
-      install: '# no install step',
-      dev: './gradlew run',
-      build: './gradlew build',
-      test: './gradlew test',
-      typeCheck: '# type checking handled by compiler',
-    },
-    rust: {
-      install: '# no install step',
-      dev: 'cargo run',
-      build: 'cargo build --release',
-      test: 'cargo test',
-      typeCheck: '# type checking handled by compiler',
-    },
-    dotnet: {
-      install: 'dotnet restore',
-      dev: 'dotnet run',
-      build: 'dotnet build',
-      test: 'dotnet test',
-      typeCheck: '# type checking handled by compiler',
-    },
-    java: {
-      install: 'mvn install',
-      dev: 'mvn exec:java',
-      build: 'mvn package',
-      test: 'mvn test',
-      typeCheck: '# type checking handled by compiler',
-    },
-    python: {
-      install: 'pip install -r requirements.txt',
-      dev: '',
-      build: '',
-      test: 'pytest',
-      typeCheck: 'mypy .',
-    },
-    go: {
-      install: 'go mod download',
-      dev: 'go run .',
-      build: 'go build ./...',
-      test: 'go test ./...',
-      typeCheck: 'go vet ./...',
-    },
-    ruby: {
-      install: 'bundle install',
-      dev: 'rails server',
-      build: '',
-      test: 'bundle exec rspec',
-      typeCheck: '',
-    },
-  };
-  const ncd = stackCommandDefaults[config.techStack] || {};
+  const ncd = STACK_COMMANDS[config.techStack] || {};
   // Swift xcodebuild commands need -scheme to target the correct scheme
   const swiftScheme =
     config.techStack === 'swift' && config.projectName ? ` -scheme ${config.projectName}` : '';
@@ -700,7 +643,7 @@ function interpolate(content, config) {
     )
     .replace(
       /\[TYPE_CHECK_COMMAND\]/g,
-      config.typeCheckCommand || ncd.typeCheck || 'npx tsc --noEmit',
+      config.typeCheckCommand || ncd.typeCheckPlaceholder || 'npx tsc --noEmit',
     )
     .replace(
       /\[TEST_COMMAND\]/g,

--- a/packages/cli/src/scaffold/skill-registry.js
+++ b/packages/cli/src/scaffold/skill-registry.js
@@ -12,6 +12,13 @@
 export const NATIVE_STACKS = ['swift', 'kotlin', 'rust', 'dotnet', 'java'];
 
 /**
+ * Web-oriented stacks that typically carry a frontend bundle and a sitemap.
+ * Used for placeholder substitution and wizard branching — pair with
+ * NATIVE_STACKS for the complete tech-stack vocabulary.
+ */
+export const WEB_STACKS = ['node-ts', 'node-js', 'python', 'ruby'];
+
+/**
  * @typedef {Object} SkillEntry
  * @property {string}  name           - Skill directory name (matches SKILL.md parent folder)
  * @property {string}  minTier        - Lowest tier that includes this skill: 's', 'm', or 'l'

--- a/packages/cli/src/utils/constants.js
+++ b/packages/cli/src/utils/constants.js
@@ -2,3 +2,21 @@ export const AUDIT_MODELS = [
   { name: 'claude-sonnet-4-6 - faster, lower cost (recommended)', value: 'claude-sonnet-4-6' },
   { name: 'claude-opus-4-7 - more thorough, higher cost', value: 'claude-opus-4-7' },
 ];
+
+/**
+ * Maximum length of a SKILL.md `description:` frontmatter value.
+ * Enforced by new-skill wizard + validateSkillMd (CDK convention).
+ */
+export const SKILL_DESC_MAX_CHARS = 250;
+
+/**
+ * Maximum line count for a project CLAUDE.md before Anthropic's adherence
+ * guidance breaks down. Enforced by doctor check.
+ */
+export const CLAUDE_MD_MAX_LINES = 200;
+
+/**
+ * Maximum allowed timeout (seconds) for a Stop hook entry.
+ * Anthropic hook spec unit is seconds; enforced by doctor check.
+ */
+export const STOP_HOOK_MAX_TIMEOUT_SEC = 600;

--- a/packages/cli/src/utils/constants.js
+++ b/packages/cli/src/utils/constants.js
@@ -1,6 +1,4 @@
 export const AUDIT_MODELS = [
   { name: 'claude-sonnet-4-6 - faster, lower cost (recommended)', value: 'claude-sonnet-4-6' },
-  { name: 'claude-opus-4-6 - more thorough, higher cost', value: 'claude-opus-4-6' },
+  { name: 'claude-opus-4-7 - more thorough, higher cost', value: 'claude-opus-4-7' },
 ];
-
-export const AUDIT_MODEL_DEFAULT = 'claude-sonnet-4-6';

--- a/packages/cli/src/utils/detect-stack.js
+++ b/packages/cli/src/utils/detect-stack.js
@@ -1,5 +1,6 @@
 import fs from 'fs-extra';
 import path from 'path';
+import { TIER_THRESHOLDS, suggestTier } from './tier-suggestion.js';
 
 /**
  * Auto-detect tech stack and project characteristics from a directory.
@@ -96,7 +97,7 @@ export async function detectStack(dir) {
 
     // Complexity hints for tier suggestion
     const fileCount = await countFiles(dir, ['node_modules', '.git', '.next', 'dist', 'build']);
-    result.suggestedTier = fileCount > 100 ? 'l' : fileCount > 30 ? 'm' : 's';
+    result.suggestedTier = suggestTier(fileCount, TIER_THRESHOLDS.nodeWeb);
   } else if (
     (await exists('pyproject.toml')) ||
     (await exists('requirements.txt')) ||
@@ -128,7 +129,7 @@ export async function detectStack(dir) {
       '.venv',
       'node_modules',
     ]);
-    result.suggestedTier = fileCount > 80 ? 'l' : fileCount > 20 ? 'm' : 's';
+    result.suggestedTier = suggestTier(fileCount, TIER_THRESHOLDS.medium);
   } else if (await exists('go.mod')) {
     result.techStack = 'go';
     result.detectedFiles.push('go.mod');
@@ -138,7 +139,7 @@ export async function detectStack(dir) {
     result.devCommand = 'go run .';
 
     const fileCount = await countFiles(dir, ['.git', 'vendor']);
-    result.suggestedTier = fileCount > 60 ? 'l' : fileCount > 15 ? 'm' : 's';
+    result.suggestedTier = suggestTier(fileCount, TIER_THRESHOLDS.compact);
   } else if (await exists('Gemfile')) {
     result.techStack = 'ruby';
     result.detectedFiles.push('Gemfile');
@@ -148,7 +149,7 @@ export async function detectStack(dir) {
     result.devCommand = 'bundle exec rails server';
 
     const fileCount = await countFiles(dir, ['.git', '.bundle', 'tmp', 'log']);
-    result.suggestedTier = fileCount > 80 ? 'l' : fileCount > 20 ? 'm' : 's';
+    result.suggestedTier = suggestTier(fileCount, TIER_THRESHOLDS.medium);
   } else if (await exists('pom.xml')) {
     result.techStack = 'java';
     result.detectedFiles.push('pom.xml');
@@ -158,7 +159,7 @@ export async function detectStack(dir) {
     result.devCommand = 'mvn exec:java';
 
     const fileCount = await countFiles(dir, ['.git', 'target']);
-    result.suggestedTier = fileCount > 80 ? 'l' : fileCount > 20 ? 'm' : 's';
+    result.suggestedTier = suggestTier(fileCount, TIER_THRESHOLDS.medium);
   } else if ((await exists('build.gradle.kts')) || (await exists('AndroidManifest.xml'))) {
     result.techStack = 'kotlin';
     result.detectedFiles.push(
@@ -170,7 +171,7 @@ export async function detectStack(dir) {
     result.devCommand = './gradlew run';
 
     const fileCount = await countFiles(dir, ['.git', 'build', '.gradle']);
-    result.suggestedTier = fileCount > 80 ? 'l' : fileCount > 20 ? 'm' : 's';
+    result.suggestedTier = suggestTier(fileCount, TIER_THRESHOLDS.medium);
   } else if (await exists('build.gradle')) {
     // Java via Gradle (non-Kotlin) - build.gradle.kts already caught above
     result.techStack = 'java';
@@ -181,7 +182,7 @@ export async function detectStack(dir) {
     result.devCommand = './gradlew run';
 
     const fileCount = await countFiles(dir, ['.git', 'build', '.gradle']);
-    result.suggestedTier = fileCount > 60 ? 'l' : fileCount > 15 ? 'm' : 's';
+    result.suggestedTier = suggestTier(fileCount, TIER_THRESHOLDS.compact);
   } else if (await exists('Package.swift')) {
     result.techStack = 'swift';
     result.detectedFiles.push('Package.swift');
@@ -191,7 +192,7 @@ export async function detectStack(dir) {
     result.devCommand = 'swift run';
 
     const fileCount = await countFiles(dir, ['.git', '.build']);
-    result.suggestedTier = fileCount > 80 ? 'l' : fileCount > 20 ? 'm' : 's';
+    result.suggestedTier = suggestTier(fileCount, TIER_THRESHOLDS.medium);
   } else if ((await findDirEndingWith('.xcodeproj')) || (await findDirEndingWith('.xcworkspace'))) {
     result.techStack = 'swift';
     const detected =
@@ -203,7 +204,7 @@ export async function detectStack(dir) {
     result.installCommand = '';
 
     const fileCount = await countFiles(dir, ['.git', 'build', 'DerivedData']);
-    result.suggestedTier = fileCount > 80 ? 'l' : fileCount > 20 ? 'm' : 's';
+    result.suggestedTier = suggestTier(fileCount, TIER_THRESHOLDS.medium);
   } else if (
     (await existsFileMatching((n) => n.endsWith('.csproj'))) ||
     (await existsFileMatching((n) => n.endsWith('.sln')))
@@ -216,7 +217,7 @@ export async function detectStack(dir) {
     result.devCommand = 'dotnet run';
 
     const fileCount = await countFiles(dir, ['.git', 'bin', 'obj']);
-    result.suggestedTier = fileCount > 80 ? 'l' : fileCount > 20 ? 'm' : 's';
+    result.suggestedTier = suggestTier(fileCount, TIER_THRESHOLDS.medium);
   } else if (await exists('Cargo.toml')) {
     result.techStack = 'rust';
     result.detectedFiles.push('Cargo.toml');
@@ -226,7 +227,7 @@ export async function detectStack(dir) {
     result.devCommand = 'cargo run';
 
     const fileCount = await countFiles(dir, ['.git', 'target']);
-    result.suggestedTier = fileCount > 60 ? 'l' : fileCount > 15 ? 'm' : 's';
+    result.suggestedTier = suggestTier(fileCount, TIER_THRESHOLDS.compact);
   }
 
   return result;

--- a/packages/cli/src/utils/print-plan.js
+++ b/packages/cli/src/utils/print-plan.js
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import { execSync } from 'child_process';
-import { NATIVE_STACKS } from '../scaffold/skill-registry.js';
+import { NATIVE_STACKS, WEB_STACKS } from '../scaffold/skill-registry.js';
 
 const TIER_LABELS = { 0: 'Discovery', S: 'Fast Lane', M: 'Standard', L: 'Full' };
 
@@ -173,8 +173,7 @@ function getDoctorCmd() {
  */
 function getCommandSummary(config) {
   const lines = [];
-  const webStacks = ['node-ts', 'node-js', 'python', 'ruby'];
-  const isWeb = webStacks.includes(config.techStack);
+  const isWeb = WEB_STACKS.includes(config.techStack);
   const isNative = NATIVE_STACKS.includes(config.techStack);
 
   if (config.testCommand) {

--- a/packages/cli/src/utils/stack-commands.js
+++ b/packages/cli/src/utils/stack-commands.js
@@ -1,0 +1,86 @@
+/**
+ * Canonical per-stack command defaults.
+ *
+ * Consumed by:
+ *   - generators/claude-md.js  — builds the commands block rendered in
+ *                                 the generated CLAUDE.md.
+ *   - scaffold/index.js        — substitutes the [TYPE_CHECK_COMMAND]
+ *                                 placeholder while interpolating templates.
+ *
+ * The two consumers share install/dev/build/test verbatim but diverge on
+ * type-check rendering, so that field has two shapes:
+ *
+ *   typeCheck            — value rendered in CLAUDE.md commands block.
+ *                          Empty string = no type-check line emitted.
+ *   typeCheckPlaceholder — value substituted into the [TYPE_CHECK_COMMAND]
+ *                          placeholder during template interpolation.
+ *                          Native stacks use a comment explaining that
+ *                          type checking is handled by the compiler.
+ */
+
+export const STACK_COMMANDS = {
+  swift: {
+    install: '# no install step',
+    dev: 'swift run',
+    build: 'xcodebuild build',
+    test: 'xcodebuild test',
+    typeCheck: '',
+    typeCheckPlaceholder: '# type checking handled by compiler',
+  },
+  kotlin: {
+    install: '# no install step',
+    dev: './gradlew run',
+    build: './gradlew build',
+    test: './gradlew test',
+    typeCheck: '',
+    typeCheckPlaceholder: '# type checking handled by compiler',
+  },
+  rust: {
+    install: '# no install step',
+    dev: 'cargo run',
+    build: 'cargo build --release',
+    test: 'cargo test',
+    typeCheck: '',
+    typeCheckPlaceholder: '# type checking handled by compiler',
+  },
+  dotnet: {
+    install: 'dotnet restore',
+    dev: 'dotnet run',
+    build: 'dotnet build',
+    test: 'dotnet test',
+    typeCheck: '',
+    typeCheckPlaceholder: '# type checking handled by compiler',
+  },
+  java: {
+    install: 'mvn install',
+    dev: 'mvn exec:java',
+    build: 'mvn package',
+    test: 'mvn test',
+    typeCheck: '',
+    typeCheckPlaceholder: '# type checking handled by compiler',
+  },
+  python: {
+    install: 'pip install -r requirements.txt',
+    dev: '',
+    build: '',
+    test: 'pytest',
+    typeCheck: '',
+    typeCheckPlaceholder: 'mypy .',
+  },
+  go: {
+    install: 'go mod download',
+    dev: 'go run .',
+    build: 'go build ./...',
+    test: 'go test ./...',
+    typeCheck: '',
+    typeCheckPlaceholder: 'go vet ./...',
+  },
+  ruby: {
+    install: 'bundle install',
+    dev: 'rails server',
+    build: '',
+    test: 'bundle exec rspec',
+    typeCheck: '',
+    typeCheckPlaceholder: '',
+  },
+};

--- a/packages/cli/src/utils/tier-suggestion.js
+++ b/packages/cli/src/utils/tier-suggestion.js
@@ -1,0 +1,36 @@
+/**
+ * Tier suggestion thresholds — maps a project's file count to a
+ * scaffold tier ('s' | 'm' | 's') using ecosystem-calibrated brackets.
+ *
+ * Three categories are tuned empirically:
+ *
+ *   nodeWeb  — Node/TS/JS web projects typically carry many small files
+ *              (per-feature folders, route handlers, components); a
+ *              30-file project is still "small" by web standards.
+ *   medium   — Most app ecosystems (Python, Ruby, Java/Maven, Kotlin,
+ *              Swift, .NET); 20+ files signals meaningful size.
+ *   compact  — Terser ecosystems (Go, Rust, Java/Gradle) where one
+ *              file often equates to one module; 15+ is meaningful.
+ *
+ * Each entry: { lToM, mToS } — fileCount > lToM → 'l', > mToS → 'm',
+ * else 's'.
+ */
+
+export const TIER_THRESHOLDS = {
+  nodeWeb: { lToM: 100, mToS: 30 },
+  medium: { lToM: 80, mToS: 20 },
+  compact: { lToM: 60, mToS: 15 },
+};
+
+/**
+ * Map a file count to a suggested scaffold tier using the given
+ * threshold pair.
+ * @param {number} fileCount
+ * @param {{lToM: number, mToS: number}} thresholds
+ * @returns {'s' | 'm' | 'l'}
+ */
+export function suggestTier(fileCount, thresholds) {
+  if (fileCount > thresholds.lToM) return 'l';
+  if (fileCount > thresholds.mToS) return 'm';
+  return 's';
+}

--- a/packages/cli/test/unit/detect-stack.test.js
+++ b/packages/cli/test/unit/detect-stack.test.js
@@ -1,0 +1,185 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs-extra';
+import path from 'path';
+import os from 'os';
+import { detectStack } from '../../src/utils/detect-stack.js';
+
+describe('detectStack — tech stack identification', () => {
+  let tmpDir;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'cdk-detect-stack-'));
+  });
+
+  afterEach(async () => {
+    await fs.remove(tmpDir);
+  });
+
+  it('empty directory returns default "other" stack', async () => {
+    const result = await detectStack(tmpDir);
+    assert.equal(result.techStack, 'other');
+    assert.deepEqual(result.detectedFiles, []);
+  });
+
+  it('package.json + tsconfig.json → node-ts', async () => {
+    await fs.writeJson(path.join(tmpDir, 'package.json'), { name: 't', version: '0.0.1' });
+    await fs.writeJson(path.join(tmpDir, 'tsconfig.json'), { compilerOptions: {} });
+    const result = await detectStack(tmpDir);
+    assert.equal(result.techStack, 'node-ts');
+    assert.equal(result.typeCheckCommand, 'npx tsc --noEmit');
+    assert.ok(result.detectedFiles.includes('package.json'));
+  });
+
+  it('package.json without tsconfig → node-js', async () => {
+    await fs.writeJson(path.join(tmpDir, 'package.json'), { name: 't', version: '0.0.1' });
+    const result = await detectStack(tmpDir);
+    assert.equal(result.techStack, 'node-js');
+  });
+
+  it('package.json + typescript in devDependencies → node-ts', async () => {
+    await fs.writeJson(path.join(tmpDir, 'package.json'), {
+      name: 't',
+      devDependencies: { typescript: '^5.0.0' },
+    });
+    const result = await detectStack(tmpDir);
+    assert.equal(result.techStack, 'node-ts');
+  });
+
+  it('pyproject.toml → python', async () => {
+    await fs.writeFile(path.join(tmpDir, 'pyproject.toml'), '[project]\nname="t"\n');
+    const result = await detectStack(tmpDir);
+    assert.equal(result.techStack, 'python');
+    assert.equal(result.installCommand, 'pip install -r requirements.txt');
+    assert.equal(result.testCommand, 'pytest');
+  });
+
+  it('go.mod → go', async () => {
+    await fs.writeFile(path.join(tmpDir, 'go.mod'), 'module example\ngo 1.21\n');
+    const result = await detectStack(tmpDir);
+    assert.equal(result.techStack, 'go');
+    assert.equal(result.testCommand, 'go test ./...');
+  });
+
+  it('Gemfile → ruby', async () => {
+    await fs.writeFile(path.join(tmpDir, 'Gemfile'), "source 'https://rubygems.org'\n");
+    const result = await detectStack(tmpDir);
+    assert.equal(result.techStack, 'ruby');
+    assert.equal(result.installCommand, 'bundle install');
+  });
+
+  it('pom.xml → java', async () => {
+    await fs.writeFile(path.join(tmpDir, 'pom.xml'), '<project></project>');
+    const result = await detectStack(tmpDir);
+    assert.equal(result.techStack, 'java');
+    assert.equal(result.installCommand, 'mvn install');
+  });
+
+  it('build.gradle.kts → kotlin', async () => {
+    await fs.writeFile(path.join(tmpDir, 'build.gradle.kts'), 'plugins { kotlin("jvm") }');
+    const result = await detectStack(tmpDir);
+    assert.equal(result.techStack, 'kotlin');
+  });
+
+  it('build.gradle (non-kts) → java via gradle', async () => {
+    await fs.writeFile(path.join(tmpDir, 'build.gradle'), "apply plugin: 'java'");
+    const result = await detectStack(tmpDir);
+    assert.equal(result.techStack, 'java');
+  });
+
+  it('Package.swift → swift', async () => {
+    await fs.writeFile(path.join(tmpDir, 'Package.swift'), '// swift-tools-version:5.5\n');
+    const result = await detectStack(tmpDir);
+    assert.equal(result.techStack, 'swift');
+    assert.equal(result.testCommand, 'swift test');
+  });
+
+  it('*.csproj → dotnet', async () => {
+    await fs.writeFile(path.join(tmpDir, 'app.csproj'), '<Project></Project>');
+    const result = await detectStack(tmpDir);
+    assert.equal(result.techStack, 'dotnet');
+    assert.equal(result.installCommand, 'dotnet restore');
+  });
+
+  it('Cargo.toml → rust', async () => {
+    await fs.writeFile(path.join(tmpDir, 'Cargo.toml'), '[package]\nname = "t"\n');
+    const result = await detectStack(tmpDir);
+    assert.equal(result.techStack, 'rust');
+    assert.equal(result.testCommand, 'cargo test');
+  });
+});
+
+describe('detectStack — suggestedTier thresholds', () => {
+  let tmpDir;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'cdk-detect-tier-'));
+  });
+
+  afterEach(async () => {
+    await fs.remove(tmpDir);
+  });
+
+  async function writeNFiles(dir, n, ext = 'js') {
+    await Promise.all(
+      Array.from({ length: n }, (_, i) =>
+        fs.writeFile(path.join(dir, `file${i}.${ext}`), '// placeholder'),
+      ),
+    );
+  }
+
+  // Node-web thresholds: > 100 → 'l', > 30 → 'm', else 's'
+  it('node-ts with 10 files → suggestedTier "s"', async () => {
+    await fs.writeJson(path.join(tmpDir, 'package.json'), { name: 't' });
+    await fs.writeJson(path.join(tmpDir, 'tsconfig.json'), {});
+    await writeNFiles(tmpDir, 10, 'ts');
+    const result = await detectStack(tmpDir);
+    assert.equal(result.suggestedTier, 's');
+  });
+
+  it('node-ts with 50 files → suggestedTier "m"', async () => {
+    await fs.writeJson(path.join(tmpDir, 'package.json'), { name: 't' });
+    await fs.writeJson(path.join(tmpDir, 'tsconfig.json'), {});
+    await writeNFiles(tmpDir, 50, 'ts');
+    const result = await detectStack(tmpDir);
+    assert.equal(result.suggestedTier, 'm');
+  });
+
+  // Medium thresholds (python): > 80 → 'l', > 20 → 'm', else 's'
+  it('python with 10 files → suggestedTier "s"', async () => {
+    await fs.writeFile(path.join(tmpDir, 'pyproject.toml'), '[project]\nname="t"\n');
+    await writeNFiles(tmpDir, 10, 'py');
+    const result = await detectStack(tmpDir);
+    assert.equal(result.suggestedTier, 's');
+  });
+
+  it('python with 30 files → suggestedTier "m"', async () => {
+    await fs.writeFile(path.join(tmpDir, 'pyproject.toml'), '[project]\nname="t"\n');
+    await writeNFiles(tmpDir, 30, 'py');
+    const result = await detectStack(tmpDir);
+    assert.equal(result.suggestedTier, 'm');
+  });
+
+  // Compact thresholds (rust): > 60 → 'l', > 15 → 'm', else 's'
+  it('rust with 5 files → suggestedTier "s"', async () => {
+    await fs.writeFile(path.join(tmpDir, 'Cargo.toml'), '[package]\nname = "t"\n');
+    await writeNFiles(tmpDir, 5, 'rs');
+    const result = await detectStack(tmpDir);
+    assert.equal(result.suggestedTier, 's');
+  });
+
+  it('rust with 25 files → suggestedTier "m"', async () => {
+    await fs.writeFile(path.join(tmpDir, 'Cargo.toml'), '[package]\nname = "t"\n');
+    await writeNFiles(tmpDir, 25, 'rs');
+    const result = await detectStack(tmpDir);
+    assert.equal(result.suggestedTier, 'm');
+  });
+
+  // Go uses compact thresholds (same as rust)
+  it('go with 20 files → suggestedTier "m"', async () => {
+    await fs.writeFile(path.join(tmpDir, 'go.mod'), 'module example\n');
+    await writeNFiles(tmpDir, 20, 'go');
+    const result = await detectStack(tmpDir);
+    assert.equal(result.suggestedTier, 'm');
+  });
+});

--- a/packages/cli/test/unit/scaffold.test.js
+++ b/packages/cli/test/unit/scaffold.test.js
@@ -762,8 +762,48 @@ describe('patchSettingsPermissions', () => {
     const settingsPath = path.join(tmpDir, '.claude', 'settings.json');
     await fs.ensureDir(path.dirname(settingsPath));
     await fs.writeFile(settingsPath, '{ invalid json !!!');
-    await patchSettingsPermissions(tmpDir, { techStack: 'swift' });
+    // Suppress the expected warning to keep test output clean.
+    const origWarn = console.warn;
+    console.warn = () => {};
+    try {
+      await patchSettingsPermissions(tmpDir, { techStack: 'swift' });
+    } finally {
+      console.warn = origWarn;
+    }
     // should complete without error (catch block)
+  });
+
+  it('malformed JSON emits a console.warn surfacing the issue', async () => {
+    const settingsPath = path.join(tmpDir, '.claude', 'settings.json');
+    await fs.ensureDir(path.dirname(settingsPath));
+    await fs.writeFile(settingsPath, '{ invalid json !!!');
+    const warnings = [];
+    const origWarn = console.warn;
+    console.warn = (msg) => warnings.push(msg);
+    try {
+      await patchSettingsPermissions(tmpDir, { techStack: 'swift' });
+    } finally {
+      console.warn = origWarn;
+    }
+    assert.equal(warnings.length, 1, 'expected exactly one warning');
+    assert.match(warnings[0], /could not patch/i);
+    assert.match(warnings[0], /swift/i);
+  });
+
+  it('malformed JSON leaves the original file contents unchanged', async () => {
+    const settingsPath = path.join(tmpDir, '.claude', 'settings.json');
+    await fs.ensureDir(path.dirname(settingsPath));
+    const originalContent = '{ invalid json !!!';
+    await fs.writeFile(settingsPath, originalContent);
+    const origWarn = console.warn;
+    console.warn = () => {};
+    try {
+      await patchSettingsPermissions(tmpDir, { techStack: 'swift' });
+    } finally {
+      console.warn = origWarn;
+    }
+    const content = await fs.readFile(settingsPath, 'utf8');
+    assert.equal(content, originalContent);
   });
 
   it('go has no deny list - original deny preserved without additions', async () => {


### PR DESCRIPTION
## Summary

- **Phase 1 drift cleanup** — CLI `--version` fix (was stuck at 1.6.1 vs package.json 1.10.3), doc refreshes across `CONTRIBUTING.md` test counts, `docs/operational-guide.md` wizard model ID + skill count.
- **Phase 2 refactor consolidation** — `AUDIT_MODELS` data fix (root cause of the wizard drift), stack constants unified (`NATIVE_STACKS` 7 literal sites → 1 import, new `WEB_STACKS`, `STACK_COMMANDS` table replaces 2 parallel dictionaries), 3 policy limits extracted to named constants, scaffold silent-catch hardened with console.warn + 2 new unit tests, `scaffoldTier0` unexported, `AUDIT_MODEL_DEFAULT` removed.
- **Detect-stack coverage + refactor** — 20 smoke tests added (the module previously had 0 unit tests despite driving every init), then tier thresholds extracted to `utils/tier-suggestion.js` with a `suggestTier()` helper (11 inline ternaries now delegate).
- **Release v1.10.4 cut**: tag + GitHub release published, `[Unreleased]` section reset.

## Test plan

- [x] Unit tests: **292/292** pass (was 270 — 22 new from detect-stack suite + settings.json malformed-catch coverage)
- [x] Integration tests: **828/828** pass
- [x] `node packages/cli/src/index.js --version` emits `1.10.4`
- [x] GitHub release published at https://github.com/marcoguillermaz/claude-dev-kit/releases/tag/v1.10.4
- [x] No breaking changes — all consumer-visible CLI output preserved; wizard now offers `claude-opus-4-7` where the Legacy `claude-opus-4-6` was shown; all scaffolded outputs byte-identical for install/dev/build/test commands across the 8 supported stacks.

## Scope

13 commits total since branching from `main`:
- `f59324d` drift-tracker test de-flake (pre-existing, branch origin)
- 12 commits from this audit session covering the three bundles above
- Full detail in `CHANGELOG.md [1.10.4]` entry

## Audit provenance

Findings traced to two Opus audit runs against the project on 2026-04-23 (`arch-audit` + `skill-dev` skills installed locally). Each commit body references the originating finding code (J4, D4, D5, D8, J2, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)