### PR TITLE
v1.11.0: Anthropic spec compliance (allowed-tools + arch-audit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,6 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - `new-skill.js:validateSkillMd` migrated from inline regex frontmatter parsing to the shared `parseSkillFile` helper. Removes duplicate regex parser drift risk; behaviour preserved (unit tests unchanged).
-- `docs/reviews/anthropic-spec-deviations.md` refreshed: §2.4 classification closed (MAJOR via triangulation of Anthropic docs + isolated YAML parser test), §2.5 table updated with real 2026-04-24 line counts (perf-audit already compliant), §8 v1.11.0 status block added, footer `Last reviewed: 2026-04-24`.
 - Integration test count: 828 → 834 (6 new checks from `scenarioSkillMdSpecCompliance`, 2 assertions × 3 tiers).
 - Unit test count: 292 → 302 (10 new cases for `skill-frontmatter` helper).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,17 +11,46 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.11.0] — 2026-04-24
+
+### Fixed
+
+- `allowed-tools` frontmatter syntax in `skill-review` tier-m/tier-l SKILL.md (`Read, Glob, Grep, Bash` → `Read Glob Grep Bash`). Anthropic spec documents space-separated string or YAML list; the comma-separated form is a scalar value with literal commas (`js-yaml` verified), which under a spec-conformant parser resolves to tool names that do not exist (`Read,`, `Glob,`, `Grep,`) and silently drops pre-authorisation. The remaining 39 SKILL.md were already compliant.
+- `arch-audit` × 3 tier (tier-s/m/l) reduced from 508 to 360 body lines by extracting Step 3c (Prompting Guide P1–P5), Step 3d (token/subagent optimization T1–T5), and Step H1 (hook compliance H1a–H1f) into a sibling `advanced-checks.md` (173 lines, level 1 nesting per Anthropic spec). Closes Anthropic best-practice violation (≤ 500 lines) and CDK-C18 in `/arch-audit`.
+
+### Added
+
+- `doctor` check `skill-md-size-budget`: warns when any `.claude/skills/*/SKILL.md` body exceeds `SKILL_MD_MAX_LINES` (500, per Anthropic best practice).
+- `doctor` check `skill-allowed-tools-syntax`: warns on comma-separated `allowed-tools` values, preventing regression of the v1.11.0 fix.
+- Integration scenario `scenarioSkillMdSpecCompliance`: scaffolds tier-s/m/l and fails if any scaffolded SKILL.md exceeds 500 lines or uses comma syntax. Hard-fails as CDK-internal normative check (distinct from the user `doctor` check which only warns).
+- `packages/cli/src/utils/skill-frontmatter.js` helper exposing `parseSkillFile`, `extractFields`, `countBodyLines`, `allowedToolsHasCommas`. Single regex-based YAML parser shared by `doctor`, `new-skill` validation, and integration tests.
+- `SKILL_MD_MAX_LINES = 500` constant in `utils/constants.js` (threshold alignment with Anthropic best practice).
+- 3 new `advanced-checks.md` reference files in `packages/cli/templates/tier-{s,m,l}/.claude/skills/arch-audit/` (byte-identical across tiers).
+- Unit test suite `test/unit/skill-frontmatter.test.js` (10 new cases covering frontmatter parsing, body line counting, and comma detection edge cases).
+
+### Changed
+
+- `new-skill.js:validateSkillMd` migrated from inline regex frontmatter parsing to the shared `parseSkillFile` helper. Removes duplicate regex parser drift risk; behaviour preserved (unit tests unchanged).
+- `docs/reviews/anthropic-spec-deviations.md` refreshed: §2.4 classification closed (MAJOR via triangulation of Anthropic docs + isolated YAML parser test), §2.5 table updated with real 2026-04-24 line counts (perf-audit already compliant), §8 v1.11.0 status block added, footer `Last reviewed: 2026-04-24`.
+- Integration test count: 828 → 834 (6 new checks from `scenarioSkillMdSpecCompliance`, 2 assertions × 3 tiers).
+- Unit test count: 292 → 302 (10 new cases for `skill-frontmatter` helper).
+
+---
+
 ## [1.10.4] — 2026-04-23
 
 ### Added
+
 - Smoke test suite for `detect-stack.js` (20 tests across 2 describe blocks) covering stack identification markers for all 11 supported stacks (package.json ± tsconfig, pyproject.toml, go.mod, Gemfile, pom.xml, build.gradle.kts, build.gradle, Package.swift, .csproj, Cargo.toml) plus `suggestedTier` thresholds for the three calibrated brackets. Prerequisite coverage for the tier-threshold extraction below.
 
 ### Fixed
+
 - CLI `--version` now reads from `package.json` at runtime (was hard-coded `1.6.1` — 4 releases of drift vs actual 1.10.3). Identified by `skill-dev` audit (J4).
 - Wizard `AUDIT_MODELS` option list no longer offers `claude-opus-4-6` (Legacy per Anthropic models page); replaced with `claude-opus-4-7`. Fixes the root cause for the `operational-guide.md:166` doc drift below.
 - `scaffold/index.js` `patchSettingsPermissions` no longer silently swallows malformed settings.json during stack-permission patching — now logs a `console.warn` that names the file, the target stack, and the underlying error. Prevents scaffolds from shipping default JS/Node permissions on native stacks with no user-visible signal. Two new unit tests assert the warning is emitted and the file content is left unchanged.
 
 ### Changed
+
 - `CONTRIBUTING.md` test counts refreshed to 828 integration + 270 unit (were 464/243, stale vs `README.md` and `CHANGELOG.md [1.10.3]`).
 - `docs/operational-guide.md:166` wizard recommendation for deep-analysis model updated from `claude-opus-4-6` (Legacy per Anthropic models page) to `claude-opus-4-7`.
 - `docs/operational-guide.md:43` + `:403` audit skill count aligned to 16 (was 15); added missing `skill-review` to the available-skills enumeration (added in v1.10.0, #58).
@@ -31,6 +60,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Extracted tier-suggestion thresholds into `utils/tier-suggestion.js`: 3 calibrated brackets (nodeWeb 100/30, medium 80/20, compact 60/15) plus `suggestTier(fileCount, thresholds)` helper. `detect-stack.js` 11 inline ternaries now delegate to the helper; values unchanged, single source of truth.
 
 ### Removed
+
 - Unused `AUDIT_MODEL_DEFAULT` constant (0 consumers — confirmed via grep).
 - `export` keyword on `scaffoldTier0` — it is only called internally from `scaffoldTier` and not listed in `_testHelpers`, so the public surface shrinks with no external impact.
 
@@ -39,6 +69,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [1.10.3] — 2026-04-23
 
 ### Fixed
+
 - arch-audit H1a grep pattern missed 15 hook events (StopFailure, PostToolUseFailure, SubagentStart/Stop, TaskCreated, PermissionRequest/Denied, TeammateIdle, SessionEnd, FileChanged, CwdChanged, ConfigChange, UserPromptExpansion, Elicitation/Result) — would have falsely flagged StopFailure already in use.
 - arch-audit C17 regex false-positive on arch-audit itself (self-referential `mcp__` in grep pattern) — added skip-by-name + `^allowed-tools:` anchor.
 - tier-l cheatsheet out of sync with skills dir: 5 skills missing (arch-audit, commit, context-review, dependency-scan, skill-review) — restored to parity with tier-m + added context-review row (tier-l exclusive).
@@ -47,10 +78,12 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - tier-l settings.json deny missing `Bash(DROP TABLE*)`, `Bash(TRUNCATE*)` — regression vs tier-m.
 
 ### Updated
+
 - arch-audit "new events worth adding" catalogue refreshed with 6 events (UserPromptExpansion, SessionEnd, TeammateIdle, TaskCreated, PostToolUseFailure, PermissionRequest) + note on new `type: "mcp_tool"` hook type (v2.1.118).
 - claudemd-standards.md: hook events list v2.1.85 → v2.1.118 (22 → 27 events, `Last verified: 2026-04-23`).
 
 ### Unchanged
+
 - No code changes in CLI source — template-only release. Integration 828/828, unit 270/270.
 
 ---
@@ -58,6 +91,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [1.10.2] — 2026-04-19
 
 ### Fixed
+
 - Cross-stack audit fixes (14 items from Node-TS + Python senior audits): NT-B1/B2, NT-T1-T5, PY-B1-B3, PY-T3/T4/T6/T7.
 - Python, Go, Ruby now scaffold with stack-specific commands instead of npm fallbacks (PY-B1).
 - `frameworkValue()` returns per-stack examples: FastAPI/Django/Flask for Python, Gin/Echo for Go, Rails/Sinatra for Ruby (NT-B1).
@@ -65,6 +99,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Phase 3b RLS generalized to "row-level access control (database-level RLS or application-level guards)" (NT-T3).
 
 ### Added
+
 - 5 stack-conditional placeholders: `[VALIDATION_LIBRARIES]`, `[TEST_CLEANUP_PATTERN]`, `[COMMIT_EXAMPLES]`, `[BUILD_ARTIFACTS]`, `[ENVIRONMENT_SETUP]`.
 - Python permissions extended: pytest, mypy, uvicorn, alembic in allow list; `alembic downgrade base` in deny (PY-B2/B3).
 - Deny list hardening: `DROP DATABASE*` and `npm publish*` added to all tier settings.json (PY-T4).
@@ -79,6 +114,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [1.10.1] — 2026-04-18
 
 ### Fixed
+
 - Native stack scaffolding gaps found via Swift validation: `swift run` default for GUI apps, `# not configured` in pipeline prose, dependency-scan `true is false` interpolation, staff-manager contamination, `Color.red` pilot example.
 - Doctor command: timeout check at both outer and inner hook levels.
 - Cheatsheet gap: 4 skills (responsive/visual/ux/ui-audit) now listed in cheatsheet templates with conditional pruning via `cheatsheet: true` in skill-registry.
@@ -86,6 +122,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Dead code: 7 orphan `replace()` calls removed from `interpolate()` (HAS_API, HAS_DATABASE, HAS_FRONTEND, HAS_E2E, AUDIT_MODEL, DESIGN_SYSTEM_NAME, HAS_PRD) — no template contained these placeholders.
 
 ### Added
+
 - `scripts/lint-templates.mjs` — static analysis: banned patterns, wizard placeholder coverage, tier M/L file sync. Zero warnings, zero false positives.
 - Content assertion tests for 3 golden-file stacks: Swift (20 checks), Node-TS (22 checks), Python (22 checks).
 - Cross-stack invariant tests: 10 stacks × 6 invariants = 60 assertions.
@@ -97,10 +134,12 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [1.10.0] — 2026-04-17
 
 ### Added
+
 - `/skill-review` skill (Tier M lite, Tier L full) — quality review pipeline for skill portfolios. Includes 5 supporting documents: REVIEW_FRAMEWORK.md, SEVERITY_SCALE.md, SPEC_SNAPSHOT.md, SKILLS_INVENTORY.md, CALIBRATION_KIT.md. Tier M skips Phase 4 (external LLM) and Phase 9 (midpoint drift). Tier L runs full pipeline.
 - 19 reference files across 15 skills: PATTERNS.md (10), CHECKS.md (2), REPORT.md (6), DIMENSIONS.md (1) — stack-scaffolded patterns separated from skill body logic.
 
 ### Changed
+
 - Pipeline v2 body purity: all 17 SKILL.md files reworked — framework-specific patterns (grep commands, CSS utilities, Tailwind classes, SwiftUI literals) extracted from bodies into reference files. Bodies contain only universal principles. Net -2009 lines.
 - Configuration sections added to security-audit (`[SITEMAP_OR_ROUTE_LIST]`), perf-audit (`[PERF_TOOL]`, `[PROFILER_COMMAND]`), skill-dev (`[LINT_COMMAND]`).
 - skill-dev: scope filter for stack-specific check exclusion, refactoring-backlog.md fallback for missing file, D8 native stack clarification.
@@ -114,6 +153,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Pre-1.10.0 development log] — targeted v1.9.1, shipped as part of v1.10.0
 
 ### Added
+
 - `/test-audit` skill (Tier M/L, universal - no `requires`) - static test-suite quality audit. Parses coverage reports in 5 supported formats (lcov.info, Istanbul JSON, Cobertura XML, go coverage.out, tarpaulin JSON; xcresult optional via `xcrun xccov`). Pyramid shape classification (unit/integration/e2e) by path convention + framework imports. 8 anti-pattern checks (T1-T8): `.only`/`fit`/`fdescribe` committed, skipped tests, `.todo` placeholders, empty test bodies, tests without assertions, hardcoded sleeps, debug output in tests, multi-file `.only` broken CI. Backlog prefix `TEST-`. New Pipeline Phase 5d Track C runs for every block after Phase 3 is green. Critical findings (`.only` committed, 0% coverage on a file changed in the block) block Phase 6. Stack-aware across all 11 supported stacks; checks without a stack-specific pattern return `N/A - skipped for <stack>`. Flaky-test detection deferred; v1 is static-only (#58)
 - `/accessibility-audit` skill (Tier M/L, `hasFrontend=true`) - unified accessibility surface. Three modes: `static` (A1-A8 grep patterns: aria-label on icon buttons, positive tabindex, outline-none regression, img alt, form labels, focus ring size, onClick on non-interactive, nav keyboard access); `full` (adds APCA contrast probes C1-C3 via Playwright, both themes); `wcag` (adds axe-core 4.9.1 scan with `wcag2a + wcag2aa + wcag21aa + wcag22aa` tags, plus `best-practice`). Backlog prefix `A11Y-`. Pipeline Phase 5d Track A execution order: `/ui-audit` (static, concurrent) → `/accessibility-audit` → `/visual-audit` → `/ux-audit` → `/responsive-audit` (#60)
 - `/migration-audit` skill (Tier M/L, `hasDatabase=true`) - stack-aware static analysis of migration files. Detects Prisma, Drizzle, Supabase CLI, raw SQL; Rails/Django/Alembic/Flyway detected but pending support. 8 check families (M1-M8): lock-heavy DDL, missing rollback, unsafe backfills, constraint sequencing, data loss, unsafe type changes, unindexed FKs, ordering integrity. Backlog prefix `MIG-`. Pipeline Phase 5d Track B now runs `/migration-audit` when migrations are applied (#59)
@@ -133,11 +173,13 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Skill `description` field in all 18 SKILL.md frontmatter files (max 250 chars, used by Claude for auto-invocation)
 
 ### Fixed
+
 - Hook `timeout` values corrected from milliseconds to seconds per Anthropic JSON schema (Tier M: 300000→300, Tier L: 600000→600)
 - Doctor check #18 threshold corrected from 600000 to 600 (seconds, not milliseconds)
 - Doctor check #18 fix message now suggests correct value (`"timeout": 300`)
 
 ### Changed
+
 - `/ui-audit` scope narrowed to design-system compliance only. Extracted to `/accessibility-audit`: CHECK 11 (icon-only aria-label), CHECK 13 (positive tabindex), CHECK 14 (outline-none), CHECK 16 (img alt), CHECK 17 (form labels), S4 (nav keyboard), S6 (focus ring), S7 (onClick non-interactive), and Step 4 (axe-core WCAG scan). `/ui-audit` is now static-only (no Playwright). Check numbering preserves gaps to avoid breaking external references (#60)
 - `/visual-audit` narrowed from 11 to 10 dimensions. V8 (Contrast & legibility) and APCA Lc anchors in V4 extracted to `/accessibility-audit` (C1-C3). Page score denominator changed from `/55` to `/50`; bucket thresholds recalibrated proportionally (Excellent ≥40 / Good 30-39 / Needs work 20-29 / Poor <20). Scoring rules updated: `Score 3 on V1/V3/V4/V9/V10 → Major` (V8 removed) (#60)
 - `/skill-db` scope narrowed to live SQL verification (schema quality S1-S6 + N+1 query patterns Q1-Q3). Migration file analysis extracted to `/migration-audit` - single source of truth for migration safety across all database stacks. Pipeline Phase 5d Track B splits migration audit (`/migration-audit`) from schema audit (`/skill-db`). Affects projects invoking `/skill-db` for migration checks (#59)
@@ -155,6 +197,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - CONTRIBUTING.md updated with skill registry workflow and `add` commands
 
 ### Fixed
+
 - `responsive-audit` was not excluded for native stacks in `injectActiveSkills()` - CLAUDE.md listed it but the directory didn't exist for Swift/Kotlin/Rust projects
 - Tier M pipeline Phase 8.5 referenced non-existent `context-reviewer` agent - changed to inline grep
 - (CodeQL High) `init-in-place.js` incomplete URL substring sanitization - `remotes.includes('github.com')` replaced with regex domain match
@@ -166,6 +209,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `doctor` now checks Stop hook timeout presence (check #18) and deny list duplicates (check #19)
 
 ### Evaluated (decisions documented, no code change)
+
 - P5 Tier L: frozen - maintain functional, no new investment until real adoption signal
 - P6 Agents: agent-to-skill conversion scheduled for next cycle (saves 27K tokens/session)
 - P7 MCP: incremental adoption - GitHub MCP Q2, ecosystem reassessment Q4
@@ -175,15 +219,18 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [1.0.0] — 2026-03-22
 
 ### Changed — Scope and positioning
+
 - Primary target redefined: Builder PM and tech lead (people with enough technical background to work end-to-end with Claude Code). Not a generic "Product Trio."
 - Tier boundaries reframed around blast radius and collaborator count, not file count or duration
 - "Governance layer" positioning removed throughout — replaced with "scaffold for legible, reviewable AI-assisted development"
 - CLI description, template files, pipeline criteria all updated to match
 
 ### Added — Enforcement layer
+
 - `.github/workflows/claude-dev-kit-verify.yml` — CI template that verifies scaffold integrity on every PR (Stop hook configured, no unfilled placeholder, CLAUDE.md present, CODEOWNERS present)
 
 ### Added — `doctor` compliance reporting
+
 - `--report` flag: machine-readable JSON output (`timestamp`, `cwd`, `summary`, per-check `status`/`fix`) consumable by CI pipelines and external audit systems
 - `--ci` flag: silent mode, exits 1 on any failure — for GitHub Actions
 
@@ -192,6 +239,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.5.3] — 2026-03-15
 
 ### Fixed — Critical
+
 - Stop hook was missing from Tier S `settings.json`, breaking the core contract ("tests must pass in every tier"). Now enforced in all four tiers.
 
 ---
@@ -199,6 +247,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.5.2] — 2026-03-10
 
 ### Added
+
 - UAT scenario definition at scope gate: when Phase 4 E2E activates, the user must explicitly list numbered user journeys (1–5 scenarios) at Phase 1. Claude implements exactly those scenarios — it does not invent test cases.
 - Phase 4 renamed "UAT / E2E tests" across Tier M/L pipelines.
 
@@ -207,6 +256,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.5.1] — 2026-03-05
 
 ### Added
+
 - Interactive tier selector: 3 diagnostic questions → auto-suggest tier with explanation
 - Conditional Phase 4 E2E testing in Tier M/L (opt-in via init wizard, per-block scope gate confirmation)
 - `doctor` now checks Stop hook for unfilled `[TEST_COMMAND]` placeholder (11th check)
@@ -217,6 +267,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.5.0] — 2026-02-20
 
 ### Added
+
 - Session recovery (`.claude/session/`)
 - Scope gate with Tier 1/2 EARS sweep auto-selection
 - Interaction Protocol in CLAUDE.md templates
@@ -234,6 +285,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.1.0] — 2026-01-15
 
 ### Added
+
 - Initial release: four-tier scaffold system (Discovery / Fast Lane / Standard / Full)
 - Three init paths: Greenfield, From context, In-place
 - `doctor` command with 10 checks

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mg-claude-dev-kit",
-  "version": "1.10.4",
+  "version": "1.11.0",
   "description": "Scaffold for legible, reviewable AI-assisted development",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/doctor.js
+++ b/packages/cli/src/commands/doctor.js
@@ -2,7 +2,16 @@ import chalk from 'chalk';
 import fs from 'fs-extra';
 import path from 'path';
 import { execSync } from 'child_process';
-import { CLAUDE_MD_MAX_LINES, STOP_HOOK_MAX_TIMEOUT_SEC } from '../utils/constants.js';
+import {
+  CLAUDE_MD_MAX_LINES,
+  SKILL_MD_MAX_LINES,
+  STOP_HOOK_MAX_TIMEOUT_SEC,
+} from '../utils/constants.js';
+import {
+  parseSkillFile,
+  countBodyLines,
+  allowedToolsHasCommas,
+} from '../utils/skill-frontmatter.js';
 
 const checks = [
   {
@@ -262,6 +271,57 @@ const checks = [
         warn: true,
         info: missingTools.length > 0 ? missingTools.join(', ') : undefined,
         fix: `Add 'allowed-tools: Playwright' frontmatter to: ${missingTools.join(', ')}`,
+      };
+    },
+  },
+  {
+    id: 'skill-allowed-tools-syntax',
+    label: `Skills use space-separated allowed-tools (Anthropic spec)`,
+    check: (cwd) => {
+      const skillsDir = path.join(cwd, '.claude', 'skills');
+      if (!fs.existsSync(skillsDir)) return { pass: true, skip: true };
+      const offenders = [];
+      try {
+        for (const skill of fs.readdirSync(skillsDir)) {
+          const skillFile = path.join(skillsDir, skill, 'SKILL.md');
+          if (!fs.existsSync(skillFile)) continue;
+          const { fields } = parseSkillFile(fs.readFileSync(skillFile, 'utf8'));
+          if (allowedToolsHasCommas(fields.allowedTools)) offenders.push(skill);
+        }
+      } catch {
+        return { pass: true, skip: true };
+      }
+      return {
+        pass: offenders.length === 0,
+        warn: true,
+        info: offenders.length > 0 ? offenders.join(', ') : undefined,
+        fix: `Replace commas with spaces in allowed-tools frontmatter (Anthropic spec: space-separated string or YAML list). Affected: ${offenders.join(', ')}`,
+      };
+    },
+  },
+  {
+    id: 'skill-md-size-budget',
+    label: `Skill bodies respect Anthropic ≤ ${SKILL_MD_MAX_LINES} lines guideline`,
+    check: (cwd) => {
+      const skillsDir = path.join(cwd, '.claude', 'skills');
+      if (!fs.existsSync(skillsDir)) return { pass: true, skip: true };
+      const oversize = [];
+      try {
+        for (const skill of fs.readdirSync(skillsDir)) {
+          const skillFile = path.join(skillsDir, skill, 'SKILL.md');
+          if (!fs.existsSync(skillFile)) continue;
+          const { body } = parseSkillFile(fs.readFileSync(skillFile, 'utf8'));
+          const lines = countBodyLines(body);
+          if (lines > SKILL_MD_MAX_LINES) oversize.push(`${skill} (${lines})`);
+        }
+      } catch {
+        return { pass: true, skip: true };
+      }
+      return {
+        pass: oversize.length === 0,
+        warn: true,
+        info: oversize.length > 0 ? oversize.join(', ') : undefined,
+        fix: `Extract detailed sections into sibling reference files (progressive disclosure). Over budget: ${oversize.join(', ')}`,
       };
     },
   },

--- a/packages/cli/src/commands/new-skill.js
+++ b/packages/cli/src/commands/new-skill.js
@@ -4,6 +4,7 @@ import path from 'path';
 import inquirer from 'inquirer';
 import { registerSkillInClaudeMd } from '../utils/claudemd-update.js';
 import { SKILL_DESC_MAX_CHARS } from '../utils/constants.js';
+import { parseSkillFile } from '../utils/skill-frontmatter.js';
 
 // Standard Playwright MCP tools (sourced from visual-audit SKILL.md)
 const PLAYWRIGHT_TOOLS = [
@@ -101,25 +102,18 @@ function validateSkillMd(content, dirName) {
   const errors = [];
   const warnings = [];
 
-  // Frontmatter presence
-  const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
-  if (!fmMatch) {
+  const { frontmatter, body, fields } = parseSkillFile(content);
+  if (frontmatter === null) {
     errors.push('Missing YAML frontmatter (--- delimiters)');
     return { errors, warnings };
   }
 
-  const fm = fmMatch[1];
-
-  // Name matches directory
-  const nameMatch = fm.match(/^name:\s*(.+)/m);
-  if (nameMatch && nameMatch[1].trim() !== dirName) {
-    errors.push(`name field "${nameMatch[1].trim()}" does not match directory "${dirName}"`);
+  if (fields.name && fields.name !== dirName) {
+    errors.push(`name field "${fields.name}" does not match directory "${dirName}"`);
   }
 
-  // Description length
-  const descMatch = fm.match(/^description:\s*(.+)/m);
-  if (descMatch) {
-    const desc = descMatch[1].trim();
+  if (fields.description) {
+    const desc = fields.description;
     if (desc.length > SKILL_DESC_MAX_CHARS) {
       errors.push(`Description too long: ${desc.length}/${SKILL_DESC_MAX_CHARS} chars`);
     } else if (desc.length < 10) {
@@ -127,14 +121,11 @@ function validateSkillMd(content, dirName) {
     }
   }
 
-  // Context must be fork
-  if (!fm.includes('context: fork')) {
+  if (fields.context !== 'fork') {
     warnings.push('context should be "fork" to prevent context pollution');
   }
 
-  // Playwright + allowed-tools
-  const body = content.slice(fmMatch[0].length);
-  if (body.includes('browser_') && !fm.includes('allowed-tools')) {
+  if (body.includes('browser_') && !fields.allowedTools) {
     warnings.push('Body references browser_ but frontmatter lacks allowed-tools');
   }
 

--- a/packages/cli/src/utils/constants.js
+++ b/packages/cli/src/utils/constants.js
@@ -10,6 +10,13 @@ export const AUDIT_MODELS = [
 export const SKILL_DESC_MAX_CHARS = 250;
 
 /**
+ * Maximum line count for a SKILL.md body (excluding frontmatter). Anthropic
+ * best practice: skills ≤ 500 lines; longer bodies belong in sibling reference
+ * files per progressive-disclosure guidance.
+ */
+export const SKILL_MD_MAX_LINES = 500;
+
+/**
  * Maximum line count for a project CLAUDE.md before Anthropic's adherence
  * guidance breaks down. Enforced by doctor check.
  */

--- a/packages/cli/src/utils/skill-frontmatter.js
+++ b/packages/cli/src/utils/skill-frontmatter.js
@@ -1,0 +1,48 @@
+const FRONTMATTER_RE = /^---\n([\s\S]*?)\n---/;
+
+export function parseSkillFile(content) {
+  const match = content.match(FRONTMATTER_RE);
+  if (!match) {
+    return { frontmatter: null, body: content, fields: {}, raw: content };
+  }
+  const frontmatter = match[1];
+  const body = content.slice(match[0].length).replace(/^\n+/, '');
+  return {
+    frontmatter,
+    body,
+    fields: extractFields(frontmatter),
+    raw: content,
+  };
+}
+
+export function extractFields(frontmatter) {
+  const fields = {};
+  const scalar = (key) => {
+    const re = new RegExp(`^${key}:\\s*(.+)$`, 'm');
+    const m = frontmatter.match(re);
+    return m ? m[1].trim() : null;
+  };
+  fields.name = scalar('name');
+  fields.description = scalar('description');
+  fields.context = scalar('context');
+  fields.model = scalar('model');
+  fields.userInvocable = scalar('user-invocable');
+  fields.argumentHint = scalar('argument-hint');
+  fields.allowedTools = scalar('allowed-tools');
+  return fields;
+}
+
+export function countBodyLines(body) {
+  if (!body) return 0;
+  const trimmed = body.replace(/\n+$/, '');
+  if (trimmed === '') return 0;
+  return trimmed.split('\n').length;
+}
+
+export function allowedToolsHasCommas(allowedToolsValue) {
+  if (!allowedToolsValue) return false;
+  if (allowedToolsValue.startsWith('[') && allowedToolsValue.endsWith(']')) {
+    return false;
+  }
+  return /,/.test(allowedToolsValue);
+}

--- a/packages/cli/templates/tier-l/.claude/skills/arch-audit/SKILL.md
+++ b/packages/cli/templates/tier-l/.claude/skills/arch-audit/SKILL.md
@@ -243,116 +243,12 @@ Run: `for f in .claude/skills/*/SKILL.md; do name=$(basename $(dirname "$f")); [
 Expected: 0 MISSING lines. Any match = FAIL.
 AUTO-FIX: for each failing skill, read the `mcp__*` tool names from its body and add `allowed-tools: [mcp__tool1, mcp__tool2, ...]` to its frontmatter after the `context:` line.
 
-## Step 3c - Anthropic Prompting Guide compliance
+## Step 3c/3d - Prompting Guide + token/subagent optimization
 
-Using the prompting guide content fetched in Step 1 **and the normative baseline in `.claude/rules/claudemd-standards.md`** (read in Step 2), evaluate `CLAUDE.md`, `pipeline.md`, and `context-review.md` against best practices. The standards file is the local stable reference - use it as the primary benchmark; live-fetched docs confirm it's still current. These checks are judgment-based - classify each as PASS or WARN (not hard FAIL), and always RECOMMEND, never auto-fix.
+See [advanced-checks.md](advanced-checks.md) for the full content of these steps. Execute them before Step 3e.
 
-**Standards file currency check (run first)**: compare the `Last verified` date in `.claude/rules/claudemd-standards.md` against today's date. If > 30 days old AND Step 1 fetched new material changes → flag as RECOMMEND to update the standards file. If ≤ 30 days → skip.
-
-**P1 - CLAUDE.md content type (Anthropic's inclusion test)**
-Anthropic's rule: CLAUDE.md should contain ONLY non-obvious information Claude cannot infer by reading the code. Apply Anthropic's own test to every section: _"Would removing this cause Claude to make mistakes?"_
-
-Flag as WARN if a section:
-
-- Describes what a file does structurally (e.g. "file X handles Y") without explaining a non-obvious constraint - Claude can read the code
-- States a standard convention Claude already knows without a project-specific reason
-- Contains tutorial-style explanations of concepts (React, TypeScript, SQL) that Claude understands natively
-- Describes current session state or temporary phase status (this belongs in CLAUDE.local.md or MEMORY.md)
-
-Report: list any sections that fail the test with a suggested action (remove, condense, or move to a more appropriate file).
-
-**P2 - Instruction clarity and actionability**
-Anthropic's guidance: instructions must be specific, actionable, and unambiguous. A vague rule gives Claude discretion where a concrete rule would remove ambiguity.
-
-Flag as WARN:
-
-- Directives with no measurable outcome ("be thorough", "be careful", "verify appropriately")
-- Instructions that say "ensure X" without specifying how to verify X
-- Rules with implicit scope ("update relevant files") where an explicit list would prevent errors
-
-Report: flagged instances with suggested sharper wording.
-
-**P3 - Structural redundancy across instruction files**
-Redundancy dilutes attention. If a rule appears in both CLAUDE.md and pipeline.md with no clear canonical source, Claude may apply it inconsistently - or the longer file may suppress the shorter one.
-
-Check: read "Known Patterns" in CLAUDE.md and "Cross-Cutting Rules" in pipeline.md side-by-side. Also check for overlap between context-review.md checks and arch-audit C1–C17.
-
-Flag as WARN: any rule stated substantively in two files where one should be canonical.
-
-Report: duplicates with a recommendation on which file is the correct owner.
-
-**P4 - Pipeline complexity proportionality**
-Anthropic's principle: instruction complexity should be proportional to the actual risk and value it protects against. Over-specified pipelines make Claude slower and more likely to get stuck on process rather than output.
-
-Evaluate:
-
-- Are there phases (or sub-phases) whose STOP gate catches errors that have actually occurred in practice? Or are they theoretical?
-- Does the Fast Lane meaningfully simplify, or does it mostly duplicate the full pipeline?
-- Are there context-review checks (C1–C12) that have never caught a real issue - suggesting they address a risk that doesn't materialize?
-- Does the total length of pipeline.md + context-review.md stay within a range where Claude can hold the key constraints in working context?
-
-Report: any phase or check that appears to add friction without demonstrated value → RECOMMEND for review or consolidation. Note: do NOT recommend removing STOP gates without strong evidence of zero value - gates protect against irreversible actions.
-
-**P5 - Long context structure and scannability**
-Anthropic guidance for long system prompts: critical rules should be visually distinct and easy to locate. Recency and position matter - Claude gives more weight to recent context.
-
-Check:
-
-- Are the most-critical, most-referenced rules (RBAC, worktree isolation, migration isolation, environment isolation) marked as CRITICAL or placed at the top of their sections?
-- Is CLAUDE.md structured so Claude can find a rule without reading the entire file?
-- Are there sections that are rarely referenced but consume significant token space in every context window?
-
-Report: structural improvements for scannability → RECOMMEND.
-
-## Step 3d - Token & subagent optimization checks
-
-These checks audit the project's own efficiency at model selection and subagent delegation. Regressions here increase cost and latency without improving output quality. Judgment-based where noted; mechanical checks reuse the grep-tier haiku batch from Step 3b.
-
-**T1 - Research agent model in arch-audit Step 1**
-Check: does the Step 1 instruction in this SKILL.md specify `model: haiku` for the research agent?
-Batch command: `grep -n "model.*haiku\|haiku.*model" .claude/skills/arch-audit/SKILL.md`
-Expected: at least 1 match in the Step 1 section. Missing = FAIL.
-AUTO-FIX: add `(model: haiku)` to the research agent invocation in Step 1.
-
-**T2 - Haiku model on all Explore subagents across skills**
-Check: every "Launch ... Explore subagent" instruction in all SKILL.md files must explicitly name `model: haiku`.
-Batch command: `grep -rn "Explore subagent" .claude/skills/*/SKILL.md | grep -v "model.*haiku\|haiku"`
-Expected: 0 matches (all invocations already name haiku). Any match = FAIL.
-AUTO-FIX: append `(model: haiku)` to the invocation description in each failing line.
-
-**T3 - Phase 5d Playwright concurrency note**
-Check: does pipeline.md Phase 5d document that `/ui-audit` (static, no Playwright by default) can run concurrently with Playwright-based skills, and that `/visual-audit`, `/ux-audit`, `/responsive-audit` must run sequentially (shared MCP Playwright session)?
-Batch command: `grep -A30 "Phase 5d" .claude/rules/pipeline.md | grep -i "concurrent\|parallel\|sequenti\|playwright.*conflict\|conflict.*playwright"`
-Expected: at least 1 match. Missing = WARN.
-RECOMMEND if failing: add a note to Phase 5d: "Run `/ui-audit` concurrently with the first Playwright skill launch. Run `/visual-audit` → `/ux-audit` → `/responsive-audit` sequentially - they share the MCP Playwright session and cannot run in parallel."
-
-Batch commands:
-Expected: ≥1 match in each file. Missing from either = FAIL.
-
-**T5 - Skill model fitness (judgment)**
-For each skill, verify `model:` frontmatter fits the task's reasoning requirement:
-
-- `model: haiku` appropriate for: mechanical structural checks, pure grep/pattern matching, URL text extraction, formatting validation
-- `model: sonnet` appropriate for: cross-file judgment, complex analysis, fix application, multi-dimension scoring
-- `model: opus` appropriate for: screenshot-based visual reasoning, multi-role journey simulation, live aesthetic scoring - requires vision + deep analysis
-
-Current expected state:
-| Skill | Expected | Rationale |
-|---|---|---|
-| arch-audit | sonnet | Complex judgment, cross-doc analysis, AUTO-FIX application |
-| ui-audit | sonnet | Design system judgment, visual compliance scoring |
-| ux-audit | opus | Multi-flow simulation + live screenshot analysis - visual reasoning requires Opus |
-| visual-audit | opus | 7-dimension aesthetic scoring + screenshot analysis - visual reasoning requires Opus |
-| security-audit | sonnet | Exploit reasoning, authorization analysis |
-| api-design | sonnet | REST pattern judgment + internal haiku Explore agent |
-| perf-audit | sonnet | Bundle analysis, server/client boundary judgment + internal haiku Explore agent |
-| skill-dev | sonnet | Coupling/abstraction judgment + internal haiku Explore agent |
-| skill-db | opus | Deep schema normalization + RLS policy reasoning requires Opus - internal haiku Explore agent for dep scan |
-| responsive-audit | opus | Multi-viewport screenshot judgment - visual reasoning requires Opus |
-
-Batch command: `grep -A1 "^name:" .claude/skills/*/SKILL.md | grep "model:"` - compare each result against the table above.
-FAIL: any skill using `model: haiku` as top-level model (only Explore _subagents within_ skills should use haiku, not the skill itself).
-WARN: any skill using `model: opus` **unless** it is one of the intentional Opus skills: `visual-audit`, `ux-audit`, `responsive-audit` (screenshot-based visual reasoning) or `skill-db` (deep schema normalization + RLS policy reasoning). All other skills should use sonnet.
+- **Step 3c** - Anthropic Prompting Guide compliance against `CLAUDE.md`, `pipeline.md`, `context-review.md` + normative baseline `.claude/rules/claudemd-standards.md`. Covers P1 (content type inclusion test), P2 (instruction clarity), P3 (redundancy across instruction files), P4 (pipeline complexity proportionality), P5 (long context scannability). All judgment-based, PASS/WARN only, RECOMMEND never AUTO-FIX.
+- **Step 3d** - Token & subagent optimization. Covers T1 (research agent haiku in Step 1), T2 (Explore subagent haiku across skills), T3 (Playwright concurrency note in Phase 5d), T5 (skill model fitness table). Mix of mechanical grep and judgment.
 
 ## Step 3e - Pipeline.md compliance check
 
@@ -436,62 +332,18 @@ Output results in the Step 6 report under a new section:
 
 ## Step H1 - Hook compliance check
 
-Using hook documentation fetched in Step 1 (`https://code.claude.com/docs/en/hooks`) and `settings.json` read in Step 2, verify the project's hook configuration against current Anthropic spec.
+See [advanced-checks.md](advanced-checks.md) for the full content. Execute between Step 3e and Step 4.
 
-**H1a - Event name currency**
-Check: every event name in `settings.json` hooks matches the current official event list.
-Run: `grep -o '"SessionStart"\|"SessionEnd"\|"UserPromptSubmit"\|"UserPromptExpansion"\|"PreToolUse"\|"PostToolUse"\|"PostToolUseFailure"\|"Stop"\|"StopFailure"\|"PermissionRequest"\|"PermissionDenied"\|"SubagentStart"\|"SubagentStop"\|"TaskCreated"\|"TaskCompleted"\|"TeammateIdle"\|"FileChanged"\|"CwdChanged"\|"ConfigChange"\|"PreCompact"\|"PostCompact"\|"InstructionsLoaded"\|"Notification"\|"Elicitation"\|"ElicitationResult"\|"WorktreeCreate"\|"WorktreeRemove"' .claude/settings.json | sort -u`
-Pass: all events appear in the Step 1 documentation. Any unrecognized event → RECOMMEND removal or rename.
+Summary of the sub-checks:
 
-**H1b - JSON response field compliance (prompt hooks)**
-For each hook with `"type": "prompt"` in settings.json: check that response fields (`ok`, `reason`, `decision`, `updatedInput`) match the documented schema.
-Source: Step 1 hooks doc content.
-If divergence found → RECOMMEND (never AUTO-FIX): specify both files that need updating:
+- **H1a** - Event name currency against the official Anthropic event list (grep on `settings.json`).
+- **H1b** - JSON response field compliance for prompt-type hooks (`ok`, `reason`, `decision`, `updatedInput`).
+- **H1c** - Bypass mechanism visibility on blocking `UserPromptSubmit` hooks.
+- **H1d** - Hook type fitness (`command` vs `prompt` vs `agent`).
+- **H1e** - Rubric/hook drift between `prompt-quality-rubric.md` and inline hook logic.
+- **H1f** - New events to consider since last audit.
 
-- `.claude/settings.json` - the hook prompt inline text (authoritative)
-- `.claude/rules/prompt-quality-rubric.md` - the "Block output format" section (documentation, follows the hook)
-
-**H1c - Bypass mechanism visibility**
-Check: every `UserPromptSubmit` hook with `type: prompt` that can return a blocking response (`ok: false`) must include bypass instructions in the `reason` field.
-Fail → RECOMMEND update to add bypass instructions.
-
-**H1d - Hook type fitness**
-For each hook, verify `type` matches intent:
-
-- `command` - shell execution, dynamic state (git, files, env)
-- `prompt` - static/contextual text injection, no shell needed
-- `agent` - multi-step async logic
-  Flag as RECOMMEND (not AUTO-FIX) any `command` hook that only outputs static text and could be simplified to `prompt`.
-
-**H1e - Rubric-hook drift check**
-Check: `.claude/rules/prompt-quality-rubric.md` must stay in sync with the inline logic in the `UserPromptSubmit` prompt hooks in `settings.json`. Drift = the rubric documents behavior that the hook no longer implements (or vice versa).
-
-Run these two greps and compare results:
-
-- T3 wildcards in rubric: `grep "T3" .claude/rules/prompt-quality-rubric.md`
-- T3 wildcards in hook: `grep "T3" .claude/settings.json`
-
-Also check output format sync:
-
-- Rubric block format: `grep -A5 "Block output format" .claude/rules/prompt-quality-rubric.md`
-- Hook output format: look for the `If a trigger matches` instruction in the settings.json hook prompt
-
-Pass: T3 wildcard lists match; rubric output format matches hook output format structure.
-Fail → AUTO-FIX: update the rubric to match the hook (hook is authoritative - rubric is documentation). Update `Last updated` date in rubric.
-
-**H1f - New events to consider**
-
-Add results to Step 6 report under:
-
-```
-### Hook compliance (H1a–H1e)
-- H1a Event name currency: [PASS/FAIL - list unknown events if any]
-- H1b JSON response fields: [PASS/FAIL - list non-compliant fields if any]
-- H1c Bypass visibility: [PASS/FAIL - list hooks missing bypass guidance]
-- H1d Hook type fitness: [PASS/WARN - list command→prompt candidates]
-- H1e Rubric-hook drift: [PASS/FAIL - list any T3 or format divergences found]
-- H1f New events: [list relevant new events, or "none since last audit"]
-```
+Add results to the Step 6 report under `### Hook compliance (H1a–H1e)`.
 
 ## Step 4 - Apply AUTO-FIX changes
 

--- a/packages/cli/templates/tier-l/.claude/skills/arch-audit/advanced-checks.md
+++ b/packages/cli/templates/tier-l/.claude/skills/arch-audit/advanced-checks.md
@@ -1,0 +1,173 @@
+# Advanced compliance checks
+
+Reference file for `arch-audit`. Contains Step 3c (Anthropic Prompting Guide compliance), Step 3d (Token & subagent optimization), and Step H1 (Hook compliance). Extracted from `SKILL.md` to respect the Anthropic best-practice budget of ≤ 500 lines per skill body. Load this file when executing the corresponding steps; otherwise the content costs zero tokens.
+
+## Step 3c - Anthropic Prompting Guide compliance
+
+Using the prompting guide content fetched in Step 1 **and the normative baseline in `.claude/rules/claudemd-standards.md`** (read in Step 2), evaluate `CLAUDE.md`, `pipeline.md`, and `context-review.md` against best practices. The standards file is the local stable reference - use it as the primary benchmark; live-fetched docs confirm it's still current. These checks are judgment-based - classify each as PASS or WARN (not hard FAIL), and always RECOMMEND, never auto-fix.
+
+**Standards file currency check (run first)**: compare the `Last verified` date in `.claude/rules/claudemd-standards.md` against today's date. If > 30 days old AND Step 1 fetched new material changes → flag as RECOMMEND to update the standards file. If ≤ 30 days → skip.
+
+**P1 - CLAUDE.md content type (Anthropic's inclusion test)**
+Anthropic's rule: CLAUDE.md should contain ONLY non-obvious information Claude cannot infer by reading the code. Apply Anthropic's own test to every section: _"Would removing this cause Claude to make mistakes?"_
+
+Flag as WARN if a section:
+
+- Describes what a file does structurally (e.g. "file X handles Y") without explaining a non-obvious constraint - Claude can read the code
+- States a standard convention Claude already knows without a project-specific reason
+- Contains tutorial-style explanations of concepts (React, TypeScript, SQL) that Claude understands natively
+- Describes current session state or temporary phase status (this belongs in CLAUDE.local.md or MEMORY.md)
+
+Report: list any sections that fail the test with a suggested action (remove, condense, or move to a more appropriate file).
+
+**P2 - Instruction clarity and actionability**
+Anthropic's guidance: instructions must be specific, actionable, and unambiguous. A vague rule gives Claude discretion where a concrete rule would remove ambiguity.
+
+Flag as WARN:
+
+- Directives with no measurable outcome ("be thorough", "be careful", "verify appropriately")
+- Instructions that say "ensure X" without specifying how to verify X
+- Rules with implicit scope ("update relevant files") where an explicit list would prevent errors
+
+Report: flagged instances with suggested sharper wording.
+
+**P3 - Structural redundancy across instruction files**
+Redundancy dilutes attention. If a rule appears in both CLAUDE.md and pipeline.md with no clear canonical source, Claude may apply it inconsistently - or the longer file may suppress the shorter one.
+
+Check: read "Known Patterns" in CLAUDE.md and "Cross-Cutting Rules" in pipeline.md side-by-side. Also check for overlap between context-review.md checks and arch-audit C1–C17.
+
+Flag as WARN: any rule stated substantively in two files where one should be canonical.
+
+Report: duplicates with a recommendation on which file is the correct owner.
+
+**P4 - Pipeline complexity proportionality**
+Anthropic's principle: instruction complexity should be proportional to the actual risk and value it protects against. Over-specified pipelines make Claude slower and more likely to get stuck on process rather than output.
+
+Evaluate:
+
+- Are there phases (or sub-phases) whose STOP gate catches errors that have actually occurred in practice? Or are they theoretical?
+- Does the Fast Lane meaningfully simplify, or does it mostly duplicate the full pipeline?
+- Are there context-review checks (C1–C12) that have never caught a real issue - suggesting they address a risk that doesn't materialize?
+- Does the total length of pipeline.md + context-review.md stay within a range where Claude can hold the key constraints in working context?
+
+Report: any phase or check that appears to add friction without demonstrated value → RECOMMEND for review or consolidation. Note: do NOT recommend removing STOP gates without strong evidence of zero value - gates protect against irreversible actions.
+
+**P5 - Long context structure and scannability**
+Anthropic guidance for long system prompts: critical rules should be visually distinct and easy to locate. Recency and position matter - Claude gives more weight to recent context.
+
+Check:
+
+- Are the most-critical, most-referenced rules (RBAC, worktree isolation, migration isolation, environment isolation) marked as CRITICAL or placed at the top of their sections?
+- Is CLAUDE.md structured so Claude can find a rule without reading the entire file?
+- Are there sections that are rarely referenced but consume significant token space in every context window?
+
+Report: structural improvements for scannability → RECOMMEND.
+
+## Step 3d - Token & subagent optimization checks
+
+These checks audit the project's own efficiency at model selection and subagent delegation. Regressions here increase cost and latency without improving output quality. Judgment-based where noted; mechanical checks reuse the grep-tier haiku batch from Step 3b.
+
+**T1 - Research agent model in arch-audit Step 1**
+Check: does the Step 1 instruction in this SKILL.md specify `model: haiku` for the research agent?
+Batch command: `grep -n "model.*haiku\|haiku.*model" .claude/skills/arch-audit/SKILL.md`
+Expected: at least 1 match in the Step 1 section. Missing = FAIL.
+AUTO-FIX: add `(model: haiku)` to the research agent invocation in Step 1.
+
+**T2 - Haiku model on all Explore subagents across skills**
+Check: every "Launch ... Explore subagent" instruction in all SKILL.md files must explicitly name `model: haiku`.
+Batch command: `grep -rn "Explore subagent" .claude/skills/*/SKILL.md | grep -v "model.*haiku\|haiku"`
+Expected: 0 matches (all invocations already name haiku). Any match = FAIL.
+AUTO-FIX: append `(model: haiku)` to the invocation description in each failing line.
+
+**T3 - Phase 5d Playwright concurrency note**
+Check: does pipeline.md Phase 5d document that `/ui-audit` (static, no Playwright by default) can run concurrently with Playwright-based skills, and that `/visual-audit`, `/ux-audit`, `/responsive-audit` must run sequentially (shared MCP Playwright session)?
+Batch command: `grep -A30 "Phase 5d" .claude/rules/pipeline.md | grep -i "concurrent\|parallel\|sequenti\|playwright.*conflict\|conflict.*playwright"`
+Expected: at least 1 match. Missing = WARN.
+RECOMMEND if failing: add a note to Phase 5d: "Run `/ui-audit` concurrently with the first Playwright skill launch. Run `/visual-audit` → `/ux-audit` → `/responsive-audit` sequentially - they share the MCP Playwright session and cannot run in parallel."
+
+Batch commands:
+Expected: ≥1 match in each file. Missing from either = FAIL.
+
+**T5 - Skill model fitness (judgment)**
+For each skill, verify `model:` frontmatter fits the task's reasoning requirement:
+
+- `model: haiku` appropriate for: mechanical structural checks, pure grep/pattern matching, URL text extraction, formatting validation
+- `model: sonnet` appropriate for: cross-file judgment, complex analysis, fix application, multi-dimension scoring
+- `model: opus` appropriate for: screenshot-based visual reasoning, multi-role journey simulation, live aesthetic scoring - requires vision + deep analysis
+
+Current expected state:
+| Skill | Expected | Rationale |
+|---|---|---|
+| arch-audit | sonnet | Complex judgment, cross-doc analysis, AUTO-FIX application |
+| ui-audit | sonnet | Design system judgment, visual compliance scoring |
+| ux-audit | opus | Multi-flow simulation + live screenshot analysis - visual reasoning requires Opus |
+| visual-audit | opus | 7-dimension aesthetic scoring + screenshot analysis - visual reasoning requires Opus |
+| security-audit | sonnet | Exploit reasoning, authorization analysis |
+| api-design | sonnet | REST pattern judgment + internal haiku Explore agent |
+| perf-audit | sonnet | Bundle analysis, server/client boundary judgment + internal haiku Explore agent |
+| skill-dev | sonnet | Coupling/abstraction judgment + internal haiku Explore agent |
+| skill-db | opus | Deep schema normalization + RLS policy reasoning requires Opus - internal haiku Explore agent for dep scan |
+| responsive-audit | opus | Multi-viewport screenshot judgment - visual reasoning requires Opus |
+
+Batch command: `grep -A1 "^name:" .claude/skills/*/SKILL.md | grep "model:"` - compare each result against the table above.
+FAIL: any skill using `model: haiku` as top-level model (only Explore _subagents within_ skills should use haiku, not the skill itself).
+WARN: any skill using `model: opus` **unless** it is one of the intentional Opus skills: `visual-audit`, `ux-audit`, `responsive-audit` (screenshot-based visual reasoning) or `skill-db` (deep schema normalization + RLS policy reasoning). All other skills should use sonnet.
+
+## Step H1 - Hook compliance check
+
+Using hook documentation fetched in Step 1 (`https://code.claude.com/docs/en/hooks`) and `settings.json` read in Step 2, verify the project's hook configuration against current Anthropic spec.
+
+**H1a - Event name currency**
+Check: every event name in `settings.json` hooks matches the current official event list.
+Run: `grep -o '"SessionStart"\|"SessionEnd"\|"UserPromptSubmit"\|"UserPromptExpansion"\|"PreToolUse"\|"PostToolUse"\|"PostToolUseFailure"\|"Stop"\|"StopFailure"\|"PermissionRequest"\|"PermissionDenied"\|"SubagentStart"\|"SubagentStop"\|"TaskCreated"\|"TaskCompleted"\|"TeammateIdle"\|"FileChanged"\|"CwdChanged"\|"ConfigChange"\|"PreCompact"\|"PostCompact"\|"InstructionsLoaded"\|"Notification"\|"Elicitation"\|"ElicitationResult"\|"WorktreeCreate"\|"WorktreeRemove"' .claude/settings.json | sort -u`
+Pass: all events appear in the Step 1 documentation. Any unrecognized event → RECOMMEND removal or rename.
+
+**H1b - JSON response field compliance (prompt hooks)**
+For each hook with `"type": "prompt"` in settings.json: check that response fields (`ok`, `reason`, `decision`, `updatedInput`) match the documented schema.
+Source: Step 1 hooks doc content.
+If divergence found → RECOMMEND (never AUTO-FIX): specify both files that need updating:
+
+- `.claude/settings.json` - the hook prompt inline text (authoritative)
+- `.claude/rules/prompt-quality-rubric.md` - the "Block output format" section (documentation, follows the hook)
+
+**H1c - Bypass mechanism visibility**
+Check: every `UserPromptSubmit` hook with `type: prompt` that can return a blocking response (`ok: false`) must include bypass instructions in the `reason` field.
+Fail → RECOMMEND update to add bypass instructions.
+
+**H1d - Hook type fitness**
+For each hook, verify `type` matches intent:
+
+- `command` - shell execution, dynamic state (git, files, env)
+- `prompt` - static/contextual text injection, no shell needed
+- `agent` - multi-step async logic
+  Flag as RECOMMEND (not AUTO-FIX) any `command` hook that only outputs static text and could be simplified to `prompt`.
+
+**H1e - Rubric-hook drift check**
+Check: `.claude/rules/prompt-quality-rubric.md` must stay in sync with the inline logic in the `UserPromptSubmit` prompt hooks in `settings.json`. Drift = the rubric documents behavior that the hook no longer implements (or vice versa).
+
+Run these two greps and compare results:
+
+- T3 wildcards in rubric: `grep "T3" .claude/rules/prompt-quality-rubric.md`
+- T3 wildcards in hook: `grep "T3" .claude/settings.json`
+
+Also check output format sync:
+
+- Rubric block format: `grep -A5 "Block output format" .claude/rules/prompt-quality-rubric.md`
+- Hook output format: look for the `If a trigger matches` instruction in the settings.json hook prompt
+
+Pass: T3 wildcard lists match; rubric output format matches hook output format structure.
+Fail → AUTO-FIX: update the rubric to match the hook (hook is authoritative - rubric is documentation). Update `Last updated` date in rubric.
+
+**H1f - New events to consider**
+
+Add results to Step 6 report under:
+
+```
+### Hook compliance (H1a–H1e)
+- H1a Event name currency: [PASS/FAIL - list unknown events if any]
+- H1b JSON response fields: [PASS/FAIL - list non-compliant fields if any]
+- H1c Bypass visibility: [PASS/FAIL - list hooks missing bypass guidance]
+- H1d Hook type fitness: [PASS/WARN - list command→prompt candidates]
+- H1e Rubric-hook drift: [PASS/FAIL - list any T3 or format divergences found]
+- H1f New events: [list relevant new events, or "none since last audit"]
+```

--- a/packages/cli/templates/tier-l/.claude/skills/skill-review/SKILL.md
+++ b/packages/cli/templates/tier-l/.claude/skills/skill-review/SKILL.md
@@ -5,7 +5,7 @@ user-invocable: true
 model: opus
 context: fork
 argument-hint: [skill-name] [tier:S|M|L|all] [mode:full|preflight-only|fixtures-only]
-allowed-tools: Read, Glob, Grep, Bash
+allowed-tools: Read Glob Grep Bash
 ---
 
 You are a skill-quality reviewer running the framework v1.2 pipeline. Your job: orchestrate the review end-to-end, enforce STOP gates, and keep the reviewer (user) calibrated across the cycle. You produce findings - you do not silently fix. Fixes happen in Phase 3 after explicit user Go.
@@ -36,7 +36,7 @@ Before Phase 1, read these in order. They are siblings of this file.
 
 - Quick mechanical linting (use `grep` + `wc -l` directly).
 - Skill authoring from scratch (use `/skill-dev` instead).
-- Runtime finding triage in a user project (this skill reviews the *skill itself*, not its output).
+- Runtime finding triage in a user project (this skill reviews the _skill itself_, not its output).
 
 ---
 
@@ -74,6 +74,7 @@ Execute C1-C8 from `anthropic-spec-checklist.md` (if sibling present) or derive 
 Per `REVIEW_FRAMEWORK.md` v1.2, Phase 2 is split 2.A → 2.E. Execute sequentially, never in parallel.
 
 ### 2.A - Fundamentals
+
 - Clarity: is the skill's purpose clear in 3 lines?
 - Scope boundary: does the claimed scope match the body?
 - Project-agnosticity (4 dimensions from framework v1.2 T2.4):
@@ -83,21 +84,26 @@ Per `REVIEW_FRAMEWORK.md` v1.2, Phase 2 is split 2.A → 2.E. Execute sequential
   4. Architectural assumptions (e.g., "there is a database").
 
 ### 2.B - Structural coherence + cross-tier
+
 If `tier:all`: load every tier variant, produce a column-by-column diff artifact. Classify each delta:
+
 - **Expected**: scope difference, verbosity, tool-set shrinkage.
 - **Unexpected**: same check at different severity across tiers, inconsistent naming, divergent output format.
 
-***** STOP - cross-tier delta review. Present diff + classified deltas. Wait for user confirmation before Phase 3 propagation rules apply. *****
+**\*** STOP - cross-tier delta review. Present diff + classified deltas. Wait for user confirmation before Phase 3 propagation rules apply. **\***
 
 ### 2.C - Refinements
+
 - Token efficiency: per-section token count, flag sections > 500 tokens that are not core logic.
 - Boilerplate drift vs most-recently-reviewed sibling skill.
 - Supporting files accuracy (if any).
 
 ### 2.D - Interactive walkthrough
+
 Present findings to user. For multi-option review questions, ALWAYS use `AskUserQuestion` tool - never inline prose.
 
-### 2.E - Behavioral fixtures *(only for 6 targeted skills per D1: ui-audit, visual-audit, accessibility-audit, security-audit, api-design, migration-audit)*
+### 2.E - Behavioral fixtures _(only for 6 targeted skills per D1: ui-audit, visual-audit, accessibility-audit, security-audit, api-design, migration-audit)_
+
 - 3 representative cases: run the skill, record output, verify expected severity labels.
 - 2 adversarial cases: craft input that should trip the skill; verify skill catches it.
 - 1 contamination probe: a pilot-project-like literal; verify the skill does NOT flag as stack-specific.
@@ -117,11 +123,11 @@ Max 3 fix attempts per Critical finding (framework v1.2 C2 rollback protocol).
 4. Token count post-fix: `wc -l SKILL.md` + tokenizer estimate. Hard-fail if > 5000 tokens (framework v1.2 T2.5).
 5. If any check regresses: revert to pre-fix state, report root-cause hypothesis, escalate to user.
 
-***** STOP - Phase 3 → Phase 4 gate (framework v1.2 C7). User approves the diff of applied fixes before any external LLM sees the new version. *****
+**\*** STOP - Phase 3 → Phase 4 gate (framework v1.2 C7). User approves the diff of applied fixes before any external LLM sees the new version. **\***
 
 ---
 
-## Phase 4 - External LLM review *(optional, portfolio-level)*
+## Phase 4 - External LLM review _(optional, portfolio-level)_
 
 Skip unless the user explicitly requests external review or the skill is in the behavioral-fixtures target set AND a pre-existing external review exists (framework v1.2 C4).
 
@@ -163,15 +169,16 @@ Present outcome checklist:
 - path/to/file - description
 ```
 
-***** STOP - do not declare complete until explicit user confirmation. *****
+**\*** STOP - do not declare complete until explicit user confirmation. **\***
 
 ---
 
-## Phase 9 - Midpoint drift check *(portfolio-level only)*
+## Phase 9 - Midpoint drift check _(portfolio-level only)_
 
 Trigger: after completing skill #N/2 (e.g., skill #9 in a 17-skill cycle). Check `SKILLS_INVENTORY.md §Review ordering` for the canonical midpoint.
 
 Procedure per `CALIBRATION_KIT.md §4`:
+
 1. Re-read §1 anchor catalog.
 2. Re-score skill #1 blindly (without looking at original labels).
 3. Compare original vs re-score.

--- a/packages/cli/templates/tier-m/.claude/skills/arch-audit/SKILL.md
+++ b/packages/cli/templates/tier-m/.claude/skills/arch-audit/SKILL.md
@@ -243,116 +243,12 @@ Run: `for f in .claude/skills/*/SKILL.md; do name=$(basename $(dirname "$f")); [
 Expected: 0 MISSING lines. Any match = FAIL.
 AUTO-FIX: for each failing skill, read the `mcp__*` tool names from its body and add `allowed-tools: [mcp__tool1, mcp__tool2, ...]` to its frontmatter after the `context:` line.
 
-## Step 3c - Anthropic Prompting Guide compliance
+## Step 3c/3d - Prompting Guide + token/subagent optimization
 
-Using the prompting guide content fetched in Step 1 **and the normative baseline in `.claude/rules/claudemd-standards.md`** (read in Step 2), evaluate `CLAUDE.md`, `pipeline.md`, and `context-review.md` against best practices. The standards file is the local stable reference - use it as the primary benchmark; live-fetched docs confirm it's still current. These checks are judgment-based - classify each as PASS or WARN (not hard FAIL), and always RECOMMEND, never auto-fix.
+See [advanced-checks.md](advanced-checks.md) for the full content of these steps. Execute them before Step 3e.
 
-**Standards file currency check (run first)**: compare the `Last verified` date in `.claude/rules/claudemd-standards.md` against today's date. If > 30 days old AND Step 1 fetched new material changes → flag as RECOMMEND to update the standards file. If ≤ 30 days → skip.
-
-**P1 - CLAUDE.md content type (Anthropic's inclusion test)**
-Anthropic's rule: CLAUDE.md should contain ONLY non-obvious information Claude cannot infer by reading the code. Apply Anthropic's own test to every section: _"Would removing this cause Claude to make mistakes?"_
-
-Flag as WARN if a section:
-
-- Describes what a file does structurally (e.g. "file X handles Y") without explaining a non-obvious constraint - Claude can read the code
-- States a standard convention Claude already knows without a project-specific reason
-- Contains tutorial-style explanations of concepts (React, TypeScript, SQL) that Claude understands natively
-- Describes current session state or temporary phase status (this belongs in CLAUDE.local.md or MEMORY.md)
-
-Report: list any sections that fail the test with a suggested action (remove, condense, or move to a more appropriate file).
-
-**P2 - Instruction clarity and actionability**
-Anthropic's guidance: instructions must be specific, actionable, and unambiguous. A vague rule gives Claude discretion where a concrete rule would remove ambiguity.
-
-Flag as WARN:
-
-- Directives with no measurable outcome ("be thorough", "be careful", "verify appropriately")
-- Instructions that say "ensure X" without specifying how to verify X
-- Rules with implicit scope ("update relevant files") where an explicit list would prevent errors
-
-Report: flagged instances with suggested sharper wording.
-
-**P3 - Structural redundancy across instruction files**
-Redundancy dilutes attention. If a rule appears in both CLAUDE.md and pipeline.md with no clear canonical source, Claude may apply it inconsistently - or the longer file may suppress the shorter one.
-
-Check: read "Known Patterns" in CLAUDE.md and "Cross-Cutting Rules" in pipeline.md side-by-side. Also check for overlap between context-review.md checks and arch-audit C1–C17.
-
-Flag as WARN: any rule stated substantively in two files where one should be canonical.
-
-Report: duplicates with a recommendation on which file is the correct owner.
-
-**P4 - Pipeline complexity proportionality**
-Anthropic's principle: instruction complexity should be proportional to the actual risk and value it protects against. Over-specified pipelines make Claude slower and more likely to get stuck on process rather than output.
-
-Evaluate:
-
-- Are there phases (or sub-phases) whose STOP gate catches errors that have actually occurred in practice? Or are they theoretical?
-- Does the Fast Lane meaningfully simplify, or does it mostly duplicate the full pipeline?
-- Are there context-review checks (C1–C12) that have never caught a real issue - suggesting they address a risk that doesn't materialize?
-- Does the total length of pipeline.md + context-review.md stay within a range where Claude can hold the key constraints in working context?
-
-Report: any phase or check that appears to add friction without demonstrated value → RECOMMEND for review or consolidation. Note: do NOT recommend removing STOP gates without strong evidence of zero value - gates protect against irreversible actions.
-
-**P5 - Long context structure and scannability**
-Anthropic guidance for long system prompts: critical rules should be visually distinct and easy to locate. Recency and position matter - Claude gives more weight to recent context.
-
-Check:
-
-- Are the most-critical, most-referenced rules (RBAC, worktree isolation, migration isolation, environment isolation) marked as CRITICAL or placed at the top of their sections?
-- Is CLAUDE.md structured so Claude can find a rule without reading the entire file?
-- Are there sections that are rarely referenced but consume significant token space in every context window?
-
-Report: structural improvements for scannability → RECOMMEND.
-
-## Step 3d - Token & subagent optimization checks
-
-These checks audit the project's own efficiency at model selection and subagent delegation. Regressions here increase cost and latency without improving output quality. Judgment-based where noted; mechanical checks reuse the grep-tier haiku batch from Step 3b.
-
-**T1 - Research agent model in arch-audit Step 1**
-Check: does the Step 1 instruction in this SKILL.md specify `model: haiku` for the research agent?
-Batch command: `grep -n "model.*haiku\|haiku.*model" .claude/skills/arch-audit/SKILL.md`
-Expected: at least 1 match in the Step 1 section. Missing = FAIL.
-AUTO-FIX: add `(model: haiku)` to the research agent invocation in Step 1.
-
-**T2 - Haiku model on all Explore subagents across skills**
-Check: every "Launch ... Explore subagent" instruction in all SKILL.md files must explicitly name `model: haiku`.
-Batch command: `grep -rn "Explore subagent" .claude/skills/*/SKILL.md | grep -v "model.*haiku\|haiku"`
-Expected: 0 matches (all invocations already name haiku). Any match = FAIL.
-AUTO-FIX: append `(model: haiku)` to the invocation description in each failing line.
-
-**T3 - Phase 5d Playwright concurrency note**
-Check: does pipeline.md Phase 5d document that `/ui-audit` (static, no Playwright by default) can run concurrently with Playwright-based skills, and that `/visual-audit`, `/ux-audit`, `/responsive-audit` must run sequentially (shared MCP Playwright session)?
-Batch command: `grep -A30 "Phase 5d" .claude/rules/pipeline.md | grep -i "concurrent\|parallel\|sequenti\|playwright.*conflict\|conflict.*playwright"`
-Expected: at least 1 match. Missing = WARN.
-RECOMMEND if failing: add a note to Phase 5d: "Run `/ui-audit` concurrently with the first Playwright skill launch. Run `/visual-audit` → `/ux-audit` → `/responsive-audit` sequentially - they share the MCP Playwright session and cannot run in parallel."
-
-Batch commands:
-Expected: ≥1 match in each file. Missing from either = FAIL.
-
-**T5 - Skill model fitness (judgment)**
-For each skill, verify `model:` frontmatter fits the task's reasoning requirement:
-
-- `model: haiku` appropriate for: mechanical structural checks, pure grep/pattern matching, URL text extraction, formatting validation
-- `model: sonnet` appropriate for: cross-file judgment, complex analysis, fix application, multi-dimension scoring
-- `model: opus` appropriate for: screenshot-based visual reasoning, multi-role journey simulation, live aesthetic scoring - requires vision + deep analysis
-
-Current expected state:
-| Skill | Expected | Rationale |
-|---|---|---|
-| arch-audit | sonnet | Complex judgment, cross-doc analysis, AUTO-FIX application |
-| ui-audit | sonnet | Design system judgment, visual compliance scoring |
-| ux-audit | opus | Multi-flow simulation + live screenshot analysis - visual reasoning requires Opus |
-| visual-audit | opus | 7-dimension aesthetic scoring + screenshot analysis - visual reasoning requires Opus |
-| security-audit | sonnet | Exploit reasoning, authorization analysis |
-| api-design | sonnet | REST pattern judgment + internal haiku Explore agent |
-| perf-audit | sonnet | Bundle analysis, server/client boundary judgment + internal haiku Explore agent |
-| skill-dev | sonnet | Coupling/abstraction judgment + internal haiku Explore agent |
-| skill-db | opus | Deep schema normalization + RLS policy reasoning requires Opus - internal haiku Explore agent for dep scan |
-| responsive-audit | opus | Multi-viewport screenshot judgment - visual reasoning requires Opus |
-
-Batch command: `grep -A1 "^name:" .claude/skills/*/SKILL.md | grep "model:"` - compare each result against the table above.
-FAIL: any skill using `model: haiku` as top-level model (only Explore _subagents within_ skills should use haiku, not the skill itself).
-WARN: any skill using `model: opus` **unless** it is one of the intentional Opus skills: `visual-audit`, `ux-audit`, `responsive-audit` (screenshot-based visual reasoning) or `skill-db` (deep schema normalization + RLS policy reasoning). All other skills should use sonnet.
+- **Step 3c** - Anthropic Prompting Guide compliance against `CLAUDE.md`, `pipeline.md`, `context-review.md` + normative baseline `.claude/rules/claudemd-standards.md`. Covers P1 (content type inclusion test), P2 (instruction clarity), P3 (redundancy across instruction files), P4 (pipeline complexity proportionality), P5 (long context scannability). All judgment-based, PASS/WARN only, RECOMMEND never AUTO-FIX.
+- **Step 3d** - Token & subagent optimization. Covers T1 (research agent haiku in Step 1), T2 (Explore subagent haiku across skills), T3 (Playwright concurrency note in Phase 5d), T5 (skill model fitness table). Mix of mechanical grep and judgment.
 
 ## Step 3e - Pipeline.md compliance check
 
@@ -436,62 +332,18 @@ Output results in the Step 6 report under a new section:
 
 ## Step H1 - Hook compliance check
 
-Using hook documentation fetched in Step 1 (`https://code.claude.com/docs/en/hooks`) and `settings.json` read in Step 2, verify the project's hook configuration against current Anthropic spec.
+See [advanced-checks.md](advanced-checks.md) for the full content. Execute between Step 3e and Step 4.
 
-**H1a - Event name currency**
-Check: every event name in `settings.json` hooks matches the current official event list.
-Run: `grep -o '"SessionStart"\|"SessionEnd"\|"UserPromptSubmit"\|"UserPromptExpansion"\|"PreToolUse"\|"PostToolUse"\|"PostToolUseFailure"\|"Stop"\|"StopFailure"\|"PermissionRequest"\|"PermissionDenied"\|"SubagentStart"\|"SubagentStop"\|"TaskCreated"\|"TaskCompleted"\|"TeammateIdle"\|"FileChanged"\|"CwdChanged"\|"ConfigChange"\|"PreCompact"\|"PostCompact"\|"InstructionsLoaded"\|"Notification"\|"Elicitation"\|"ElicitationResult"\|"WorktreeCreate"\|"WorktreeRemove"' .claude/settings.json | sort -u`
-Pass: all events appear in the Step 1 documentation. Any unrecognized event → RECOMMEND removal or rename.
+Summary of the sub-checks:
 
-**H1b - JSON response field compliance (prompt hooks)**
-For each hook with `"type": "prompt"` in settings.json: check that response fields (`ok`, `reason`, `decision`, `updatedInput`) match the documented schema.
-Source: Step 1 hooks doc content.
-If divergence found → RECOMMEND (never AUTO-FIX): specify both files that need updating:
+- **H1a** - Event name currency against the official Anthropic event list (grep on `settings.json`).
+- **H1b** - JSON response field compliance for prompt-type hooks (`ok`, `reason`, `decision`, `updatedInput`).
+- **H1c** - Bypass mechanism visibility on blocking `UserPromptSubmit` hooks.
+- **H1d** - Hook type fitness (`command` vs `prompt` vs `agent`).
+- **H1e** - Rubric/hook drift between `prompt-quality-rubric.md` and inline hook logic.
+- **H1f** - New events to consider since last audit.
 
-- `.claude/settings.json` - the hook prompt inline text (authoritative)
-- `.claude/rules/prompt-quality-rubric.md` - the "Block output format" section (documentation, follows the hook)
-
-**H1c - Bypass mechanism visibility**
-Check: every `UserPromptSubmit` hook with `type: prompt` that can return a blocking response (`ok: false`) must include bypass instructions in the `reason` field.
-Fail → RECOMMEND update to add bypass instructions.
-
-**H1d - Hook type fitness**
-For each hook, verify `type` matches intent:
-
-- `command` - shell execution, dynamic state (git, files, env)
-- `prompt` - static/contextual text injection, no shell needed
-- `agent` - multi-step async logic
-  Flag as RECOMMEND (not AUTO-FIX) any `command` hook that only outputs static text and could be simplified to `prompt`.
-
-**H1e - Rubric-hook drift check**
-Check: `.claude/rules/prompt-quality-rubric.md` must stay in sync with the inline logic in the `UserPromptSubmit` prompt hooks in `settings.json`. Drift = the rubric documents behavior that the hook no longer implements (or vice versa).
-
-Run these two greps and compare results:
-
-- T3 wildcards in rubric: `grep "T3" .claude/rules/prompt-quality-rubric.md`
-- T3 wildcards in hook: `grep "T3" .claude/settings.json`
-
-Also check output format sync:
-
-- Rubric block format: `grep -A5 "Block output format" .claude/rules/prompt-quality-rubric.md`
-- Hook output format: look for the `If a trigger matches` instruction in the settings.json hook prompt
-
-Pass: T3 wildcard lists match; rubric output format matches hook output format structure.
-Fail → AUTO-FIX: update the rubric to match the hook (hook is authoritative - rubric is documentation). Update `Last updated` date in rubric.
-
-**H1f - New events to consider**
-
-Add results to Step 6 report under:
-
-```
-### Hook compliance (H1a–H1e)
-- H1a Event name currency: [PASS/FAIL - list unknown events if any]
-- H1b JSON response fields: [PASS/FAIL - list non-compliant fields if any]
-- H1c Bypass visibility: [PASS/FAIL - list hooks missing bypass guidance]
-- H1d Hook type fitness: [PASS/WARN - list command→prompt candidates]
-- H1e Rubric-hook drift: [PASS/FAIL - list any T3 or format divergences found]
-- H1f New events: [list relevant new events, or "none since last audit"]
-```
+Add results to the Step 6 report under `### Hook compliance (H1a–H1e)`.
 
 ## Step 4 - Apply AUTO-FIX changes
 

--- a/packages/cli/templates/tier-m/.claude/skills/arch-audit/advanced-checks.md
+++ b/packages/cli/templates/tier-m/.claude/skills/arch-audit/advanced-checks.md
@@ -1,0 +1,173 @@
+# Advanced compliance checks
+
+Reference file for `arch-audit`. Contains Step 3c (Anthropic Prompting Guide compliance), Step 3d (Token & subagent optimization), and Step H1 (Hook compliance). Extracted from `SKILL.md` to respect the Anthropic best-practice budget of ≤ 500 lines per skill body. Load this file when executing the corresponding steps; otherwise the content costs zero tokens.
+
+## Step 3c - Anthropic Prompting Guide compliance
+
+Using the prompting guide content fetched in Step 1 **and the normative baseline in `.claude/rules/claudemd-standards.md`** (read in Step 2), evaluate `CLAUDE.md`, `pipeline.md`, and `context-review.md` against best practices. The standards file is the local stable reference - use it as the primary benchmark; live-fetched docs confirm it's still current. These checks are judgment-based - classify each as PASS or WARN (not hard FAIL), and always RECOMMEND, never auto-fix.
+
+**Standards file currency check (run first)**: compare the `Last verified` date in `.claude/rules/claudemd-standards.md` against today's date. If > 30 days old AND Step 1 fetched new material changes → flag as RECOMMEND to update the standards file. If ≤ 30 days → skip.
+
+**P1 - CLAUDE.md content type (Anthropic's inclusion test)**
+Anthropic's rule: CLAUDE.md should contain ONLY non-obvious information Claude cannot infer by reading the code. Apply Anthropic's own test to every section: _"Would removing this cause Claude to make mistakes?"_
+
+Flag as WARN if a section:
+
+- Describes what a file does structurally (e.g. "file X handles Y") without explaining a non-obvious constraint - Claude can read the code
+- States a standard convention Claude already knows without a project-specific reason
+- Contains tutorial-style explanations of concepts (React, TypeScript, SQL) that Claude understands natively
+- Describes current session state or temporary phase status (this belongs in CLAUDE.local.md or MEMORY.md)
+
+Report: list any sections that fail the test with a suggested action (remove, condense, or move to a more appropriate file).
+
+**P2 - Instruction clarity and actionability**
+Anthropic's guidance: instructions must be specific, actionable, and unambiguous. A vague rule gives Claude discretion where a concrete rule would remove ambiguity.
+
+Flag as WARN:
+
+- Directives with no measurable outcome ("be thorough", "be careful", "verify appropriately")
+- Instructions that say "ensure X" without specifying how to verify X
+- Rules with implicit scope ("update relevant files") where an explicit list would prevent errors
+
+Report: flagged instances with suggested sharper wording.
+
+**P3 - Structural redundancy across instruction files**
+Redundancy dilutes attention. If a rule appears in both CLAUDE.md and pipeline.md with no clear canonical source, Claude may apply it inconsistently - or the longer file may suppress the shorter one.
+
+Check: read "Known Patterns" in CLAUDE.md and "Cross-Cutting Rules" in pipeline.md side-by-side. Also check for overlap between context-review.md checks and arch-audit C1–C17.
+
+Flag as WARN: any rule stated substantively in two files where one should be canonical.
+
+Report: duplicates with a recommendation on which file is the correct owner.
+
+**P4 - Pipeline complexity proportionality**
+Anthropic's principle: instruction complexity should be proportional to the actual risk and value it protects against. Over-specified pipelines make Claude slower and more likely to get stuck on process rather than output.
+
+Evaluate:
+
+- Are there phases (or sub-phases) whose STOP gate catches errors that have actually occurred in practice? Or are they theoretical?
+- Does the Fast Lane meaningfully simplify, or does it mostly duplicate the full pipeline?
+- Are there context-review checks (C1–C12) that have never caught a real issue - suggesting they address a risk that doesn't materialize?
+- Does the total length of pipeline.md + context-review.md stay within a range where Claude can hold the key constraints in working context?
+
+Report: any phase or check that appears to add friction without demonstrated value → RECOMMEND for review or consolidation. Note: do NOT recommend removing STOP gates without strong evidence of zero value - gates protect against irreversible actions.
+
+**P5 - Long context structure and scannability**
+Anthropic guidance for long system prompts: critical rules should be visually distinct and easy to locate. Recency and position matter - Claude gives more weight to recent context.
+
+Check:
+
+- Are the most-critical, most-referenced rules (RBAC, worktree isolation, migration isolation, environment isolation) marked as CRITICAL or placed at the top of their sections?
+- Is CLAUDE.md structured so Claude can find a rule without reading the entire file?
+- Are there sections that are rarely referenced but consume significant token space in every context window?
+
+Report: structural improvements for scannability → RECOMMEND.
+
+## Step 3d - Token & subagent optimization checks
+
+These checks audit the project's own efficiency at model selection and subagent delegation. Regressions here increase cost and latency without improving output quality. Judgment-based where noted; mechanical checks reuse the grep-tier haiku batch from Step 3b.
+
+**T1 - Research agent model in arch-audit Step 1**
+Check: does the Step 1 instruction in this SKILL.md specify `model: haiku` for the research agent?
+Batch command: `grep -n "model.*haiku\|haiku.*model" .claude/skills/arch-audit/SKILL.md`
+Expected: at least 1 match in the Step 1 section. Missing = FAIL.
+AUTO-FIX: add `(model: haiku)` to the research agent invocation in Step 1.
+
+**T2 - Haiku model on all Explore subagents across skills**
+Check: every "Launch ... Explore subagent" instruction in all SKILL.md files must explicitly name `model: haiku`.
+Batch command: `grep -rn "Explore subagent" .claude/skills/*/SKILL.md | grep -v "model.*haiku\|haiku"`
+Expected: 0 matches (all invocations already name haiku). Any match = FAIL.
+AUTO-FIX: append `(model: haiku)` to the invocation description in each failing line.
+
+**T3 - Phase 5d Playwright concurrency note**
+Check: does pipeline.md Phase 5d document that `/ui-audit` (static, no Playwright by default) can run concurrently with Playwright-based skills, and that `/visual-audit`, `/ux-audit`, `/responsive-audit` must run sequentially (shared MCP Playwright session)?
+Batch command: `grep -A30 "Phase 5d" .claude/rules/pipeline.md | grep -i "concurrent\|parallel\|sequenti\|playwright.*conflict\|conflict.*playwright"`
+Expected: at least 1 match. Missing = WARN.
+RECOMMEND if failing: add a note to Phase 5d: "Run `/ui-audit` concurrently with the first Playwright skill launch. Run `/visual-audit` → `/ux-audit` → `/responsive-audit` sequentially - they share the MCP Playwright session and cannot run in parallel."
+
+Batch commands:
+Expected: ≥1 match in each file. Missing from either = FAIL.
+
+**T5 - Skill model fitness (judgment)**
+For each skill, verify `model:` frontmatter fits the task's reasoning requirement:
+
+- `model: haiku` appropriate for: mechanical structural checks, pure grep/pattern matching, URL text extraction, formatting validation
+- `model: sonnet` appropriate for: cross-file judgment, complex analysis, fix application, multi-dimension scoring
+- `model: opus` appropriate for: screenshot-based visual reasoning, multi-role journey simulation, live aesthetic scoring - requires vision + deep analysis
+
+Current expected state:
+| Skill | Expected | Rationale |
+|---|---|---|
+| arch-audit | sonnet | Complex judgment, cross-doc analysis, AUTO-FIX application |
+| ui-audit | sonnet | Design system judgment, visual compliance scoring |
+| ux-audit | opus | Multi-flow simulation + live screenshot analysis - visual reasoning requires Opus |
+| visual-audit | opus | 7-dimension aesthetic scoring + screenshot analysis - visual reasoning requires Opus |
+| security-audit | sonnet | Exploit reasoning, authorization analysis |
+| api-design | sonnet | REST pattern judgment + internal haiku Explore agent |
+| perf-audit | sonnet | Bundle analysis, server/client boundary judgment + internal haiku Explore agent |
+| skill-dev | sonnet | Coupling/abstraction judgment + internal haiku Explore agent |
+| skill-db | opus | Deep schema normalization + RLS policy reasoning requires Opus - internal haiku Explore agent for dep scan |
+| responsive-audit | opus | Multi-viewport screenshot judgment - visual reasoning requires Opus |
+
+Batch command: `grep -A1 "^name:" .claude/skills/*/SKILL.md | grep "model:"` - compare each result against the table above.
+FAIL: any skill using `model: haiku` as top-level model (only Explore _subagents within_ skills should use haiku, not the skill itself).
+WARN: any skill using `model: opus` **unless** it is one of the intentional Opus skills: `visual-audit`, `ux-audit`, `responsive-audit` (screenshot-based visual reasoning) or `skill-db` (deep schema normalization + RLS policy reasoning). All other skills should use sonnet.
+
+## Step H1 - Hook compliance check
+
+Using hook documentation fetched in Step 1 (`https://code.claude.com/docs/en/hooks`) and `settings.json` read in Step 2, verify the project's hook configuration against current Anthropic spec.
+
+**H1a - Event name currency**
+Check: every event name in `settings.json` hooks matches the current official event list.
+Run: `grep -o '"SessionStart"\|"SessionEnd"\|"UserPromptSubmit"\|"UserPromptExpansion"\|"PreToolUse"\|"PostToolUse"\|"PostToolUseFailure"\|"Stop"\|"StopFailure"\|"PermissionRequest"\|"PermissionDenied"\|"SubagentStart"\|"SubagentStop"\|"TaskCreated"\|"TaskCompleted"\|"TeammateIdle"\|"FileChanged"\|"CwdChanged"\|"ConfigChange"\|"PreCompact"\|"PostCompact"\|"InstructionsLoaded"\|"Notification"\|"Elicitation"\|"ElicitationResult"\|"WorktreeCreate"\|"WorktreeRemove"' .claude/settings.json | sort -u`
+Pass: all events appear in the Step 1 documentation. Any unrecognized event → RECOMMEND removal or rename.
+
+**H1b - JSON response field compliance (prompt hooks)**
+For each hook with `"type": "prompt"` in settings.json: check that response fields (`ok`, `reason`, `decision`, `updatedInput`) match the documented schema.
+Source: Step 1 hooks doc content.
+If divergence found → RECOMMEND (never AUTO-FIX): specify both files that need updating:
+
+- `.claude/settings.json` - the hook prompt inline text (authoritative)
+- `.claude/rules/prompt-quality-rubric.md` - the "Block output format" section (documentation, follows the hook)
+
+**H1c - Bypass mechanism visibility**
+Check: every `UserPromptSubmit` hook with `type: prompt` that can return a blocking response (`ok: false`) must include bypass instructions in the `reason` field.
+Fail → RECOMMEND update to add bypass instructions.
+
+**H1d - Hook type fitness**
+For each hook, verify `type` matches intent:
+
+- `command` - shell execution, dynamic state (git, files, env)
+- `prompt` - static/contextual text injection, no shell needed
+- `agent` - multi-step async logic
+  Flag as RECOMMEND (not AUTO-FIX) any `command` hook that only outputs static text and could be simplified to `prompt`.
+
+**H1e - Rubric-hook drift check**
+Check: `.claude/rules/prompt-quality-rubric.md` must stay in sync with the inline logic in the `UserPromptSubmit` prompt hooks in `settings.json`. Drift = the rubric documents behavior that the hook no longer implements (or vice versa).
+
+Run these two greps and compare results:
+
+- T3 wildcards in rubric: `grep "T3" .claude/rules/prompt-quality-rubric.md`
+- T3 wildcards in hook: `grep "T3" .claude/settings.json`
+
+Also check output format sync:
+
+- Rubric block format: `grep -A5 "Block output format" .claude/rules/prompt-quality-rubric.md`
+- Hook output format: look for the `If a trigger matches` instruction in the settings.json hook prompt
+
+Pass: T3 wildcard lists match; rubric output format matches hook output format structure.
+Fail → AUTO-FIX: update the rubric to match the hook (hook is authoritative - rubric is documentation). Update `Last updated` date in rubric.
+
+**H1f - New events to consider**
+
+Add results to Step 6 report under:
+
+```
+### Hook compliance (H1a–H1e)
+- H1a Event name currency: [PASS/FAIL - list unknown events if any]
+- H1b JSON response fields: [PASS/FAIL - list non-compliant fields if any]
+- H1c Bypass visibility: [PASS/FAIL - list hooks missing bypass guidance]
+- H1d Hook type fitness: [PASS/WARN - list command→prompt candidates]
+- H1e Rubric-hook drift: [PASS/FAIL - list any T3 or format divergences found]
+- H1f New events: [list relevant new events, or "none since last audit"]
+```

--- a/packages/cli/templates/tier-m/.claude/skills/skill-review/SKILL.md
+++ b/packages/cli/templates/tier-m/.claude/skills/skill-review/SKILL.md
@@ -5,7 +5,7 @@ user-invocable: true
 model: opus
 context: fork
 argument-hint: [skill-name] [tier:S|M|L|all] [mode:full|preflight-only|fixtures-only]
-allowed-tools: Read, Glob, Grep, Bash
+allowed-tools: Read Glob Grep Bash
 ---
 
 You are a skill-quality reviewer running the framework v1.2 pipeline in **lite mode** (Tier M). Your job: orchestrate a focused review for small portfolios, enforce STOP gates, keep findings rubric-anchored. You produce findings - you do not silently fix. Fixes happen in Phase 3 after explicit user Go.
@@ -63,21 +63,26 @@ Execute C1-C8 from `SPEC_SNAPSHOT.md` §1-§7. Binary pass/fail per check.
 Execute sequentially: 2.A → 2.B → 2.C → 2.D → 2.E (if applicable).
 
 ### 2.A - Fundamentals
+
 - Clarity, scope boundary, project-agnosticity (4 dimensions: literal / severity habits / remediation style / architectural assumptions).
 
 ### 2.B - Cross-tier coherence
+
 If `tier:all`: load every tier variant, produce a column-by-column diff. Classify each delta as expected (scope, verbosity, tool-set) or unexpected.
 
-***** STOP - cross-tier delta review. Wait for user confirmation before Phase 3 propagation. *****
+**\*** STOP - cross-tier delta review. Wait for user confirmation before Phase 3 propagation. **\***
 
 ### 2.C - Refinements
+
 - Token efficiency per section.
 - Boilerplate drift vs most-recently-reviewed sibling.
 
 ### 2.D - Interactive walkthrough
+
 Always use `AskUserQuestion` tool for multi-option review questions - never inline prose.
 
-### 2.E - Behavioral fixtures *(optional in lite mode; run only if skill is UI-heavy or security-critical)*
+### 2.E - Behavioral fixtures _(optional in lite mode; run only if skill is UI-heavy or security-critical)_
+
 - 2 representative cases.
 - 1 adversarial case.
 - 1 severity-calibration case.
@@ -96,7 +101,7 @@ Max 3 fix attempts per Critical finding.
 4. Token count post-fix. Hard-fail > 5000 tokens.
 5. Any regression: revert, escalate with root-cause.
 
-***** STOP - Phase 3 closeout. User approves the diff before proceeding. *****
+**\*** STOP - Phase 3 closeout. User approves the diff before proceeding. **\***
 
 ---
 
@@ -132,7 +137,7 @@ Rationale: external LLM review adds ~60-90 min per skill (prompt generation + 3 
 - path/to/file - description
 ```
 
-***** STOP - explicit user confirmation before marking complete. *****
+**\*** STOP - explicit user confirmation before marking complete. **\***
 
 ---
 

--- a/packages/cli/templates/tier-s/.claude/skills/arch-audit/SKILL.md
+++ b/packages/cli/templates/tier-s/.claude/skills/arch-audit/SKILL.md
@@ -243,116 +243,12 @@ Run: `for f in .claude/skills/*/SKILL.md; do name=$(basename $(dirname "$f")); [
 Expected: 0 MISSING lines. Any match = FAIL.
 AUTO-FIX: for each failing skill, read the `mcp__*` tool names from its body and add `allowed-tools: [mcp__tool1, mcp__tool2, ...]` to its frontmatter after the `context:` line.
 
-## Step 3c - Anthropic Prompting Guide compliance
+## Step 3c/3d - Prompting Guide + token/subagent optimization
 
-Using the prompting guide content fetched in Step 1 **and the normative baseline in `.claude/rules/claudemd-standards.md`** (read in Step 2), evaluate `CLAUDE.md`, `pipeline.md`, and `context-review.md` against best practices. The standards file is the local stable reference - use it as the primary benchmark; live-fetched docs confirm it's still current. These checks are judgment-based - classify each as PASS or WARN (not hard FAIL), and always RECOMMEND, never auto-fix.
+See [advanced-checks.md](advanced-checks.md) for the full content of these steps. Execute them before Step 3e.
 
-**Standards file currency check (run first)**: compare the `Last verified` date in `.claude/rules/claudemd-standards.md` against today's date. If > 30 days old AND Step 1 fetched new material changes → flag as RECOMMEND to update the standards file. If ≤ 30 days → skip.
-
-**P1 - CLAUDE.md content type (Anthropic's inclusion test)**
-Anthropic's rule: CLAUDE.md should contain ONLY non-obvious information Claude cannot infer by reading the code. Apply Anthropic's own test to every section: _"Would removing this cause Claude to make mistakes?"_
-
-Flag as WARN if a section:
-
-- Describes what a file does structurally (e.g. "file X handles Y") without explaining a non-obvious constraint - Claude can read the code
-- States a standard convention Claude already knows without a project-specific reason
-- Contains tutorial-style explanations of concepts (React, TypeScript, SQL) that Claude understands natively
-- Describes current session state or temporary phase status (this belongs in CLAUDE.local.md or MEMORY.md)
-
-Report: list any sections that fail the test with a suggested action (remove, condense, or move to a more appropriate file).
-
-**P2 - Instruction clarity and actionability**
-Anthropic's guidance: instructions must be specific, actionable, and unambiguous. A vague rule gives Claude discretion where a concrete rule would remove ambiguity.
-
-Flag as WARN:
-
-- Directives with no measurable outcome ("be thorough", "be careful", "verify appropriately")
-- Instructions that say "ensure X" without specifying how to verify X
-- Rules with implicit scope ("update relevant files") where an explicit list would prevent errors
-
-Report: flagged instances with suggested sharper wording.
-
-**P3 - Structural redundancy across instruction files**
-Redundancy dilutes attention. If a rule appears in both CLAUDE.md and pipeline.md with no clear canonical source, Claude may apply it inconsistently - or the longer file may suppress the shorter one.
-
-Check: read "Known Patterns" in CLAUDE.md and "Cross-Cutting Rules" in pipeline.md side-by-side. Also check for overlap between context-review.md checks and arch-audit C1–C17.
-
-Flag as WARN: any rule stated substantively in two files where one should be canonical.
-
-Report: duplicates with a recommendation on which file is the correct owner.
-
-**P4 - Pipeline complexity proportionality**
-Anthropic's principle: instruction complexity should be proportional to the actual risk and value it protects against. Over-specified pipelines make Claude slower and more likely to get stuck on process rather than output.
-
-Evaluate:
-
-- Are there phases (or sub-phases) whose STOP gate catches errors that have actually occurred in practice? Or are they theoretical?
-- Does the Fast Lane meaningfully simplify, or does it mostly duplicate the full pipeline?
-- Are there context-review checks (C1–C12) that have never caught a real issue - suggesting they address a risk that doesn't materialize?
-- Does the total length of pipeline.md + context-review.md stay within a range where Claude can hold the key constraints in working context?
-
-Report: any phase or check that appears to add friction without demonstrated value → RECOMMEND for review or consolidation. Note: do NOT recommend removing STOP gates without strong evidence of zero value - gates protect against irreversible actions.
-
-**P5 - Long context structure and scannability**
-Anthropic guidance for long system prompts: critical rules should be visually distinct and easy to locate. Recency and position matter - Claude gives more weight to recent context.
-
-Check:
-
-- Are the most-critical, most-referenced rules (RBAC, worktree isolation, migration isolation, environment isolation) marked as CRITICAL or placed at the top of their sections?
-- Is CLAUDE.md structured so Claude can find a rule without reading the entire file?
-- Are there sections that are rarely referenced but consume significant token space in every context window?
-
-Report: structural improvements for scannability → RECOMMEND.
-
-## Step 3d - Token & subagent optimization checks
-
-These checks audit the project's own efficiency at model selection and subagent delegation. Regressions here increase cost and latency without improving output quality. Judgment-based where noted; mechanical checks reuse the grep-tier haiku batch from Step 3b.
-
-**T1 - Research agent model in arch-audit Step 1**
-Check: does the Step 1 instruction in this SKILL.md specify `model: haiku` for the research agent?
-Batch command: `grep -n "model.*haiku\|haiku.*model" .claude/skills/arch-audit/SKILL.md`
-Expected: at least 1 match in the Step 1 section. Missing = FAIL.
-AUTO-FIX: add `(model: haiku)` to the research agent invocation in Step 1.
-
-**T2 - Haiku model on all Explore subagents across skills**
-Check: every "Launch ... Explore subagent" instruction in all SKILL.md files must explicitly name `model: haiku`.
-Batch command: `grep -rn "Explore subagent" .claude/skills/*/SKILL.md | grep -v "model.*haiku\|haiku"`
-Expected: 0 matches (all invocations already name haiku). Any match = FAIL.
-AUTO-FIX: append `(model: haiku)` to the invocation description in each failing line.
-
-**T3 - Phase 5d Playwright concurrency note**
-Check: does pipeline.md Phase 5d document that `/ui-audit` (static, no Playwright by default) can run concurrently with Playwright-based skills, and that `/visual-audit`, `/ux-audit`, `/responsive-audit` must run sequentially (shared MCP Playwright session)?
-Batch command: `grep -A30 "Phase 5d" .claude/rules/pipeline.md | grep -i "concurrent\|parallel\|sequenti\|playwright.*conflict\|conflict.*playwright"`
-Expected: at least 1 match. Missing = WARN.
-RECOMMEND if failing: add a note to Phase 5d: "Run `/ui-audit` concurrently with the first Playwright skill launch. Run `/visual-audit` → `/ux-audit` → `/responsive-audit` sequentially - they share the MCP Playwright session and cannot run in parallel."
-
-Batch commands:
-Expected: ≥1 match in each file. Missing from either = FAIL.
-
-**T5 - Skill model fitness (judgment)**
-For each skill, verify `model:` frontmatter fits the task's reasoning requirement:
-
-- `model: haiku` appropriate for: mechanical structural checks, pure grep/pattern matching, URL text extraction, formatting validation
-- `model: sonnet` appropriate for: cross-file judgment, complex analysis, fix application, multi-dimension scoring
-- `model: opus` appropriate for: screenshot-based visual reasoning, multi-role journey simulation, live aesthetic scoring - requires vision + deep analysis
-
-Current expected state:
-| Skill | Expected | Rationale |
-|---|---|---|
-| arch-audit | sonnet | Complex judgment, cross-doc analysis, AUTO-FIX application |
-| ui-audit | sonnet | Design system judgment, visual compliance scoring |
-| ux-audit | opus | Multi-flow simulation + live screenshot analysis - visual reasoning requires Opus |
-| visual-audit | opus | 7-dimension aesthetic scoring + screenshot analysis - visual reasoning requires Opus |
-| security-audit | sonnet | Exploit reasoning, authorization analysis |
-| api-design | sonnet | REST pattern judgment + internal haiku Explore agent |
-| perf-audit | sonnet | Bundle analysis, server/client boundary judgment + internal haiku Explore agent |
-| skill-dev | sonnet | Coupling/abstraction judgment + internal haiku Explore agent |
-| skill-db | opus | Deep schema normalization + RLS policy reasoning requires Opus - internal haiku Explore agent for dep scan |
-| responsive-audit | opus | Multi-viewport screenshot judgment - visual reasoning requires Opus |
-
-Batch command: `grep -A1 "^name:" .claude/skills/*/SKILL.md | grep "model:"` - compare each result against the table above.
-FAIL: any skill using `model: haiku` as top-level model (only Explore _subagents within_ skills should use haiku, not the skill itself).
-WARN: any skill using `model: opus` **unless** it is one of the intentional Opus skills: `visual-audit`, `ux-audit`, `responsive-audit` (screenshot-based visual reasoning) or `skill-db` (deep schema normalization + RLS policy reasoning). All other skills should use sonnet.
+- **Step 3c** - Anthropic Prompting Guide compliance against `CLAUDE.md`, `pipeline.md`, `context-review.md` + normative baseline `.claude/rules/claudemd-standards.md`. Covers P1 (content type inclusion test), P2 (instruction clarity), P3 (redundancy across instruction files), P4 (pipeline complexity proportionality), P5 (long context scannability). All judgment-based, PASS/WARN only, RECOMMEND never AUTO-FIX.
+- **Step 3d** - Token & subagent optimization. Covers T1 (research agent haiku in Step 1), T2 (Explore subagent haiku across skills), T3 (Playwright concurrency note in Phase 5d), T5 (skill model fitness table). Mix of mechanical grep and judgment.
 
 ## Step 3e - Pipeline.md compliance check
 
@@ -436,62 +332,18 @@ Output results in the Step 6 report under a new section:
 
 ## Step H1 - Hook compliance check
 
-Using hook documentation fetched in Step 1 (`https://code.claude.com/docs/en/hooks`) and `settings.json` read in Step 2, verify the project's hook configuration against current Anthropic spec.
+See [advanced-checks.md](advanced-checks.md) for the full content. Execute between Step 3e and Step 4.
 
-**H1a - Event name currency**
-Check: every event name in `settings.json` hooks matches the current official event list.
-Run: `grep -o '"SessionStart"\|"SessionEnd"\|"UserPromptSubmit"\|"UserPromptExpansion"\|"PreToolUse"\|"PostToolUse"\|"PostToolUseFailure"\|"Stop"\|"StopFailure"\|"PermissionRequest"\|"PermissionDenied"\|"SubagentStart"\|"SubagentStop"\|"TaskCreated"\|"TaskCompleted"\|"TeammateIdle"\|"FileChanged"\|"CwdChanged"\|"ConfigChange"\|"PreCompact"\|"PostCompact"\|"InstructionsLoaded"\|"Notification"\|"Elicitation"\|"ElicitationResult"\|"WorktreeCreate"\|"WorktreeRemove"' .claude/settings.json | sort -u`
-Pass: all events appear in the Step 1 documentation. Any unrecognized event → RECOMMEND removal or rename.
+Summary of the sub-checks:
 
-**H1b - JSON response field compliance (prompt hooks)**
-For each hook with `"type": "prompt"` in settings.json: check that response fields (`ok`, `reason`, `decision`, `updatedInput`) match the documented schema.
-Source: Step 1 hooks doc content.
-If divergence found → RECOMMEND (never AUTO-FIX): specify both files that need updating:
+- **H1a** - Event name currency against the official Anthropic event list (grep on `settings.json`).
+- **H1b** - JSON response field compliance for prompt-type hooks (`ok`, `reason`, `decision`, `updatedInput`).
+- **H1c** - Bypass mechanism visibility on blocking `UserPromptSubmit` hooks.
+- **H1d** - Hook type fitness (`command` vs `prompt` vs `agent`).
+- **H1e** - Rubric/hook drift between `prompt-quality-rubric.md` and inline hook logic.
+- **H1f** - New events to consider since last audit.
 
-- `.claude/settings.json` - the hook prompt inline text (authoritative)
-- `.claude/rules/prompt-quality-rubric.md` - the "Block output format" section (documentation, follows the hook)
-
-**H1c - Bypass mechanism visibility**
-Check: every `UserPromptSubmit` hook with `type: prompt` that can return a blocking response (`ok: false`) must include bypass instructions in the `reason` field.
-Fail → RECOMMEND update to add bypass instructions.
-
-**H1d - Hook type fitness**
-For each hook, verify `type` matches intent:
-
-- `command` - shell execution, dynamic state (git, files, env)
-- `prompt` - static/contextual text injection, no shell needed
-- `agent` - multi-step async logic
-  Flag as RECOMMEND (not AUTO-FIX) any `command` hook that only outputs static text and could be simplified to `prompt`.
-
-**H1e - Rubric-hook drift check**
-Check: `.claude/rules/prompt-quality-rubric.md` must stay in sync with the inline logic in the `UserPromptSubmit` prompt hooks in `settings.json`. Drift = the rubric documents behavior that the hook no longer implements (or vice versa).
-
-Run these two greps and compare results:
-
-- T3 wildcards in rubric: `grep "T3" .claude/rules/prompt-quality-rubric.md`
-- T3 wildcards in hook: `grep "T3" .claude/settings.json`
-
-Also check output format sync:
-
-- Rubric block format: `grep -A5 "Block output format" .claude/rules/prompt-quality-rubric.md`
-- Hook output format: look for the `If a trigger matches` instruction in the settings.json hook prompt
-
-Pass: T3 wildcard lists match; rubric output format matches hook output format structure.
-Fail → AUTO-FIX: update the rubric to match the hook (hook is authoritative - rubric is documentation). Update `Last updated` date in rubric.
-
-**H1f - New events to consider**
-
-Add results to Step 6 report under:
-
-```
-### Hook compliance (H1a–H1e)
-- H1a Event name currency: [PASS/FAIL - list unknown events if any]
-- H1b JSON response fields: [PASS/FAIL - list non-compliant fields if any]
-- H1c Bypass visibility: [PASS/FAIL - list hooks missing bypass guidance]
-- H1d Hook type fitness: [PASS/WARN - list command→prompt candidates]
-- H1e Rubric-hook drift: [PASS/FAIL - list any T3 or format divergences found]
-- H1f New events: [list relevant new events, or "none since last audit"]
-```
+Add results to the Step 6 report under `### Hook compliance (H1a–H1e)`.
 
 ## Step 4 - Apply AUTO-FIX changes
 

--- a/packages/cli/templates/tier-s/.claude/skills/arch-audit/advanced-checks.md
+++ b/packages/cli/templates/tier-s/.claude/skills/arch-audit/advanced-checks.md
@@ -1,0 +1,173 @@
+# Advanced compliance checks
+
+Reference file for `arch-audit`. Contains Step 3c (Anthropic Prompting Guide compliance), Step 3d (Token & subagent optimization), and Step H1 (Hook compliance). Extracted from `SKILL.md` to respect the Anthropic best-practice budget of ≤ 500 lines per skill body. Load this file when executing the corresponding steps; otherwise the content costs zero tokens.
+
+## Step 3c - Anthropic Prompting Guide compliance
+
+Using the prompting guide content fetched in Step 1 **and the normative baseline in `.claude/rules/claudemd-standards.md`** (read in Step 2), evaluate `CLAUDE.md`, `pipeline.md`, and `context-review.md` against best practices. The standards file is the local stable reference - use it as the primary benchmark; live-fetched docs confirm it's still current. These checks are judgment-based - classify each as PASS or WARN (not hard FAIL), and always RECOMMEND, never auto-fix.
+
+**Standards file currency check (run first)**: compare the `Last verified` date in `.claude/rules/claudemd-standards.md` against today's date. If > 30 days old AND Step 1 fetched new material changes → flag as RECOMMEND to update the standards file. If ≤ 30 days → skip.
+
+**P1 - CLAUDE.md content type (Anthropic's inclusion test)**
+Anthropic's rule: CLAUDE.md should contain ONLY non-obvious information Claude cannot infer by reading the code. Apply Anthropic's own test to every section: _"Would removing this cause Claude to make mistakes?"_
+
+Flag as WARN if a section:
+
+- Describes what a file does structurally (e.g. "file X handles Y") without explaining a non-obvious constraint - Claude can read the code
+- States a standard convention Claude already knows without a project-specific reason
+- Contains tutorial-style explanations of concepts (React, TypeScript, SQL) that Claude understands natively
+- Describes current session state or temporary phase status (this belongs in CLAUDE.local.md or MEMORY.md)
+
+Report: list any sections that fail the test with a suggested action (remove, condense, or move to a more appropriate file).
+
+**P2 - Instruction clarity and actionability**
+Anthropic's guidance: instructions must be specific, actionable, and unambiguous. A vague rule gives Claude discretion where a concrete rule would remove ambiguity.
+
+Flag as WARN:
+
+- Directives with no measurable outcome ("be thorough", "be careful", "verify appropriately")
+- Instructions that say "ensure X" without specifying how to verify X
+- Rules with implicit scope ("update relevant files") where an explicit list would prevent errors
+
+Report: flagged instances with suggested sharper wording.
+
+**P3 - Structural redundancy across instruction files**
+Redundancy dilutes attention. If a rule appears in both CLAUDE.md and pipeline.md with no clear canonical source, Claude may apply it inconsistently - or the longer file may suppress the shorter one.
+
+Check: read "Known Patterns" in CLAUDE.md and "Cross-Cutting Rules" in pipeline.md side-by-side. Also check for overlap between context-review.md checks and arch-audit C1–C17.
+
+Flag as WARN: any rule stated substantively in two files where one should be canonical.
+
+Report: duplicates with a recommendation on which file is the correct owner.
+
+**P4 - Pipeline complexity proportionality**
+Anthropic's principle: instruction complexity should be proportional to the actual risk and value it protects against. Over-specified pipelines make Claude slower and more likely to get stuck on process rather than output.
+
+Evaluate:
+
+- Are there phases (or sub-phases) whose STOP gate catches errors that have actually occurred in practice? Or are they theoretical?
+- Does the Fast Lane meaningfully simplify, or does it mostly duplicate the full pipeline?
+- Are there context-review checks (C1–C12) that have never caught a real issue - suggesting they address a risk that doesn't materialize?
+- Does the total length of pipeline.md + context-review.md stay within a range where Claude can hold the key constraints in working context?
+
+Report: any phase or check that appears to add friction without demonstrated value → RECOMMEND for review or consolidation. Note: do NOT recommend removing STOP gates without strong evidence of zero value - gates protect against irreversible actions.
+
+**P5 - Long context structure and scannability**
+Anthropic guidance for long system prompts: critical rules should be visually distinct and easy to locate. Recency and position matter - Claude gives more weight to recent context.
+
+Check:
+
+- Are the most-critical, most-referenced rules (RBAC, worktree isolation, migration isolation, environment isolation) marked as CRITICAL or placed at the top of their sections?
+- Is CLAUDE.md structured so Claude can find a rule without reading the entire file?
+- Are there sections that are rarely referenced but consume significant token space in every context window?
+
+Report: structural improvements for scannability → RECOMMEND.
+
+## Step 3d - Token & subagent optimization checks
+
+These checks audit the project's own efficiency at model selection and subagent delegation. Regressions here increase cost and latency without improving output quality. Judgment-based where noted; mechanical checks reuse the grep-tier haiku batch from Step 3b.
+
+**T1 - Research agent model in arch-audit Step 1**
+Check: does the Step 1 instruction in this SKILL.md specify `model: haiku` for the research agent?
+Batch command: `grep -n "model.*haiku\|haiku.*model" .claude/skills/arch-audit/SKILL.md`
+Expected: at least 1 match in the Step 1 section. Missing = FAIL.
+AUTO-FIX: add `(model: haiku)` to the research agent invocation in Step 1.
+
+**T2 - Haiku model on all Explore subagents across skills**
+Check: every "Launch ... Explore subagent" instruction in all SKILL.md files must explicitly name `model: haiku`.
+Batch command: `grep -rn "Explore subagent" .claude/skills/*/SKILL.md | grep -v "model.*haiku\|haiku"`
+Expected: 0 matches (all invocations already name haiku). Any match = FAIL.
+AUTO-FIX: append `(model: haiku)` to the invocation description in each failing line.
+
+**T3 - Phase 5d Playwright concurrency note**
+Check: does pipeline.md Phase 5d document that `/ui-audit` (static, no Playwright by default) can run concurrently with Playwright-based skills, and that `/visual-audit`, `/ux-audit`, `/responsive-audit` must run sequentially (shared MCP Playwright session)?
+Batch command: `grep -A30 "Phase 5d" .claude/rules/pipeline.md | grep -i "concurrent\|parallel\|sequenti\|playwright.*conflict\|conflict.*playwright"`
+Expected: at least 1 match. Missing = WARN.
+RECOMMEND if failing: add a note to Phase 5d: "Run `/ui-audit` concurrently with the first Playwright skill launch. Run `/visual-audit` → `/ux-audit` → `/responsive-audit` sequentially - they share the MCP Playwright session and cannot run in parallel."
+
+Batch commands:
+Expected: ≥1 match in each file. Missing from either = FAIL.
+
+**T5 - Skill model fitness (judgment)**
+For each skill, verify `model:` frontmatter fits the task's reasoning requirement:
+
+- `model: haiku` appropriate for: mechanical structural checks, pure grep/pattern matching, URL text extraction, formatting validation
+- `model: sonnet` appropriate for: cross-file judgment, complex analysis, fix application, multi-dimension scoring
+- `model: opus` appropriate for: screenshot-based visual reasoning, multi-role journey simulation, live aesthetic scoring - requires vision + deep analysis
+
+Current expected state:
+| Skill | Expected | Rationale |
+|---|---|---|
+| arch-audit | sonnet | Complex judgment, cross-doc analysis, AUTO-FIX application |
+| ui-audit | sonnet | Design system judgment, visual compliance scoring |
+| ux-audit | opus | Multi-flow simulation + live screenshot analysis - visual reasoning requires Opus |
+| visual-audit | opus | 7-dimension aesthetic scoring + screenshot analysis - visual reasoning requires Opus |
+| security-audit | sonnet | Exploit reasoning, authorization analysis |
+| api-design | sonnet | REST pattern judgment + internal haiku Explore agent |
+| perf-audit | sonnet | Bundle analysis, server/client boundary judgment + internal haiku Explore agent |
+| skill-dev | sonnet | Coupling/abstraction judgment + internal haiku Explore agent |
+| skill-db | opus | Deep schema normalization + RLS policy reasoning requires Opus - internal haiku Explore agent for dep scan |
+| responsive-audit | opus | Multi-viewport screenshot judgment - visual reasoning requires Opus |
+
+Batch command: `grep -A1 "^name:" .claude/skills/*/SKILL.md | grep "model:"` - compare each result against the table above.
+FAIL: any skill using `model: haiku` as top-level model (only Explore _subagents within_ skills should use haiku, not the skill itself).
+WARN: any skill using `model: opus` **unless** it is one of the intentional Opus skills: `visual-audit`, `ux-audit`, `responsive-audit` (screenshot-based visual reasoning) or `skill-db` (deep schema normalization + RLS policy reasoning). All other skills should use sonnet.
+
+## Step H1 - Hook compliance check
+
+Using hook documentation fetched in Step 1 (`https://code.claude.com/docs/en/hooks`) and `settings.json` read in Step 2, verify the project's hook configuration against current Anthropic spec.
+
+**H1a - Event name currency**
+Check: every event name in `settings.json` hooks matches the current official event list.
+Run: `grep -o '"SessionStart"\|"SessionEnd"\|"UserPromptSubmit"\|"UserPromptExpansion"\|"PreToolUse"\|"PostToolUse"\|"PostToolUseFailure"\|"Stop"\|"StopFailure"\|"PermissionRequest"\|"PermissionDenied"\|"SubagentStart"\|"SubagentStop"\|"TaskCreated"\|"TaskCompleted"\|"TeammateIdle"\|"FileChanged"\|"CwdChanged"\|"ConfigChange"\|"PreCompact"\|"PostCompact"\|"InstructionsLoaded"\|"Notification"\|"Elicitation"\|"ElicitationResult"\|"WorktreeCreate"\|"WorktreeRemove"' .claude/settings.json | sort -u`
+Pass: all events appear in the Step 1 documentation. Any unrecognized event → RECOMMEND removal or rename.
+
+**H1b - JSON response field compliance (prompt hooks)**
+For each hook with `"type": "prompt"` in settings.json: check that response fields (`ok`, `reason`, `decision`, `updatedInput`) match the documented schema.
+Source: Step 1 hooks doc content.
+If divergence found → RECOMMEND (never AUTO-FIX): specify both files that need updating:
+
+- `.claude/settings.json` - the hook prompt inline text (authoritative)
+- `.claude/rules/prompt-quality-rubric.md` - the "Block output format" section (documentation, follows the hook)
+
+**H1c - Bypass mechanism visibility**
+Check: every `UserPromptSubmit` hook with `type: prompt` that can return a blocking response (`ok: false`) must include bypass instructions in the `reason` field.
+Fail → RECOMMEND update to add bypass instructions.
+
+**H1d - Hook type fitness**
+For each hook, verify `type` matches intent:
+
+- `command` - shell execution, dynamic state (git, files, env)
+- `prompt` - static/contextual text injection, no shell needed
+- `agent` - multi-step async logic
+  Flag as RECOMMEND (not AUTO-FIX) any `command` hook that only outputs static text and could be simplified to `prompt`.
+
+**H1e - Rubric-hook drift check**
+Check: `.claude/rules/prompt-quality-rubric.md` must stay in sync with the inline logic in the `UserPromptSubmit` prompt hooks in `settings.json`. Drift = the rubric documents behavior that the hook no longer implements (or vice versa).
+
+Run these two greps and compare results:
+
+- T3 wildcards in rubric: `grep "T3" .claude/rules/prompt-quality-rubric.md`
+- T3 wildcards in hook: `grep "T3" .claude/settings.json`
+
+Also check output format sync:
+
+- Rubric block format: `grep -A5 "Block output format" .claude/rules/prompt-quality-rubric.md`
+- Hook output format: look for the `If a trigger matches` instruction in the settings.json hook prompt
+
+Pass: T3 wildcard lists match; rubric output format matches hook output format structure.
+Fail → AUTO-FIX: update the rubric to match the hook (hook is authoritative - rubric is documentation). Update `Last updated` date in rubric.
+
+**H1f - New events to consider**
+
+Add results to Step 6 report under:
+
+```
+### Hook compliance (H1a–H1e)
+- H1a Event name currency: [PASS/FAIL - list unknown events if any]
+- H1b JSON response fields: [PASS/FAIL - list non-compliant fields if any]
+- H1c Bypass visibility: [PASS/FAIL - list hooks missing bypass guidance]
+- H1d Hook type fitness: [PASS/WARN - list command→prompt candidates]
+- H1e Rubric-hook drift: [PASS/FAIL - list any T3 or format divergences found]
+- H1f New events: [list relevant new events, or "none since last audit"]
+```

--- a/packages/cli/test/integration/run.js
+++ b/packages/cli/test/integration/run.js
@@ -19,6 +19,12 @@ import { execFileSync } from 'child_process';
 import { scaffoldTier, scaffoldTierSafe } from '../../src/scaffold/index.js';
 import { generateClaudeMd } from '../../src/generators/claude-md.js';
 import { generateReadme } from '../../src/generators/readme.js';
+import {
+  parseSkillFile,
+  countBodyLines,
+  allowedToolsHasCommas,
+} from '../../src/utils/skill-frontmatter.js';
+import { SKILL_MD_MAX_LINES } from '../../src/utils/constants.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const TEMPLATES_DIR = path.resolve(__dirname, '../../templates');
@@ -2357,6 +2363,72 @@ async function scenarioCrossStackInvariants() {
   }
 }
 
+async function scenarioSkillMdSpecCompliance() {
+  section('SKILL.md Anthropic spec compliance (size + allowed-tools syntax)');
+
+  for (const tier of ['s', 'm', 'l']) {
+    const config = {
+      ...BASE,
+      tier,
+      isDiscovery: false,
+      hasFrontend: true,
+      hasApi: true,
+      hasDatabase: true,
+    };
+    const scenarioDir = path.join(OUTPUT_DIR, `spec-compliance-tier-${tier}`);
+    await fs.ensureDir(scenarioDir);
+    await scaffoldTier(tier, scenarioDir, config, TEMPLATES_DIR);
+
+    const skillsDir = path.join(scenarioDir, '.claude/skills');
+    if (!fs.existsSync(skillsDir)) {
+      pass(`Tier ${tier}: no .claude/skills (nothing to validate)`);
+      continue;
+    }
+
+    const skillDirs = fs
+      .readdirSync(skillsDir)
+      .filter((name) => fs.statSync(path.join(skillsDir, name)).isDirectory());
+
+    const tierOversize = [];
+    const tierCommas = [];
+
+    for (const skill of skillDirs) {
+      const skillFile = path.join(skillsDir, skill, 'SKILL.md');
+      if (!fs.existsSync(skillFile)) continue;
+      const raw = fs.readFileSync(skillFile, 'utf8');
+      const { body, fields, frontmatter } = parseSkillFile(raw);
+
+      if (frontmatter === null) {
+        fail(`Tier ${tier}: ${skill}/SKILL.md missing YAML frontmatter`);
+        continue;
+      }
+
+      const lines = countBodyLines(body);
+      if (lines > SKILL_MD_MAX_LINES) {
+        tierOversize.push(`${skill} (${lines} lines)`);
+      }
+
+      if (allowedToolsHasCommas(fields.allowedTools)) {
+        tierCommas.push(skill);
+      }
+    }
+
+    if (tierOversize.length === 0) {
+      pass(`Tier ${tier}: all ${skillDirs.length} SKILL.md bodies ≤ ${SKILL_MD_MAX_LINES} lines`);
+    } else {
+      fail(
+        `Tier ${tier}: SKILL.md bodies over ${SKILL_MD_MAX_LINES} lines: ${tierOversize.join(', ')}`,
+      );
+    }
+
+    if (tierCommas.length === 0) {
+      pass(`Tier ${tier}: all allowed-tools values use space-separated syntax`);
+    } else {
+      fail(`Tier ${tier}: allowed-tools uses comma syntax (not spec): ${tierCommas.join(', ')}`);
+    }
+  }
+}
+
 // ── Main ─────────────────────────────────────────────────────────────────────
 
 async function main() {
@@ -2400,6 +2472,7 @@ async function main() {
   await scenarioNodeTsContentAssertions();
   await scenarioPythonContentAssertions();
   await scenarioCrossStackInvariants();
+  await scenarioSkillMdSpecCompliance();
 
   // ── Summary ────────────────────────────────────────────────────────────────
 

--- a/packages/cli/test/unit/skill-frontmatter.test.js
+++ b/packages/cli/test/unit/skill-frontmatter.test.js
@@ -1,0 +1,87 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parseSkillFile,
+  extractFields,
+  countBodyLines,
+  allowedToolsHasCommas,
+} from '../../src/utils/skill-frontmatter.js';
+
+describe('parseSkillFile', () => {
+  it('returns null frontmatter when no delimiters present', () => {
+    const { frontmatter, body, fields } = parseSkillFile('Just body content.\n');
+    assert.equal(frontmatter, null);
+    assert.equal(body, 'Just body content.\n');
+    assert.deepEqual(fields, {});
+  });
+
+  it('extracts frontmatter and body from well-formed SKILL.md', () => {
+    const src = `---
+name: test-skill
+description: A short description.
+context: fork
+---
+
+Body content starts here.
+Line two.`;
+    const { frontmatter, body, fields } = parseSkillFile(src);
+    assert.ok(frontmatter.includes('name: test-skill'));
+    assert.equal(body, 'Body content starts here.\nLine two.');
+    assert.equal(fields.name, 'test-skill');
+    assert.equal(fields.description, 'A short description.');
+    assert.equal(fields.context, 'fork');
+  });
+
+  it('captures allowed-tools value when present', () => {
+    const src = `---
+name: x
+allowed-tools: Read Glob Grep
+---
+
+body`;
+    const { fields } = parseSkillFile(src);
+    assert.equal(fields.allowedTools, 'Read Glob Grep');
+  });
+});
+
+describe('extractFields', () => {
+  it('returns null for unspecified fields', () => {
+    const fields = extractFields('name: x');
+    assert.equal(fields.name, 'x');
+    assert.equal(fields.description, null);
+    assert.equal(fields.model, null);
+  });
+});
+
+describe('countBodyLines', () => {
+  it('returns 0 for empty body', () => {
+    assert.equal(countBodyLines(''), 0);
+    assert.equal(countBodyLines('\n\n\n'), 0);
+  });
+
+  it('counts lines ignoring trailing newlines', () => {
+    assert.equal(countBodyLines('line 1\nline 2\nline 3\n\n\n'), 3);
+    assert.equal(countBodyLines('only one line'), 1);
+  });
+});
+
+describe('allowedToolsHasCommas', () => {
+  it('returns false for null / undefined / empty', () => {
+    assert.equal(allowedToolsHasCommas(null), false);
+    assert.equal(allowedToolsHasCommas(''), false);
+  });
+
+  it('detects comma-separated scalar form (the deviation we guard against)', () => {
+    assert.equal(allowedToolsHasCommas('Read, Glob, Grep'), true);
+    assert.equal(allowedToolsHasCommas('Read,Glob'), true);
+  });
+
+  it('accepts space-separated scalar form', () => {
+    assert.equal(allowedToolsHasCommas('Read Glob Grep'), false);
+    assert.equal(allowedToolsHasCommas('Bash(git add *) Bash(git commit *)'), false);
+  });
+
+  it('accepts YAML flow list form (commas inside brackets are list separators, not scalar commas)', () => {
+    assert.equal(allowedToolsHasCommas('[Read, Glob, Grep]'), false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes Issue #90 (ICE 441). Ships two Anthropic spec compliance fixes and a guardrail layer that keeps them from coming back.

**What changed for users**

- `allowed-tools` frontmatter syntax is now space-separated across every scaffolded SKILL.md. The comma-separated form is a YAML scalar with literal commas in it (verified with js-yaml); a spec-conformant parser that splits on whitespace resolves it to tool names that don't exist (`Read,`, `Glob,`, `Grep,`), which silently drops pre-authorisation. Only 2 files still used the comma form (skill-review tier-m and tier-l); the other 39 were already compliant.
- `arch-audit` skill body went from 508 to 360 lines across all three tiers. Step 3c (P1–P5 Prompting Guide compliance), Step 3d (T1–T5 token/subagent optimization) and Step H1 (H1a–H1f hook compliance) now live in a sibling `advanced-checks.md` at level-1 nesting. Nothing was rewritten, only relocated.

**Guardrails introduced**

- Two new `doctor` checks that warn on regression: `skill-md-size-budget` (body > 500 lines) and `skill-allowed-tools-syntax` (comma in allowed-tools value).
- A new CDK-internal integration scenario (`scenarioSkillMdSpecCompliance`) that scaffolds all three tiers and hard-fails if any SKILL.md is over 500 lines or uses the comma syntax. Distinct from the user-facing doctor check (warn, not fail) because on our own templates we don't get to compromise.
- New shared helper `packages/cli/src/utils/skill-frontmatter.js` used by both doctor checks, the new integration scenario, and the migrated `new-skill.js:validateSkillMd`. Kills the duplicate-regex-parser drift risk.

**Classification note**

Deviation classified as MAJOR via triangulation: (1) Anthropic doc §Frontmatter reference states `allowed-tools` accepts space-separated string or YAML list; (2) an isolated YAML parser test shows \`Read, Glob, Grep, Bash\` parses as a scalar with literal commas, not a list; (3) the implication under a spec-conformant parser is silent pre-authorisation loss. Fix applied unconditionally for strict spec compliance.

## Test plan

- [x] Lint clean (eslint src/ test/)
- [x] Unit tests: 302 pass (was 292; +10 for skill-frontmatter helper)
- [x] Integration tests: 834 pass (was 828; +6 from scenarioSkillMdSpecCompliance)
- [x] Doctor --report on fresh tier-m scaffold: all checks pass, including the two new ones
- [x] Cross-tier byte-identity verified on advanced-checks.md

## References

- Anthropic docs: https://code.claude.com/docs/en/skills §Frontmatter reference, https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices §Token budgets
- ICE 441 (I:7 C:9 E:7)