### PR TITLE
v1.12.0: doctor cross-file validation (Issue #91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,30 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.12.0] — 2026-04-24
+
+### Added
+
+- Five new `doctor` cross-file validation checks, all `warn:true` for user-facing scans (hard-fail only in CDK-internal integration tests):
+  - `settings-no-placeholders`: flags unfilled `[UPPERCASE_TOKEN]` placeholders in `.claude/settings.json`.
+  - `claudemd-stop-hook-test-cmd-match`: confirms the test command in the Stop hook appears in CLAUDE.md Key Commands. Handles both Tier S (`… && exit 0; CMD || echo`) and Tier M/L (`… && exit 0; cd $CLAUDE_PROJECT_DIR && CMD 2>&1 | tail`) hook shapes.
+  - `claudemd-skills-directory-parity`: set-diffs `## Active Skills` in CLAUDE.md against `.claude/skills/` directory listing. `custom-*` skills excluded.
+  - `pipeline-md-tier-coherence`: self-consistency check between the H1 of `pipeline.md` (Fast Lane / Tier M / Tier L) and the phase-section pattern (`FL-N` vs `Phase N` vs `Phase 1.6`).
+  - `security-md-stack-alignment`: detects stack markers in the cwd (`Package.swift`, `build.gradle`, `Cargo.toml`, `go.mod`, `Gemfile`, `pom.xml`, `pyproject.toml`, `tsconfig.json`, `package.json`, `*.csproj`) and verifies `security.md` uses the expected variant (web / native-apple / native-android / systems) via H1 signature with content-marker fallback.
+- New shared helper `packages/cli/src/utils/doctor-cross-file.js` with 9 functions (`parseActiveSkills`, `parseStopHookTestCmd`, `claudeMdContainsCommand`, `hasPlaceholder`, `detectPipelineTier`, `detectPhaseCountTier`, `detectSecurityVariant`, `expectedSecurityVariant`, `detectStackSync`). Sync-only companion to the async `detect-stack.js`.
+- New unit test suite `test/unit/doctor-cross-file.test.js` — 30 cases covering the 9 helpers + edge cases (placeholder detection, YAML list vs scalar `allowed-tools` forms, H1 signature fallback).
+- New integration scenario `scenarioDoctorCrossFileValidation` in `test/integration/run.js`: scaffolds tier-s/m/l, injects stack markers, and exercises both the happy path (all 5 checks pass/skip) and five corruption cases (one per check) that verify the expected drift is detected.
+
+### Changed
+
+- `doctor` runs **26 checks** total (was 21 post-v1.11.0, documented as 19 in stale README/operational-guide). v1.12.0 closes both the legacy doc drift and adds the 5 new checks.
+- README check-count reference updated to `(26 checks)`.
+- `docs/operational-guide.md` §Runs N checks refreshed to enumerate all 26 with Tier-0 skip note updated to "Checks 12-26".
+- Integration test count: 834 → 864 (+30 from 6 assertions × 5 tier rows in `scenarioDoctorCrossFileValidation`).
+- Unit test count: 302 → 332 (+30 from `doctor-cross-file` helper cases).
+
+---
+
 ## [1.11.0] — 2026-04-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The Stop hook in `settings.json` is the core enforcement mechanism. It blocks Cl
 npx mg-claude-dev-kit init                    # scaffold wizard
 npx mg-claude-dev-kit init --dry-run          # preview without writing
 npx mg-claude-dev-kit init --answers file.json  # skip prompts (CI/automation)
-npx mg-claude-dev-kit doctor                  # validate setup (19 checks)
+npx mg-claude-dev-kit doctor                  # validate setup (26 checks)
 npx mg-claude-dev-kit doctor --report         # JSON output for CI
 npx mg-claude-dev-kit doctor --ci             # silent, exit 1 on failure
 npx mg-claude-dev-kit upgrade                 # update template files

--- a/docs/operational-guide.md
+++ b/docs/operational-guide.md
@@ -23,7 +23,7 @@
 13. [Governance mechanics](#13-governance-mechanics)
 14. [Conventions and non-negotiables](#14-conventions-and-non-negotiables)
 15. [Maintaining the scaffold](#15-maintaining-the-scaffold)
-15b. [Anthropic drift tracking](#15b-anthropic-drift-tracking)
+    15b. [Anthropic drift tracking](#15b-anthropic-drift-tracking)
 16. [Frequently asked questions](#16-frequently-asked-questions)
 
 ---
@@ -83,11 +83,11 @@ You're using Claude Code but the process is ad-hoc. Claude makes autonomous deci
 
 **Your path**: Tier S, M, or L depending on project complexity.
 
-| Signal | Suggested tier |
-|---|---|
-| Low blast radius, single dev, reversible in minutes | Tier S - Fast Lane |
-| Single feature, moderate impact, 1-2 collaborators | Tier M - Standard |
-| High blast radius, team of 3+, complex domain, shared systems | Tier L - Full |
+| Signal                                                        | Suggested tier     |
+| ------------------------------------------------------------- | ------------------ |
+| Low blast radius, single dev, reversible in minutes           | Tier S - Fast Lane |
+| Single feature, moderate impact, 1-2 collaborators            | Tier M - Standard  |
+| High blast radius, team of 3+, complex domain, shared systems | Tier L - Full      |
 
 Read sections 4, 5, 6 (your tier), 7, and 8 of this guide.
 
@@ -103,15 +103,16 @@ You don't want a full scaffold yet - just one skill or rule to try on your exist
 
 ## 3. Prerequisites
 
-| Requirement | Version | Why |
-|---|---|---|
-| Node.js | >= 22 | CLI runtime |
-| Claude Code | latest | The AI assistant being governed |
-| Git | any | Branch discipline enforced by pipeline |
-| `gh` CLI | any | Optional - needed only for cloning private repos in From context mode |
-| Pre-commit | any | Optional - needed only if you enable the pre-commit hook |
+| Requirement | Version | Why                                                                   |
+| ----------- | ------- | --------------------------------------------------------------------- |
+| Node.js     | >= 22   | CLI runtime                                                           |
+| Claude Code | latest  | The AI assistant being governed                                       |
+| Git         | any     | Branch discipline enforced by pipeline                                |
+| `gh` CLI    | any     | Optional - needed only for cloning private repos in From context mode |
+| Pre-commit  | any     | Optional - needed only if you enable the pre-commit hook              |
 
 Install Claude Code:
+
 ```bash
 npm install -g @anthropic-ai/claude-code
 ```
@@ -144,10 +145,12 @@ Three init paths are available. All support `--dry-run` (preview without writing
 **Use when**: you are starting a new project and there is no existing codebase.
 
 The wizard asks first: **"How familiar is your team with Claude Code?"**
+
 - **Just starting out** -> Tier 0 (Discovery). The remaining questions are simplified.
 - **We use it and want guardrails** -> continues to the experienced path below.
 
 For experienced users, the wizard asks:
+
 - Project name and one-line description
 - **3 diagnostic questions -> auto-suggest tier**:
   1. "How many engineers will use Claude Code on this project?" (solo / small team / larger team)
@@ -169,6 +172,7 @@ For experienced users, the wizard asks:
 Output: a fully scaffolded project directory with `CLAUDE.md`, pipeline rules, settings, and docs - ready to open in Claude Code.
 
 **After running:**
+
 1. Read `.claude/FIRST_SESSION.md` (Tier M/L) - your team's guide to the first block cycle. Auto-deleted after first block closure.
 2. Review `CLAUDE.md` - fill in the project-specific details.
 3. Open Claude Code: `claude` from the project root.
@@ -180,6 +184,7 @@ Output: a fully scaffolded project directory with `CLAUDE.md`, pipeline rules, s
 **Use when**: you are starting a new governance project but want to bootstrap it from an existing codebase or documentation.
 
 The wizard asks for:
+
 - One or more source repositories (GitHub URL, `org/repo`, or local path)
 - Optional source documents (PDF, Markdown, TXT file paths)
 - New project name
@@ -187,6 +192,7 @@ The wizard asks for:
 - Pipeline tier, pre-commit, `.github/`
 
 What happens:
+
 1. Each source repo is cloned into `.claude/context/repos/<name>/` using `gh` CLI (private repos) or `git clone --depth=1` (public).
 2. Source documents are copied to `.claude/context/docs/`.
 3. The governance scaffold is created.
@@ -202,6 +208,7 @@ What happens:
 **Use when**: you already have a project at the current directory and you want to add the governance layer without starting fresh.
 
 The CLI:
+
 1. Auto-detects your tech stack by inspecting `package.json`, `tsconfig.json`, `requirements.txt`, `go.mod`, `Cargo.toml`, `Package.swift`, `Gemfile`, `pom.xml`, `build.gradle`, `*.csproj`, and Xcode project directories. Supported stacks: Node.js/TS, Node.js/JS, Python, Go, Swift, Kotlin, Rust, .NET, Ruby, Java.
 2. Shows detected values pre-filled in every prompt - you confirm or override.
 3. Counts your source files to suggest an appropriate tier.
@@ -253,25 +260,28 @@ The pipeline is the sequence of phases Claude follows for every development task
 **Use for**: teams exploring Claude Code for the first time. No pipeline knowledge required.
 **What it provides**: one constraint (tests must pass) and project context (CLAUDE.md). Nothing else.
 
-| File | Purpose |
-|---|---|
-| `CLAUDE.md` | Project context: stack, commands, conventions. Claude reads this every session. |
-| `.claude/settings.json` | Stop hook: tests must pass before Claude declares a task complete. |
-| `GETTING_STARTED.md` | Step-by-step guide for the first session. |
+| File                    | Purpose                                                                         |
+| ----------------------- | ------------------------------------------------------------------------------- |
+| `CLAUDE.md`             | Project context: stack, commands, conventions. Claude reads this every session. |
+| `.claude/settings.json` | Stop hook: tests must pass before Claude declares a task complete.              |
+| `GETTING_STARTED.md`    | Step-by-step guide for the first session.                                       |
 
 **The Stop hook is the only governance control in Tier 0** - and it's the most important one.
 
 **After running init (Tier 0):**
+
 1. Edit `CLAUDE.md` - fill in the project description and verify the commands.
 2. Read `GETTING_STARTED.md` for what to expect.
 3. Run `claude` from the project root.
 
 **Upgrading from Tier 0:**
+
 ```bash
 npx mg-claude-dev-kit upgrade --tier=s   # adds branch discipline + commit rules
 npx mg-claude-dev-kit upgrade --tier=m   # adds phased pipeline + review gates + docs
 npx mg-claude-dev-kit upgrade --tier=l   # adds full governance + audit skills
 ```
+
 Upgrade is non-destructive - it adds new files without overwriting your existing `CLAUDE.md` or `settings.json`.
 
 ---
@@ -282,13 +292,13 @@ Upgrade is non-destructive - it adds new files without overwriting your existing
 **Branch prefix**: `fix/description` - Claude detects this and switches to Fast Lane automatically.
 **Scaffolded files**: minimal set - no informational docs (files-guide, adr-template, pipeline-standards, claudemd-standards are excluded for Tier S).
 
-| Phase | Action |
-|---|---|
-| FL-0 | Check `.claude/session/` for interrupted fix. Create session file. Confirm `fix/*` branch. **Escalation check**: if the fix touches a shared utility with >5 import consumers, escalate to Tier M. |
-| FL-1 | **Compact scope confirm** (one list of files + changes, wait for execution keyword). Implement. Run type check + tests. Commit. |
-| FL-2 | Merge to staging. Wait for deploy. Verify in 1-3 steps. |
-| FL-3 | Merge to main. Verify production deploy. One-line summary: `fix complete - description . type check . tests N/N` |
-| FL-4 | Update checklist if fix closes a tracked item. Delete session file (only after fix confirmed in production). |
+| Phase | Action                                                                                                                                                                                             |
+| ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| FL-0  | Check `.claude/session/` for interrupted fix. Create session file. Confirm `fix/*` branch. **Escalation check**: if the fix touches a shared utility with >5 import consumers, escalate to Tier M. |
+| FL-1  | **Compact scope confirm** (one list of files + changes, wait for execution keyword). Implement. Run type check + tests. Commit.                                                                    |
+| FL-2  | Merge to staging. Wait for deploy. Verify in 1-3 steps.                                                                                                                                            |
+| FL-3  | Merge to main. Verify production deploy. One-line summary: `fix complete - description . type check . tests N/N`                                                                                   |
+| FL-4  | Update checklist if fix closes a tracked item. Delete session file (only after fix confirmed in production).                                                                                       |
 
 **One lightweight gate** in FL-1 (compact scope confirm). Claude proceeds autonomously after execution keyword.
 
@@ -301,23 +311,24 @@ Upgrade is non-destructive - it adds new files without overwriting your existing
 **Use for**: feature blocks, 1-2 week changes, <=15 files, no complex domain changes.
 **Branch prefix**: `feature/block-name`.
 
-| Phase | Action | Gate |
-|---|---|---|
-| 0 | Session orientation. CONTEXT_IMPORT.md check. Session file (create/resume). Read CLAUDE.local.md. Read MEMORY.md. Branch check. | - |
-| 1 | **Mode selection** (Spec-first A or Scope-confirm B) + scope sweep (Tier 1 or 2) + dependency scan (`/dependency-scan`) + spec doc if Mode A. | STOP |
-| 1.5 | Design review - data flow, trade-offs, discarded alternatives. *(skip for <=3 files, no migrations)* | STOP |
-| 2 | Implementation. Security checklist (5 checks) before commit. `/simplify` on changed files. | - |
-| 3 | Type check + build + tests. Intermediate commit. | - |
-| 3b | API integration tests (auth 401, authz 403, validation 400, business rules, DB state). *(if routes were added/modified)* | - |
-| 4 | **UAT / E2E tests** (Playwright/Cypress). *(only if E2E command configured AND scope gate confirmed UI flows + user defined UAT scenarios)* | - |
-| 5b | Test data setup - insert representative records for all relevant states. | - |
-| 5c | Staging deploy + smoke test (both themes if UI changes). | - |
-| 5d | **Block-scoped quality audit** - Track A (UI) and Track B (API/DB). Severity: Critical fix before Phase 6; Major flag in checklist; Minor to backlog. | - |
-| 6 | Outcome checklist with actual results. | STOP |
-| 8 | Block closure: session file delete (with ambiguity check), docs, 3-commit sequence (code/docs/context), promote to main. | - |
-| 8.5 | Context review C1-C12 (all run in main session). Mandatory closing message. `/compact`. | - |
+| Phase | Action                                                                                                                                                | Gate |
+| ----- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ---- |
+| 0     | Session orientation. CONTEXT_IMPORT.md check. Session file (create/resume). Read CLAUDE.local.md. Read MEMORY.md. Branch check.                       | -    |
+| 1     | **Mode selection** (Spec-first A or Scope-confirm B) + scope sweep (Tier 1 or 2) + dependency scan (`/dependency-scan`) + spec doc if Mode A.         | STOP |
+| 1.5   | Design review - data flow, trade-offs, discarded alternatives. _(skip for <=3 files, no migrations)_                                                  | STOP |
+| 2     | Implementation. Security checklist (5 checks) before commit. `/simplify` on changed files.                                                            | -    |
+| 3     | Type check + build + tests. Intermediate commit.                                                                                                      | -    |
+| 3b    | API integration tests (auth 401, authz 403, validation 400, business rules, DB state). _(if routes were added/modified)_                              | -    |
+| 4     | **UAT / E2E tests** (Playwright/Cypress). _(only if E2E command configured AND scope gate confirmed UI flows + user defined UAT scenarios)_           | -    |
+| 5b    | Test data setup - insert representative records for all relevant states.                                                                              | -    |
+| 5c    | Staging deploy + smoke test (both themes if UI changes).                                                                                              | -    |
+| 5d    | **Block-scoped quality audit** - Track A (UI) and Track B (API/DB). Severity: Critical fix before Phase 6; Major flag in checklist; Minor to backlog. | -    |
+| 6     | Outcome checklist with actual results.                                                                                                                | STOP |
+| 8     | Block closure: session file delete (with ambiguity check), docs, 3-commit sequence (code/docs/context), promote to main.                              | -    |
+| 8.5   | Context review C1-C12 (all run in main session). Mandatory closing message. `/compact`.                                                               | -    |
 
 **After running init (Tier M):**
+
 1. Read `.claude/FIRST_SESSION.md` - your team's guide to the first block cycle.
 2. Fill in `CLAUDE.md` placeholders and `docs/requirements.md` with planned blocks.
 3. Run `claude` from the project root. Claude orients itself in Phase 0 automatically.
@@ -332,6 +343,7 @@ Claude auto-selects the working mode based on block signals and declares it with
 - **Mode B - Scope-confirm** (auto-selected when all signals are absent: Tier 1 sweep, refactor, bug fix, isolated change with bounded scope): structured sweep, then proceed.
 
 **Scope sweep** (both modes): Claude auto-selects Tier 1 or Tier 2:
+
 - **Tier 1 - Standard Sweep** (<=5 files, single entity, no migration, no new pattern): 8 dimensions (roles, data, triggers, errors, UI states, integrations, reversibility, exclusions).
 - **Tier 2 - Deep Sweep** (>5 files, new entity, migration, multi-role): Tier 1 + states, conditions, pre-mortem.
 - Claude declares: "does this block include critical UI flows?" If yes and E2E is configured, you list the UAT scenarios (1-5 numbered user journeys). Claude tests exactly those - no invented scenarios.
@@ -345,27 +357,28 @@ Claude auto-selects the working mode based on block signals and declares it with
 
 > **Current status**: Tier L is in maintenance mode. It remains functional and tested, but no new features are being added to Tier L exclusively. New capabilities are developed for Tier M first and promoted to L when there is real adoption signal.
 
-| Phase | Action | Gate |
-|---|---|---|
-| 0 | Session orientation. CONTEXT_IMPORT.md check. Session file (create/resume, rename in Phase 1). Read CLAUDE.local.md. Read MEMORY.md. Branch check. | - |
-| 1 | **Mode selection** (Spec-first A or Scope-confirm B) + scope sweep (Tier 1 or 2 EARS) + full dependency scan (`/dependency-scan`) + spec doc if Mode A. | STOP |
-| 1.5 | Design review - data flow, data structures, discarded alternatives. *(skip for <=3 files)* | STOP |
-| 1.6 | Visual & UX design. ASCII wireframe + component map + UX rationale. *(UI blocks only)* | STOP |
-| Plan lock | EnterPlanMode -> user enables auto-accept -> ExitPlanMode -> `/compact` | - |
-| 2 | Implementation. Destructive migration rollback comments. Security checklist (5 checks). `/simplify`. | - |
-| 3 | Type check + build + unit tests. Intermediate commit. | - |
-| 3b | API integration tests (auth 401, authz 403, validation 400, business rules, DB state, cleanup). | - |
-| 4 | **UAT / E2E tests** *(only if E2E command configured AND scope gate confirmed UI flows + user defined UAT scenarios)* | - |
-| 5b | Test data setup - cleanup-first, all relevant states. | - |
-| 5c | Staging deploy + smoke test (all roles, both themes if UI). | - |
-| 5d | **Block-scoped quality audit** - Track A (UI) and Track B (API/DB) with full skill suite. | - |
-| 6 | Outcome checklist: build/test + design system compliance + features + audit results. | STOP |
-| 8 | Block closure: session file (ambiguity check), docs, ADR, 3-commit sequence (code/docs/context), main. | - |
-| 8.5 | C1-C3 via `/context-review`. C4-C12 in main session. **Mandatory closing message**. `/compact`. | - |
+| Phase     | Action                                                                                                                                                  | Gate |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ---- |
+| 0         | Session orientation. CONTEXT_IMPORT.md check. Session file (create/resume, rename in Phase 1). Read CLAUDE.local.md. Read MEMORY.md. Branch check.      | -    |
+| 1         | **Mode selection** (Spec-first A or Scope-confirm B) + scope sweep (Tier 1 or 2 EARS) + full dependency scan (`/dependency-scan`) + spec doc if Mode A. | STOP |
+| 1.5       | Design review - data flow, data structures, discarded alternatives. _(skip for <=3 files)_                                                              | STOP |
+| 1.6       | Visual & UX design. ASCII wireframe + component map + UX rationale. _(UI blocks only)_                                                                  | STOP |
+| Plan lock | EnterPlanMode -> user enables auto-accept -> ExitPlanMode -> `/compact`                                                                                 | -    |
+| 2         | Implementation. Destructive migration rollback comments. Security checklist (5 checks). `/simplify`.                                                    | -    |
+| 3         | Type check + build + unit tests. Intermediate commit.                                                                                                   | -    |
+| 3b        | API integration tests (auth 401, authz 403, validation 400, business rules, DB state, cleanup).                                                         | -    |
+| 4         | **UAT / E2E tests** _(only if E2E command configured AND scope gate confirmed UI flows + user defined UAT scenarios)_                                   | -    |
+| 5b        | Test data setup - cleanup-first, all relevant states.                                                                                                   | -    |
+| 5c        | Staging deploy + smoke test (all roles, both themes if UI).                                                                                             | -    |
+| 5d        | **Block-scoped quality audit** - Track A (UI) and Track B (API/DB) with full skill suite.                                                               | -    |
+| 6         | Outcome checklist: build/test + design system compliance + features + audit results.                                                                    | STOP |
+| 8         | Block closure: session file (ambiguity check), docs, ADR, 3-commit sequence (code/docs/context), main.                                                  | -    |
+| 8.5       | C1-C3 via `/context-review`. C4-C12 in main session. **Mandatory closing message**. `/compact`.                                                         | -    |
 
 **Four STOP gates** (Phases 1, 1.5, 1.6, 6). Plan-lock before Phase 2 locks the full approved plan before code is written.
 
 **Structural Requirements Changes (R1-R4)** - separate pipeline activated when stakeholders change functional scope on already-implemented blocks:
+
 - **R1**: update requirements section by section, STOP for approval
 - **R2**: impact analysis - which blocks, which files, which tests
 - **R3**: update checklist + backlog, STOP before touching code
@@ -403,6 +416,7 @@ This copies the SKILL.md file into `.claude/skills/<name>/` and appends it to th
 Available skills (16): `arch-audit`, `security-audit`, `perf-audit`, `skill-dev`, `skill-review`, `simplify`, `commit`, `api-design`, `skill-db`, `migration-audit`, `visual-audit`, `ux-audit`, `responsive-audit`, `ui-audit`, `accessibility-audit`, `test-audit`.
 
 Options:
+
 - `--force` - overwrite if the skill already exists
 - `--dry-run` - show what would be created without writing files
 
@@ -419,12 +433,12 @@ Available rules: `git`, `output-style`, `security`.
 
 The security rule supports stack-specific variants via `--stack`:
 
-| Stack flag | Security variant installed |
-|---|---|
-| *(none)* | Web (default) |
-| `swift` | Native Apple |
-| `kotlin` | Native Android |
-| `rust`, `go`, `dotnet`, `java` | Systems |
+| Stack flag                     | Security variant installed |
+| ------------------------------ | -------------------------- |
+| _(none)_                       | Web (default)              |
+| `swift`                        | Native Apple               |
+| `kotlin`                       | Native Android             |
+| `rust`, `go`, `dotnet`, `java` | Systems                    |
 
 Options: `--force`, `--dry-run` (same as `add skill`).
 
@@ -443,6 +457,7 @@ Interactive wizard that generates a complete custom skill:
 The generated skill uses the `custom-` naming convention, which protects it from being overwritten during `upgrade` or `init` operations.
 
 Options:
+
 - `--name <name>` - skip the name prompt (auto-prepends `custom-` if missing)
 - `--dry-run` - preview what would be created
 - `--answers <json>` - bypass all prompts with JSON (for automation)
@@ -537,6 +552,7 @@ Scaffolded by the CLI for Tier M and Tier L. A practical guide to the first bloc
 The primary project context file. Claude reads it at the start of every session.
 
 **Auto-populated fields** (filled by the scaffold from wizard/detection data):
+
 - **Project name** - from wizard input
 - **Tech Stack Summary** - from detected stack (e.g. "Node.js + TypeScript", "Swift / macOS")
 - **Framework** - auto-detected from dependencies. Shows "N/A - native app" for Swift/Kotlin/Rust/.NET/Java.
@@ -544,6 +560,7 @@ The primary project context file. Claude reads it at the start of every session.
 - **Key Commands** - from wizard input or native defaults (e.g. `xcodebuild test` for Swift)
 
 **What to fill in manually:**
+
 - Project overview (2-4 sentences)
 - Database, Auth, Storage, Email, Deploy fields
 - Folder conventions and naming conventions
@@ -559,6 +576,7 @@ The primary project context file. Claude reads it at the start of every session.
 Shared lessons and active project state. Updated at the end of every block.
 
 **Sections:**
+
 - **Active plan** - block-by-block status table. Updated every block.
 - **Key technical patterns** - non-obvious decisions worth preserving across sessions.
 - **Lessons** - things that went wrong and how to avoid them.
@@ -571,30 +589,30 @@ Shared lessons and active project state. Updated at the end of every block.
 
 Permissions and hooks. Five hooks are pre-configured in Tier M/L (three in Tier S):
 
-| Hook | Event | Tier | What it does |
-|---|---|---|---|
-| Test gate | `Stop` | S M L | Runs test command. If tests fail, Claude is blocked and must fix before declaring done. |
-| Audit log | `PostToolUse` | M L | Appends every Write/Edit/Bash call to `~/.claude/audit/[project].jsonl`. |
-| Session log | `SessionStart` | S M L | Logs session start to `~/.claude/audit/sessions.log`. |
-| Arch-audit reminder | `SessionStart` | S M L | If `/arch-audit` hasn't run in 7 days, prints a reminder at session open. |
-| Instructions debug log | `InstructionsLoaded` | M L | Appends loaded context payload to `/tmp/claude-instructions-YYYYMMDD.log`. |
-| CLAUDE.local.md reminder | `PostCompact` | M L | Reminds Claude to re-read `.claude/CLAUDE.local.md` after `/compact`. |
-| Destructive command block | `PreToolUse` | L | Blocks `rm -rf /`, `DROP DATABASE`, and similar patterns. |
-| LLM security review | `Stop` | L | Haiku checks for hardcoded secrets and missing auth at session close. |
+| Hook                      | Event                | Tier  | What it does                                                                            |
+| ------------------------- | -------------------- | ----- | --------------------------------------------------------------------------------------- |
+| Test gate                 | `Stop`               | S M L | Runs test command. If tests fail, Claude is blocked and must fix before declaring done. |
+| Audit log                 | `PostToolUse`        | M L   | Appends every Write/Edit/Bash call to `~/.claude/audit/[project].jsonl`.                |
+| Session log               | `SessionStart`       | S M L | Logs session start to `~/.claude/audit/sessions.log`.                                   |
+| Arch-audit reminder       | `SessionStart`       | S M L | If `/arch-audit` hasn't run in 7 days, prints a reminder at session open.               |
+| Instructions debug log    | `InstructionsLoaded` | M L   | Appends loaded context payload to `/tmp/claude-instructions-YYYYMMDD.log`.              |
+| CLAUDE.local.md reminder  | `PostCompact`        | M L   | Reminds Claude to re-read `.claude/CLAUDE.local.md` after `/compact`.                   |
+| Destructive command block | `PreToolUse`         | L     | Blocks `rm -rf /`, `DROP DATABASE`, and similar patterns.                               |
+| LLM security review       | `Stop`               | L     | Haiku checks for hardcoded secrets and missing auth at session close.                   |
 
 **Stack-aware permissions**: `permissions.allow` is set to stack-appropriate CLI tools at scaffold time. `permissions.deny` includes base protections (force push, `rm -rf /`, `DROP TABLE`, `TRUNCATE`) plus stack-specific release/publish commands:
 
-| Stack | Allow | Deny (additions) |
-|---|---|---|
-| Node.js (default) | git, node, npm, npx, curl | - |
-| Swift | git, swift, xcodebuild, xcrun, curl | xcodebuild archive, xcrun altool --upload-app |
-| Kotlin | git, gradlew, gradle, curl | gradlew publish |
-| Rust | git, cargo, rustc, curl | cargo publish |
-| .NET | git, dotnet, curl | dotnet nuget push |
-| Java | git, mvn, gradlew, gradle, curl | mvn deploy, gradlew publish |
-| Ruby | git, bundle, rails, rake, curl | gem push |
-| Python | git, python, pip, uv, curl | twine upload |
-| Go | git, go, curl | - |
+| Stack             | Allow                               | Deny (additions)                              |
+| ----------------- | ----------------------------------- | --------------------------------------------- |
+| Node.js (default) | git, node, npm, npx, curl           | -                                             |
+| Swift             | git, swift, xcodebuild, xcrun, curl | xcodebuild archive, xcrun altool --upload-app |
+| Kotlin            | git, gradlew, gradle, curl          | gradlew publish                               |
+| Rust              | git, cargo, rustc, curl             | cargo publish                                 |
+| .NET              | git, dotnet, curl                   | dotnet nuget push                             |
+| Java              | git, mvn, gradlew, gradle, curl     | mvn deploy, gradlew publish                   |
+| Ruby              | git, bundle, rails, rake, curl      | gem push                                      |
+| Python            | git, python, pip, uv, curl          | twine upload                                  |
+| Go                | git, go, curl                       | -                                             |
 
 ---
 
@@ -603,6 +621,7 @@ Permissions and hooks. Five hooks are pre-configured in Tier M/L (three in Tier 
 The development workflow Claude follows. Tier-appropriate content is scaffolded at init time.
 
 You can add project-specific overrides at the bottom of this file:
+
 ```markdown
 ## Project-specific rules
 
@@ -616,12 +635,12 @@ You can add project-specific overrides at the bottom of this file:
 
 Stack-aware security rules. The scaffold selects the appropriate variant based on your tech stack:
 
-| Variant | Stacks | Focus areas |
-|---|---|---|
-| **Web** (default) | Node.js, Python, Ruby, Go/Java/.NET with API | Auth checks, input validation, SQL injection, RLS/ACL, API response security, HTTP headers |
-| **Native Apple** | Swift | App Sandbox entitlements, Keychain access, TCC permissions, Data Protection, code signing |
-| **Native Android** | Kotlin | Manifest permissions, Android Keystore, EncryptedSharedPreferences, network security config, ProGuard |
-| **Systems** | Rust, Go, .NET, Java (without API) | Memory safety, process execution, file permissions, input validation at system boundaries |
+| Variant            | Stacks                                       | Focus areas                                                                                           |
+| ------------------ | -------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| **Web** (default)  | Node.js, Python, Ruby, Go/Java/.NET with API | Auth checks, input validation, SQL injection, RLS/ACL, API response security, HTTP headers            |
+| **Native Apple**   | Swift                                        | App Sandbox entitlements, Keychain access, TCC permissions, Data Protection, code signing             |
+| **Native Android** | Kotlin                                       | Manifest permissions, Android Keystore, EncryptedSharedPreferences, network security config, ProGuard |
+| **Systems**        | Rust, Go, .NET, Java (without API)           | Memory safety, process execution, file permissions, input validation at system boundaries             |
 
 Selection logic: Swift always gets native-apple, Kotlin always gets native-android. Rust/Go/.NET/Java get the systems variant when `hasApi=false`, otherwise the web variant. All other stacks get the web variant. The output file is always named `security.md` regardless of variant.
 
@@ -645,20 +664,20 @@ Communication rules for Claude in this project. No sycophantic openers, no AI di
 
 End-of-block compliance checklist. Executed in Phase 8.5. Contains 12 checks (C1-C12), each with an explicit grep command, pass condition, and false-positive notes:
 
-| Check | What it verifies |
-|---|---|
-| C1 | No credentials or tokens in auto-memory |
-| C2 | No unresolved `[PLACEHOLDER_NAME]` patterns in active files |
-| C3 | No stale field/config key names in CLAUDE.md |
-| C4 | No forward-looking references to closed blocks |
-| C5 | Every `MEMORY.md` mention in pipeline.md qualified |
-| C6 | No duplication between auto-memory and CLAUDE.md |
-| C7 | Both MEMORY files < 150 lines |
-| C8 | All paths in files-guide.md exist on disk |
-| C9 | Active plan in project-root MEMORY.md is current |
-| C10 | No dead file references in cross-doc paths |
-| C11 | No completed items remain in refactoring-backlog.md |
-| C12 | Canonical docs current (sitemap, db-map, PRD) |
+| Check | What it verifies                                            |
+| ----- | ----------------------------------------------------------- |
+| C1    | No credentials or tokens in auto-memory                     |
+| C2    | No unresolved `[PLACEHOLDER_NAME]` patterns in active files |
+| C3    | No stale field/config key names in CLAUDE.md                |
+| C4    | No forward-looking references to closed blocks              |
+| C5    | Every `MEMORY.md` mention in pipeline.md qualified          |
+| C6    | No duplication between auto-memory and CLAUDE.md            |
+| C7    | Both MEMORY files < 150 lines                               |
+| C8    | All paths in files-guide.md exist on disk                   |
+| C9    | Active plan in project-root MEMORY.md is current            |
+| C10   | No dead file references in cross-doc paths                  |
+| C11   | No completed items remain in refactoring-backlog.md         |
+| C12   | Canonical docs current (sitemap, db-map, PRD)               |
 
 **In Tier L**: C1-C3 are delegated to `/context-review` (grep-only, forked context). C4-C12 run in the main session.
 **In Tier M**: all 12 checks run in the main session.
@@ -699,24 +718,24 @@ All skill applicability rules are managed by a central skill registry (`packages
 
 ### Tier availability and install conditions
 
-| Command | S | M | L | Install condition | Requires |
-|---|---|---|---|---|---|
-| `/arch-audit` | x | x | x | always | Internet access (fetches Anthropic docs) |
-| `/commit` | x | x | x | always | - |
-| `/security-audit` | x | x | x | always | - |
-| `/perf-audit` | x | x | x | always | - |
-| `/skill-dev` | x | x | x | always | - |
-| `/simplify` | x | x | x | always | - |
-| `/api-design` | - | x | x | `hasApi=true` | - |
-| `/skill-db` | - | x | x | `hasDatabase=true` | - |
-| `/migration-audit` | - | x | x | `hasDatabase=true` | - |
-| `/responsive-audit` | - | x | x | `hasFrontend=true` | Dev server + Playwright MCP |
-| `/ux-audit` | - | x | x | `hasFrontend=true` | Dev server + Playwright MCP |
-| `/visual-audit` | - | x | x | `hasFrontend=true` | Dev server + Playwright MCP |
-| `/ui-audit` | - | x | x | `hasFrontend=true` AND `hasDesignSystem=true` | - (static) |
-| `/accessibility-audit` | - | x | x | `hasFrontend=true` | Dev server + Playwright MCP (for full/wcag modes; static mode needs nothing) |
-| `/test-audit` | - | x | x | always (no `requires`) | - (static analysis) |
-| `/skill-review` | - | x | x | always | - (static analysis) |
+| Command                | S   | M   | L   | Install condition                             | Requires                                                                     |
+| ---------------------- | --- | --- | --- | --------------------------------------------- | ---------------------------------------------------------------------------- |
+| `/arch-audit`          | x   | x   | x   | always                                        | Internet access (fetches Anthropic docs)                                     |
+| `/commit`              | x   | x   | x   | always                                        | -                                                                            |
+| `/security-audit`      | x   | x   | x   | always                                        | -                                                                            |
+| `/perf-audit`          | x   | x   | x   | always                                        | -                                                                            |
+| `/skill-dev`           | x   | x   | x   | always                                        | -                                                                            |
+| `/simplify`            | x   | x   | x   | always                                        | -                                                                            |
+| `/api-design`          | -   | x   | x   | `hasApi=true`                                 | -                                                                            |
+| `/skill-db`            | -   | x   | x   | `hasDatabase=true`                            | -                                                                            |
+| `/migration-audit`     | -   | x   | x   | `hasDatabase=true`                            | -                                                                            |
+| `/responsive-audit`    | -   | x   | x   | `hasFrontend=true`                            | Dev server + Playwright MCP                                                  |
+| `/ux-audit`            | -   | x   | x   | `hasFrontend=true`                            | Dev server + Playwright MCP                                                  |
+| `/visual-audit`        | -   | x   | x   | `hasFrontend=true`                            | Dev server + Playwright MCP                                                  |
+| `/ui-audit`            | -   | x   | x   | `hasFrontend=true` AND `hasDesignSystem=true` | - (static)                                                                   |
+| `/accessibility-audit` | -   | x   | x   | `hasFrontend=true`                            | Dev server + Playwright MCP (for full/wcag modes; static mode needs nothing) |
+| `/test-audit`          | -   | x   | x   | always (no `requires`)                        | - (static analysis)                                                          |
+| `/skill-review`        | -   | x   | x   | always                                        | - (static analysis)                                                          |
 
 ### General rules
 
@@ -742,15 +761,16 @@ After the smoke test and before the outcome checklist, three tracks can run:
 
 ### Severity handling
 
-| Level | Action |
-|---|---|
+| Level    | Action                                                                 |
+| -------- | ---------------------------------------------------------------------- |
 | Critical | Fix before Phase 6. Claude does not proceed with open Critical issues. |
-| Major | Flag in Phase 6 checklist with planned resolution. |
-| Minor | Log in `docs/refactoring-backlog.md`. |
+| Major    | Flag in Phase 6 checklist with planned resolution.                     |
+| Minor    | Log in `docs/refactoring-backlog.md`.                                  |
 
 ### Playwright MCP prerequisite (for browser skills)
 
 Add to `.claude/settings.json`:
+
 ```json
 "mcpServers": {
   "playwright": {
@@ -767,6 +787,7 @@ Add to `.claude/settings.json`:
 **File**: `.claude/skills/security-audit/SKILL.md` | **Backlog prefix**: `SEC-n`
 
 **3-path selector**: before starting, the skill reads CLAUDE.md and determines the execution mode:
+
 - **WEB**: web or API project - full web audit (Steps 0-5) + Step 3e if non-JS stack
 - **WEB+NATIVE**: native app with API routes - full web audit + Step 3e native checks
 - **NATIVE-ONLY**: native app with no API routes - skips Steps 0-5, runs Step 3e (NS1-NS6 platform checks) + Step 6
@@ -848,6 +869,7 @@ Unified accessibility surface. Three modes: `static` (A1-A8 grep-based patterns:
 Static test-suite quality audit. No live re-runs, no CI-history parsing - parses coverage reports already produced by the project's test runner. Stack-aware across all 11 supported stacks.
 
 Checks:
+
 - **Coverage (C1-C3)**: auto-detects and parses lcov.info (node-ts/node-js/rust), Istanbul JSON (coverage-summary.json/coverage-final.json), Cobertura XML (python/java/dotnet), go coverage.out, tarpaulin JSON, xcresult (swift, optional). Severity: `< 50%` = High, `< 80%` = Medium, `0% on a file changed in this block` = Critical.
 - **Pyramid (P1-P3)**: categorizes discovered tests as unit / integration / e2e by path convention and framework imports (`@playwright/test`, `cypress`, `detox`, `selenium`). Target ~70/20/10. Flags inverted (e2e > 30%), middle-heavy (integration > 50%), and single-layer suites.
 - **Anti-patterns (T1-T8, all stack-adapted)**: T1 `.only`/`fit`/`fdescribe` committed (Critical), T2 skipped tests (Medium; High if > 10% of suite), T3 `.todo` placeholders (Low), T4 empty test bodies (High), T5 tests without assertions (High), T6 hardcoded sleeps ≥ 500ms (Medium), T7 debug output left in tests (Low), T8 multi-file `.only` pattern (Critical).
@@ -900,12 +922,12 @@ Handles checks C1-C3 of the context review (credential scan, placeholder scan, f
 
 ### What stays monolithic
 
-| Phase | Reason |
-|---|---|
+| Phase                    | Reason                                                                  |
+| ------------------------ | ----------------------------------------------------------------------- |
 | Phase 2 - Implementation | Writes have cross-file dependencies; sequential authorship is auditable |
-| Phase 3 - Build + tests | Sequential toolchain constraint (type check -> build -> test) |
-| Phase 8 - Block closure | Document updates have content dependencies between them |
-| Phase 8.5 C4-C12 | Require judgment about the current block's state |
+| Phase 3 - Build + tests  | Sequential toolchain constraint (type check -> build -> test)           |
+| Phase 8 - Block closure  | Document updates have content dependencies between them                 |
+| Phase 8.5 C4-C12         | Require judgment about the current block's state                        |
 
 ---
 
@@ -932,6 +954,7 @@ Every skill file has YAML frontmatter and a markdown body with step-by-step inst
 **Optional fields**: `effort` (low/medium/high), `argument-hint` (parameter syntax), `allowed-tools` (MCP tools the skill needs).
 
 **Model selection**:
+
 - **haiku**: Pattern-matching, classification, grep-based checks, commit messages. Fast, cheap.
 - **sonnet**: Analysis requiring judgment, multi-file reasoning, security audits, design reviews.
 - **opus**: Visual analysis (screenshots, UI review), complex architectural reasoning.
@@ -950,6 +973,7 @@ context: fork
 ## Step 1 - Check outdated packages
 
 Run the appropriate command for the project's package manager:
+
 - npm: `npm outdated --json`
 - pip: `pip list --outdated --format=json`
 
@@ -958,8 +982,8 @@ Run the appropriate command for the project's package manager:
 List packages with major version bumps:
 
 | Package | Current | Latest | Breaking? |
-|---|---|---|---|
-| name | x.y.z | a.b.c | yes/no |
+| ------- | ------- | ------ | --------- |
+| name    | x.y.z   | a.b.c  | yes/no    |
 ```
 
 After creating a custom skill, add it to the `## Active Skills` section in CLAUDE.md. See [Custom Skills Guide](custom-skills.md) for the full authoring reference.
@@ -1027,17 +1051,20 @@ If gitleaks finds a secret: the commit is blocked. Fix by removing the secret an
 These apply in all tiers:
 
 **Branch discipline**
+
 - Never commit directly to `main` or `staging`
 - Features: `feature/block-name`
 - Fixes: `fix/description`
 
 **Conventional commits**
+
 ```
 feat(scope): add user notifications
 fix(auth): handle expired token on refresh
 docs: update API guide
 chore: bump dependencies
 ```
+
 Imperative mood, under 72 characters. Scope is optional but encouraged.
 
 **STOP gates are hard stops** - not suggestions. Never say "yes continue" to a requirements summary you haven't read. The gate exists for a human decision checkpoint.
@@ -1073,7 +1100,7 @@ npx mg-claude-dev-kit doctor --report  # JSON compliance output for CI pipelines
 npx mg-claude-dev-kit doctor --ci      # silent mode: exit 1 if any check fails
 ```
 
-Runs 19 checks:
+Runs 26 checks:
 
 1. Claude Code CLI is installed and reachable
 2. `CLAUDE.md` is present
@@ -1091,11 +1118,18 @@ Runs 19 checks:
 14. `docs/pipeline-standards.md` present (Tier M/L - warn if missing)
 15. `.claude/skills/commit/` present (Tier M/L - warn if missing)
 16. Skills invoking Playwright `browser_*` tools declare `allowed-tools` frontmatter (warn if missing)
-17. `.claude/rules/context-review.md` includes C12 (warn if not present - upgrade needed)
-18. Stop hook has `timeout` configured and ≤ 600s (warn if missing - prevents hanging test commands)
-19. No duplicate entries in `permissions.deny` list (warn if duplicates found)
+17. Skills use space-separated `allowed-tools` per Anthropic spec (warn on commas)
+18. Skill bodies respect Anthropic ≤ 500 lines guideline (warn if oversized)
+19. `.claude/settings.json` has no unfilled `[UPPERCASE]` placeholders (warn)
+20. CLAUDE.md Key Commands include the Stop hook test command (warn on drift)
+21. CLAUDE.md `## Active Skills` matches `.claude/skills/` directories (warn on mismatch)
+22. `pipeline.md` H1 matches its phase structure — Tier S/M/L self-consistency (warn)
+23. `security.md` variant matches the detected stack (warn on drift)
+24. `.claude/rules/context-review.md` includes C12 (warn if not present - upgrade needed)
+25. Stop hook has `timeout` configured and ≤ 600s (warn if missing - prevents hanging test commands)
+26. No duplicate entries in `permissions.deny` list (warn if duplicates found)
 
-Checks 12-19 are skipped for Tier 0 projects.
+Checks 12-26 are skipped for Tier 0 projects.
 
 **`--report` output**: machine-readable JSON with timestamp, cwd, summary (passed/warned/failed/skipped), and per-check details. Consumed by CI systems or external audit tools.
 
@@ -1114,13 +1148,13 @@ Do not edit scaffolded rule files directly if you want upgrade compatibility. In
 
 ### CLAUDE.md vs. MEMORY.md vs. ADRs
 
-| Content | Location |
-|---|---|
-| Stable project truths (stack, conventions, RBAC) | `CLAUDE.md` |
-| Active work state, in-progress lessons, recent patterns | `MEMORY.md` |
-| Architectural decisions + rationale + AI constraints | `docs/adr/NNNN-title.md` |
-| Non-obvious patterns stable enough to be permanent | `CLAUDE.md` Known Patterns section |
-| Block-specific state for session recovery | `.claude/session/block-name.md` |
+| Content                                                 | Location                           |
+| ------------------------------------------------------- | ---------------------------------- |
+| Stable project truths (stack, conventions, RBAC)        | `CLAUDE.md`                        |
+| Active work state, in-progress lessons, recent patterns | `MEMORY.md`                        |
+| Architectural decisions + rationale + AI constraints    | `docs/adr/NNNN-title.md`           |
+| Non-obvious patterns stable enough to be permanent      | `CLAUDE.md` Known Patterns section |
+| Block-specific state for session recovery               | `.claude/session/block-name.md`    |
 
 ---
 
@@ -1187,9 +1221,11 @@ After Claude marks the status as `COMPLETE`, the file is a historical record. Yo
 **Q: How do I handle multiple worktrees (parallel feature development)?**
 
 Create each worktree from `staging`, never from `main`:
+
 ```bash
 git worktree add .claude/worktrees/feature-name -b worktree-feature-name staging
 ```
+
 Rules: each worktree has its own branch. Merge to `staging` sequentially - smoke-test the first before merging the second. Check migration numbering across worktrees.
 
 ---
@@ -1231,4 +1267,4 @@ Nine example fixtures are in `packages/cli/test/fixtures/wizard-answers/`. Copy 
 
 ---
 
-*Last updated: 2026-04-23 - v1.10.4*
+_Last updated: 2026-04-23 - v1.10.4_

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mg-claude-dev-kit",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Scaffold for legible, reviewable AI-assisted development",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/doctor.js
+++ b/packages/cli/src/commands/doctor.js
@@ -12,6 +12,17 @@ import {
   countBodyLines,
   allowedToolsHasCommas,
 } from '../utils/skill-frontmatter.js';
+import {
+  parseActiveSkills,
+  parseStopHookTestCmd,
+  claudeMdContainsCommand,
+  hasPlaceholder,
+  detectPipelineTier,
+  detectPhaseCountTier,
+  detectSecurityVariant,
+  expectedSecurityVariant,
+  detectStackSync,
+} from '../utils/doctor-cross-file.js';
 
 const checks = [
   {
@@ -322,6 +333,151 @@ const checks = [
         warn: true,
         info: oversize.length > 0 ? oversize.join(', ') : undefined,
         fix: `Extract detailed sections into sibling reference files (progressive disclosure). Over budget: ${oversize.join(', ')}`,
+      };
+    },
+  },
+  {
+    id: 'settings-no-placeholders',
+    label: '.claude/settings.json has no unfilled placeholders',
+    check: (cwd) => {
+      const p = path.join(cwd, '.claude', 'settings.json');
+      if (!fs.existsSync(p)) return { pass: true, skip: true };
+      const raw = fs.readFileSync(p, 'utf8');
+      const pass = !hasPlaceholder(raw);
+      return {
+        pass,
+        warn: true,
+        info: pass ? undefined : 'placeholder tokens like [TEST_COMMAND] still present',
+        fix: 'Fill or remove [UPPERCASE_TOKEN] placeholders in .claude/settings.json before using the scaffold.',
+      };
+    },
+  },
+  {
+    id: 'claudemd-stop-hook-test-cmd-match',
+    label: 'CLAUDE.md Key Commands include the Stop hook test command',
+    check: (cwd) => {
+      const claudePath = path.join(cwd, 'CLAUDE.md');
+      const settingsPath = path.join(cwd, '.claude', 'settings.json');
+      if (!fs.existsSync(claudePath) || !fs.existsSync(settingsPath)) {
+        return { pass: true, skip: true };
+      }
+      let settings;
+      try {
+        settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+      } catch {
+        return { pass: true, skip: true };
+      }
+      const testCmd = parseStopHookTestCmd(settings);
+      if (!testCmd || hasPlaceholder(testCmd)) return { pass: true, skip: true };
+      const claudeMd = fs.readFileSync(claudePath, 'utf8');
+      const pass = claudeMdContainsCommand(claudeMd, testCmd);
+      return {
+        pass,
+        warn: true,
+        info: pass
+          ? undefined
+          : `Stop hook runs "${testCmd}" but CLAUDE.md Key Commands does not mention it`,
+        fix: `Align CLAUDE.md Key Commands with Stop hook: add "${testCmd}" or update the Stop hook to match.`,
+      };
+    },
+  },
+  {
+    id: 'claudemd-skills-directory-parity',
+    label: 'CLAUDE.md Active Skills matches .claude/skills/ directories',
+    check: (cwd) => {
+      const claudePath = path.join(cwd, 'CLAUDE.md');
+      const skillsDir = path.join(cwd, '.claude', 'skills');
+      if (!fs.existsSync(claudePath) || !fs.existsSync(skillsDir)) {
+        return { pass: true, skip: true };
+      }
+      const claudeMd = fs.readFileSync(claudePath, 'utf8');
+      const declared = new Set(parseActiveSkills(claudeMd));
+      if (declared.size === 0) return { pass: true, skip: true };
+      let installed;
+      try {
+        installed = new Set(
+          fs
+            .readdirSync(skillsDir, { withFileTypes: true })
+            .filter((e) => e.isDirectory() && !e.name.startsWith('custom-'))
+            .map((e) => e.name),
+        );
+      } catch {
+        return { pass: true, skip: true };
+      }
+      const declaredMissing = [...declared].filter((s) => !installed.has(s));
+      const installedNotDeclared = [...installed].filter((s) => !declared.has(s));
+      const pass = declaredMissing.length === 0 && installedNotDeclared.length === 0;
+      const problems = [];
+      if (declaredMissing.length)
+        problems.push(`declared but missing: ${declaredMissing.join(', ')}`);
+      if (installedNotDeclared.length)
+        problems.push(`installed but not declared: ${installedNotDeclared.join(', ')}`);
+      return {
+        pass,
+        warn: true,
+        info: pass ? undefined : problems.join(' · '),
+        fix: 'Align CLAUDE.md "## Active Skills" with the directories under .claude/skills/ (custom-* skills are exempt).',
+      };
+    },
+  },
+  {
+    id: 'pipeline-md-tier-coherence',
+    label: 'pipeline.md H1 matches its phase structure (Tier S/M/L self-consistency)',
+    check: (cwd) => {
+      const p = path.join(cwd, '.claude', 'rules', 'pipeline.md');
+      if (!fs.existsSync(p)) return { pass: true, skip: true };
+      const content = fs.readFileSync(p, 'utf8');
+      const declaredTier = detectPipelineTier(content);
+      if (declaredTier === 'unknown') {
+        return {
+          pass: false,
+          warn: true,
+          info: 'pipeline.md H1 does not declare a tier (Fast Lane / Tier M / Tier L)',
+          fix: 'Restore the canonical H1 from the CDK template (Fast Lane Pipeline, Standard Development Pipeline - Tier M, or Full Development Pipeline - Tier L).',
+        };
+      }
+      const bodyTier = detectPhaseCountTier(content);
+      const pass = bodyTier === 'unknown' || bodyTier === declaredTier;
+      return {
+        pass,
+        warn: true,
+        info: pass
+          ? undefined
+          : `H1 declares Tier ${declaredTier.toUpperCase()} but phase markers look like Tier ${bodyTier.toUpperCase()}`,
+        fix: 'Reconcile pipeline.md: H1 and phase sections must agree on tier. Reinstall via `claude-dev-kit upgrade --tier=<tier>` if in doubt.',
+      };
+    },
+  },
+  {
+    id: 'security-md-stack-alignment',
+    label: 'security.md variant matches the detected stack',
+    check: (cwd) => {
+      const securityPath = path.join(cwd, '.claude', 'rules', 'security.md');
+      if (!fs.existsSync(securityPath)) return { pass: true, skip: true };
+      const stack = detectStackSync(cwd);
+      if (!stack) return { pass: true, skip: true, info: 'stack not detectable in this directory' };
+      const securityMd = fs.readFileSync(securityPath, 'utf8');
+      const actual = detectSecurityVariant(securityMd);
+      if (actual === 'unknown') {
+        return {
+          pass: false,
+          warn: true,
+          info: 'security.md variant could not be identified (H1 and content markers absent)',
+          fix: 'Reinstall security.md via `claude-dev-kit upgrade` so the correct variant is written.',
+        };
+      }
+      const hasApi = fs.existsSync(path.join(cwd, 'CLAUDE.md'))
+        ? /^##\s*API/im.test(fs.readFileSync(path.join(cwd, 'CLAUDE.md'), 'utf8'))
+        : true;
+      const expected = expectedSecurityVariant(stack, hasApi);
+      const pass = actual === expected;
+      return {
+        pass,
+        warn: true,
+        info: pass
+          ? undefined
+          : `stack "${stack}" expects "${expected}" variant, found "${actual}"`,
+        fix: `Reinstall security.md for stack "${stack}" via \`claude-dev-kit upgrade\` — expected variant "${expected}".`,
       };
     },
   },

--- a/packages/cli/src/utils/doctor-cross-file.js
+++ b/packages/cli/src/utils/doctor-cross-file.js
@@ -1,0 +1,106 @@
+import fs from 'fs';
+import path from 'path';
+
+const PLACEHOLDER_TOKEN_RE = /\[[A-Z][A-Z0-9_]+\]/;
+
+export function parseActiveSkills(claudeMd) {
+  const section = claudeMd.match(/^## Active Skills\s*\n([\s\S]*?)(?=\n## |\n---|\n\n##|\n$)/m);
+  if (!section) return [];
+  const lines = section[1].split('\n');
+  const skills = [];
+  for (const line of lines) {
+    const m = line.match(/^-\s+`\/([a-z0-9]+(?:-[a-z0-9]+)*)`/);
+    if (m) skills.push(m[1]);
+  }
+  return skills;
+}
+
+export function parseStopHookTestCmd(settingsJson) {
+  try {
+    const hook = settingsJson?.hooks?.Stop?.[0]?.hooks?.[0]?.command;
+    if (!hook || typeof hook !== 'string') return null;
+    const tierM = hook.match(
+      /&&\s*exit\s+0\s*;\s*cd\s+\$CLAUDE_PROJECT_DIR\s*&&\s*(.+?)\s+2>&1\s*\|/,
+    );
+    if (tierM) return tierM[1].trim();
+    const tierS = hook.match(/&&\s*exit\s+0\s*;\s*(.+?)\s*\|\|/);
+    return tierS ? tierS[1].trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+export function claudeMdContainsCommand(claudeMd, command) {
+  if (!command) return false;
+  const keyCommandsBlock = claudeMd.match(/^## Key Commands\s*\n([\s\S]*?)(?=\n## |\n---|\n$)/m);
+  if (!keyCommandsBlock) return false;
+  return keyCommandsBlock[1].includes(command);
+}
+
+export function hasPlaceholder(text) {
+  return PLACEHOLDER_TOKEN_RE.test(text);
+}
+
+export function detectPipelineTier(pipelineMd) {
+  const h1 = (pipelineMd.split('\n')[0] || '').trim();
+  if (/^#\s+Fast Lane Pipeline\b/.test(h1)) return 's';
+  if (/^#\s+Standard Development Pipeline - Tier M\b/.test(h1)) return 'm';
+  if (/^#\s+Full Development Pipeline - Tier L\b/.test(h1)) return 'l';
+  return 'unknown';
+}
+
+export function detectPhaseCountTier(pipelineMd) {
+  if (/^##\s+FL-\d+/m.test(pipelineMd)) return 's';
+  if (/^##\s+Phase\s+1\.6/m.test(pipelineMd)) return 'l';
+  if (/^##\s+Phase\s+\d+/m.test(pipelineMd)) return 'm';
+  return 'unknown';
+}
+
+export function detectSecurityVariant(securityMd) {
+  const h1 = (securityMd.split('\n')[0] || '').trim();
+  if (/^#\s+Security Rules - Native Apple\b/.test(h1)) return 'native-apple';
+  if (/^#\s+Security Rules - Native Android\b/.test(h1)) return 'native-android';
+  if (/^#\s+Security Rules - Systems & Backend\b/.test(h1)) return 'systems';
+  if (/^#\s+Security Rules\s*$/.test(h1)) return 'web';
+  const variantMarkers = [
+    { re: /\bKeychain\b/, variant: 'native-apple' },
+    { re: /\bAndroid Keystore\b|\bAndroidManifest\.xml\b/, variant: 'native-android' },
+    { re: /\bMemory & Resource Safety\b/, variant: 'systems' },
+    { re: /\brow-level access control\b|\bRLS\b/i, variant: 'web' },
+  ];
+  for (const { re, variant } of variantMarkers) {
+    if (re.test(securityMd)) return variant;
+  }
+  return 'unknown';
+}
+
+export function expectedSecurityVariant(techStack, hasApi) {
+  if (techStack === 'swift') return 'native-apple';
+  if (techStack === 'kotlin') return 'native-android';
+  const systems = ['rust', 'dotnet', 'java', 'go'];
+  if (systems.includes(techStack) && hasApi === false) return 'systems';
+  return 'web';
+}
+
+export function detectStackSync(cwd) {
+  const exists = (f) => fs.existsSync(path.join(cwd, f));
+  if (exists('Package.swift')) return 'swift';
+  if (exists('build.gradle.kts') || exists('build.gradle')) return 'kotlin';
+  if (exists('Cargo.toml')) return 'rust';
+  if (exists('go.mod')) return 'go';
+  if (exists('Gemfile')) return 'ruby';
+  if (exists('pom.xml')) return 'java';
+  if (exists('pyproject.toml') || exists('requirements.txt')) return 'python';
+  if (fs.existsSync(cwd)) {
+    try {
+      const entries = fs.readdirSync(cwd);
+      if (entries.some((n) => n.endsWith('.csproj'))) return 'dotnet';
+    } catch {
+      // ignore
+    }
+  }
+  if (exists('tsconfig.json') || exists('package.json')) {
+    return exists('tsconfig.json') ? 'node-ts' : 'node-js';
+  }
+  return null;
+}

--- a/packages/cli/test/integration/run.js
+++ b/packages/cli/test/integration/run.js
@@ -2429,6 +2429,199 @@ async function scenarioSkillMdSpecCompliance() {
   }
 }
 
+async function scenarioDoctorCrossFileValidation() {
+  section('Doctor cross-file validation (v1.12.0 new checks)');
+
+  const CLI = path.resolve(__dirname, '../../src/index.js');
+  const NEW_CHECK_IDS = [
+    'settings-no-placeholders',
+    'claudemd-stop-hook-test-cmd-match',
+    'claudemd-skills-directory-parity',
+    'pipeline-md-tier-coherence',
+    'security-md-stack-alignment',
+  ];
+
+  function injectStackMarker(dir, stack) {
+    if (stack === 'node-ts') {
+      fs.writeFileSync(
+        path.join(dir, 'package.json'),
+        '{"name":"test","devDependencies":{"typescript":"5.0.0"}}',
+      );
+      fs.writeFileSync(path.join(dir, 'tsconfig.json'), '{}');
+    } else if (stack === 'swift') {
+      fs.writeFileSync(path.join(dir, 'Package.swift'), '// swift-tools-version:5.9\n');
+    }
+  }
+
+  function fillStopHookTestCmd(dir) {
+    const settingsPath = path.join(dir, '.claude/settings.json');
+    const raw = fs.readFileSync(settingsPath, 'utf8');
+    fs.writeFileSync(settingsPath, raw.replace(/\[TEST_COMMAND\]/g, 'npx vitest run'));
+  }
+
+  function fillClaudeMdTestCmd(dir) {
+    const claudePath = path.join(dir, 'CLAUDE.md');
+    const raw = fs.readFileSync(claudePath, 'utf8');
+    fs.writeFileSync(claudePath, raw.replace(/\[TEST_COMMAND\]/g, 'npx vitest run'));
+  }
+
+  function runDoctor(dir) {
+    try {
+      const output = execFileSync('node', [CLI, 'doctor', '--report'], {
+        cwd: dir,
+        encoding: 'utf8',
+      });
+      return JSON.parse(output);
+    } catch (e) {
+      const raw = (e.stdout || '').toString();
+      try {
+        return JSON.parse(raw);
+      } catch {
+        return null;
+      }
+    }
+  }
+
+  function getCheckStatus(report, id) {
+    return report?.checks?.find((c) => c.id === id)?.status;
+  }
+
+  for (const tier of ['s', 'm', 'l']) {
+    const config = {
+      ...BASE,
+      tier,
+      isDiscovery: false,
+      hasFrontend: true,
+      hasApi: true,
+      hasDatabase: true,
+    };
+
+    // Positive test: scaffold pulito + stack marker + placeholder risolti
+    const cleanDir = await scaffold(`doctor-xfile-clean-tier-${tier}`, tier, config);
+    injectStackMarker(cleanDir, 'node-ts');
+    fillStopHookTestCmd(cleanDir);
+    fillClaudeMdTestCmd(cleanDir);
+    const cleanReport = runDoctor(cleanDir);
+    if (!cleanReport) {
+      fail(`Tier ${tier}: doctor --report did not emit valid JSON on clean scaffold`);
+      continue;
+    }
+    for (const id of NEW_CHECK_IDS) {
+      const status = getCheckStatus(cleanReport, id);
+      if (status === 'pass' || status === 'skip') {
+        pass(`Tier ${tier} clean: ${id} = ${status}`);
+      } else {
+        fail(`Tier ${tier} clean: ${id} = ${status} (expected pass or skip)`);
+      }
+    }
+
+    // Corruption: re-inject [TEST_COMMAND] placeholder into settings.json after scaffold filled it
+    const corruptPlaceholder = await scaffold(
+      `doctor-xfile-corrupt-placeholder-tier-${tier}`,
+      tier,
+      config,
+    );
+    injectStackMarker(corruptPlaceholder, 'node-ts');
+    fillClaudeMdTestCmd(corruptPlaceholder);
+    const placeholderSettingsPath = path.join(corruptPlaceholder, '.claude/settings.json');
+    const placeholderSettings = JSON.parse(fs.readFileSync(placeholderSettingsPath, 'utf8'));
+    if (placeholderSettings?.hooks?.Stop?.[0]?.hooks?.[0]) {
+      placeholderSettings.hooks.Stop[0].hooks[0].command =
+        '[ "$stop_hook_active" = "1" ] && exit 0; [TEST_COMMAND] || echo blocked';
+      fs.writeFileSync(placeholderSettingsPath, JSON.stringify(placeholderSettings, null, 2));
+    }
+    const placeholderReport = runDoctor(corruptPlaceholder);
+    const placeholderStatus = getCheckStatus(placeholderReport, 'settings-no-placeholders');
+    if (placeholderStatus === 'warn' || placeholderStatus === 'fail') {
+      pass(`Tier ${tier} corrupt-placeholder: settings-no-placeholders = ${placeholderStatus}`);
+    } else {
+      fail(`Tier ${tier} corrupt-placeholder: expected warn/fail, got ${placeholderStatus}`);
+    }
+
+    // Corruption: overwrite Stop hook command directly to a different test cmd than CLAUDE.md
+    const corruptCmdMismatch = await scaffold(
+      `doctor-xfile-corrupt-cmd-tier-${tier}`,
+      tier,
+      config,
+    );
+    injectStackMarker(corruptCmdMismatch, 'node-ts');
+    fillClaudeMdTestCmd(corruptCmdMismatch);
+    const mismatchSettingsPath = path.join(corruptCmdMismatch, '.claude/settings.json');
+    const mismatchSettings = JSON.parse(fs.readFileSync(mismatchSettingsPath, 'utf8'));
+    if (mismatchSettings?.hooks?.Stop?.[0]?.hooks?.[0]) {
+      mismatchSettings.hooks.Stop[0].hooks[0].command =
+        '[ "$stop_hook_active" = "1" ] && exit 0; npx jest || echo blocked';
+      fs.writeFileSync(mismatchSettingsPath, JSON.stringify(mismatchSettings, null, 2));
+    }
+    const cmdReport = runDoctor(corruptCmdMismatch);
+    const cmdStatus = getCheckStatus(cmdReport, 'claudemd-stop-hook-test-cmd-match');
+    if (cmdStatus === 'warn' || cmdStatus === 'fail') {
+      pass(`Tier ${tier} corrupt-cmd-mismatch: claudemd-stop-hook-test-cmd-match = ${cmdStatus}`);
+    } else {
+      fail(`Tier ${tier} corrupt-cmd-mismatch: expected warn/fail, got ${cmdStatus}`);
+    }
+
+    // Corruption: remove a skill directory
+    const corruptSkillMissing = await scaffold(
+      `doctor-xfile-corrupt-skill-tier-${tier}`,
+      tier,
+      config,
+    );
+    injectStackMarker(corruptSkillMissing, 'node-ts');
+    fillStopHookTestCmd(corruptSkillMissing);
+    fillClaudeMdTestCmd(corruptSkillMissing);
+    const archSkillDir = path.join(corruptSkillMissing, '.claude/skills/arch-audit');
+    if (fs.existsSync(archSkillDir)) fs.rmSync(archSkillDir, { recursive: true, force: true });
+    const skillReport = runDoctor(corruptSkillMissing);
+    const skillStatus = getCheckStatus(skillReport, 'claudemd-skills-directory-parity');
+    if (skillStatus === 'warn' || skillStatus === 'fail') {
+      pass(`Tier ${tier} corrupt-skill-missing: claudemd-skills-directory-parity = ${skillStatus}`);
+    } else {
+      fail(`Tier ${tier} corrupt-skill-missing: expected warn/fail, got ${skillStatus}`);
+    }
+
+    // Corruption: pipeline.md H1 with a wrong tier name
+    const corruptTier = await scaffold(`doctor-xfile-corrupt-tier-${tier}`, tier, config);
+    injectStackMarker(corruptTier, 'node-ts');
+    fillStopHookTestCmd(corruptTier);
+    fillClaudeMdTestCmd(corruptTier);
+    const pipelinePath = path.join(corruptTier, '.claude/rules/pipeline.md');
+    if (fs.existsSync(pipelinePath)) {
+      const raw = fs.readFileSync(pipelinePath, 'utf8');
+      const wrongH1 =
+        tier === 's' ? '# Full Development Pipeline - Tier L\n' : '# Fast Lane Pipeline\n';
+      fs.writeFileSync(pipelinePath, raw.replace(/^#[^\n]*\n/, wrongH1));
+    }
+    const tierReport = runDoctor(corruptTier);
+    const tierStatus = getCheckStatus(tierReport, 'pipeline-md-tier-coherence');
+    if (tierStatus === 'warn' || tierStatus === 'fail') {
+      pass(`Tier ${tier} corrupt-tier-h1: pipeline-md-tier-coherence = ${tierStatus}`);
+    } else {
+      fail(`Tier ${tier} corrupt-tier-h1: expected warn/fail, got ${tierStatus}`);
+    }
+
+    // Corruption: node-ts marker but security.md overwritten with the Apple variant
+    const corruptSecurity = await scaffold(`doctor-xfile-corrupt-sec-tier-${tier}`, tier, config);
+    injectStackMarker(corruptSecurity, 'node-ts');
+    fillStopHookTestCmd(corruptSecurity);
+    fillClaudeMdTestCmd(corruptSecurity);
+    const securityPath = path.join(corruptSecurity, '.claude/rules/security.md');
+    if (fs.existsSync(securityPath)) {
+      fs.writeFileSync(
+        securityPath,
+        '# Security Rules - Native Apple (macOS / iOS)\n\nStore secrets in Keychain only.\n',
+      );
+    }
+    const secReport = runDoctor(corruptSecurity);
+    const secStatus = getCheckStatus(secReport, 'security-md-stack-alignment');
+    if (secStatus === 'warn' || secStatus === 'fail') {
+      pass(`Tier ${tier} corrupt-security: security-md-stack-alignment = ${secStatus}`);
+    } else {
+      fail(`Tier ${tier} corrupt-security: expected warn/fail, got ${secStatus}`);
+    }
+  }
+}
+
 // ── Main ─────────────────────────────────────────────────────────────────────
 
 async function main() {
@@ -2473,6 +2666,7 @@ async function main() {
   await scenarioPythonContentAssertions();
   await scenarioCrossStackInvariants();
   await scenarioSkillMdSpecCompliance();
+  await scenarioDoctorCrossFileValidation();
 
   // ── Summary ────────────────────────────────────────────────────────────────
 

--- a/packages/cli/test/unit/doctor-cross-file.test.js
+++ b/packages/cli/test/unit/doctor-cross-file.test.js
@@ -1,0 +1,216 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parseActiveSkills,
+  parseStopHookTestCmd,
+  claudeMdContainsCommand,
+  hasPlaceholder,
+  detectPipelineTier,
+  detectPhaseCountTier,
+  detectSecurityVariant,
+  expectedSecurityVariant,
+} from '../../src/utils/doctor-cross-file.js';
+
+describe('parseActiveSkills', () => {
+  it('extracts skill names from Active Skills section', () => {
+    const md = `# Project
+
+## Active Skills
+
+- \`/arch-audit\`
+- \`/commit\`
+- \`/security-audit\`
+
+## Environment
+`;
+    assert.deepEqual(parseActiveSkills(md), ['arch-audit', 'commit', 'security-audit']);
+  });
+
+  it('returns empty when section missing', () => {
+    assert.deepEqual(parseActiveSkills('# No section here'), []);
+  });
+
+  it('ignores non-skill bullets in section', () => {
+    const md = `## Active Skills\n\n- plain text\n- \`/valid-skill\`\n\n## Next`;
+    assert.deepEqual(parseActiveSkills(md), ['valid-skill']);
+  });
+});
+
+describe('parseStopHookTestCmd', () => {
+  it('extracts command between exit 0 and ||', () => {
+    const settings = {
+      hooks: {
+        Stop: [
+          {
+            hooks: [
+              {
+                type: 'command',
+                command: '[ "$stop_hook_active" = "1" ] && exit 0; npm test || echo "fail"',
+              },
+            ],
+          },
+        ],
+      },
+    };
+    assert.equal(parseStopHookTestCmd(settings), 'npm test');
+  });
+
+  it('returns null when no Stop hook', () => {
+    assert.equal(parseStopHookTestCmd({}), null);
+  });
+
+  it('returns null on malformed shape', () => {
+    assert.equal(parseStopHookTestCmd({ hooks: { Stop: 'oops' } }), null);
+  });
+
+  it('preserves placeholder when still unfilled', () => {
+    const settings = {
+      hooks: {
+        Stop: [
+          {
+            hooks: [
+              { command: '[ "$stop_hook_active" = "1" ] && exit 0; [TEST_COMMAND] || echo x' },
+            ],
+          },
+        ],
+      },
+    };
+    assert.equal(parseStopHookTestCmd(settings), '[TEST_COMMAND]');
+  });
+
+  it('extracts tier M/L command wrapped in cd + pipe to tail', () => {
+    const settings = {
+      hooks: {
+        Stop: [
+          {
+            hooks: [
+              {
+                command:
+                  '[ "$stop_hook_active" = "1" ] && exit 0; cd $CLAUDE_PROJECT_DIR && npx vitest run 2>&1 | tail -5; [[ ${PIPESTATUS[0]} -ne 0 ]] && echo x',
+              },
+            ],
+          },
+        ],
+      },
+    };
+    assert.equal(parseStopHookTestCmd(settings), 'npx vitest run');
+  });
+});
+
+describe('claudeMdContainsCommand', () => {
+  it('finds command inside Key Commands block only', () => {
+    const md = `## Key Commands\n\n\`\`\`bash\nnpm install\nnpm test\n\`\`\`\n\n## Other`;
+    assert.equal(claudeMdContainsCommand(md, 'npm test'), true);
+    assert.equal(claudeMdContainsCommand(md, 'pytest'), false);
+  });
+
+  it('returns false when Key Commands section missing', () => {
+    assert.equal(claudeMdContainsCommand('# No commands', 'npm test'), false);
+  });
+
+  it('returns false for empty command', () => {
+    assert.equal(claudeMdContainsCommand('## Key Commands\nanything', ''), false);
+  });
+});
+
+describe('hasPlaceholder', () => {
+  it('detects placeholder tokens', () => {
+    assert.equal(hasPlaceholder('value: [TEST_COMMAND]'), true);
+    assert.equal(hasPlaceholder('[FRAMEWORK_VALUE]'), true);
+    assert.equal(hasPlaceholder('[A_B_C_1]'), true);
+  });
+
+  it('does not flag lowercase or mixed', () => {
+    assert.equal(hasPlaceholder('[lowercase]'), false);
+    assert.equal(hasPlaceholder('no brackets here'), false);
+    assert.equal(hasPlaceholder('[Mixed_Case]'), false);
+  });
+});
+
+describe('detectPipelineTier', () => {
+  it('recognises tier S Fast Lane', () => {
+    assert.equal(detectPipelineTier('# Fast Lane Pipeline\n\nstuff'), 's');
+  });
+
+  it('recognises tier M', () => {
+    assert.equal(detectPipelineTier('# Standard Development Pipeline - Tier M\n'), 'm');
+  });
+
+  it('recognises tier L', () => {
+    assert.equal(detectPipelineTier('# Full Development Pipeline - Tier L\n'), 'l');
+  });
+
+  it('returns unknown for unexpected H1', () => {
+    assert.equal(detectPipelineTier('# Something Else'), 'unknown');
+  });
+});
+
+describe('detectPhaseCountTier', () => {
+  it('tier S detected via FL-N sections', () => {
+    assert.equal(detectPhaseCountTier('## FL-0 Setup\n## FL-1 Implement'), 's');
+  });
+
+  it('tier L detected via Phase 1.6', () => {
+    assert.equal(detectPhaseCountTier('## Phase 1\n## Phase 1.6 Visual Design\n## Phase 2'), 'l');
+  });
+
+  it('tier M detected via plain Phase N', () => {
+    assert.equal(detectPhaseCountTier('## Phase 0\n## Phase 1\n## Phase 2'), 'm');
+  });
+});
+
+describe('detectSecurityVariant', () => {
+  it('H1 apple signature', () => {
+    assert.equal(
+      detectSecurityVariant('# Security Rules - Native Apple (macOS / iOS)\n'),
+      'native-apple',
+    );
+  });
+
+  it('H1 android signature', () => {
+    assert.equal(
+      detectSecurityVariant('# Security Rules - Native Android (Kotlin / Java)\n'),
+      'native-android',
+    );
+  });
+
+  it('H1 systems signature', () => {
+    assert.equal(
+      detectSecurityVariant(
+        '# Security Rules - Systems & Backend (Rust / Go / .NET / Java / C++)\n',
+      ),
+      'systems',
+    );
+  });
+
+  it('H1 web signature (exact, no suffix)', () => {
+    assert.equal(detectSecurityVariant('# Security Rules\n\nmore'), 'web');
+  });
+
+  it('falls back to content markers when H1 modified', () => {
+    const md = '# Custom Rules\n\nStore secrets in Android Keystore only.';
+    assert.equal(detectSecurityVariant(md), 'native-android');
+  });
+});
+
+describe('expectedSecurityVariant', () => {
+  it('swift → native-apple', () => {
+    assert.equal(expectedSecurityVariant('swift', false), 'native-apple');
+  });
+
+  it('kotlin → native-android', () => {
+    assert.equal(expectedSecurityVariant('kotlin', false), 'native-android');
+  });
+
+  it('rust without API → systems', () => {
+    assert.equal(expectedSecurityVariant('rust', false), 'systems');
+  });
+
+  it('rust with API → web', () => {
+    assert.equal(expectedSecurityVariant('rust', true), 'web');
+  });
+
+  it('node-ts → web', () => {
+    assert.equal(expectedSecurityVariant('node-ts', true), 'web');
+  });
+});


### PR DESCRIPTION
## Summary

Closes Issue #91 (ICE 294). Adds five cross-file validation checks to `doctor`, closing the gap where a scaffold could pass every single-file check while drifting between CLAUDE.md, .claude/skills/, settings.json, pipeline.md, and security.md.

**What changed for users**

The five new checks run under `doctor` and `doctor --report` like any other check. All are `warn:true` at the user layer: they never block `doctor --ci`, they surface drift without breaking pipelines.

- `settings-no-placeholders`: flags unfilled `[UPPERCASE_TOKEN]` placeholders in `.claude/settings.json`.
- `claudemd-stop-hook-test-cmd-match`: confirms the test command declared in the Stop hook also shows up in CLAUDE.md Key Commands. Handles both the Tier S `… && exit 0; CMD || echo` shape and the Tier M/L `… && exit 0; cd \$CLAUDE_PROJECT_DIR && CMD 2>&1 | tail` shape.
- `claudemd-skills-directory-parity`: set-diff between `## Active Skills` in CLAUDE.md and the directory listing of `.claude/skills/`. `custom-*` skills are excluded on both sides.
- `pipeline-md-tier-coherence`: self-consistency between the H1 of pipeline.md (Fast Lane / Tier M / Tier L) and the phase-section pattern (`FL-N` vs `Phase N` vs `Phase 1.6`).
- `security-md-stack-alignment`: detects stack markers in cwd and verifies security.md uses the matching variant via H1 signature, with a content-marker fallback (Keychain, Android Keystore, Memory & Resource Safety, RLS).

**Infrastructure**

- New shared helper `packages/cli/src/utils/doctor-cross-file.js` with 9 functions. Used by the 5 new doctor checks plus the integration scenario. Sync-only companion to the async `detect-stack.js`: doctor checks have to stay synchronous to match the existing pattern.
- 30 new unit test cases in `test/unit/doctor-cross-file.test.js`.
- New integration scenario `scenarioDoctorCrossFileValidation`. It scaffolds tier-s/m/l, injects a node-ts stack marker (package.json + tsconfig.json), and covers both the happy path (5 checks pass or skip) and 5 independent corruption cases, each validating one check in isolation (+30 integration assertions).

**Drift closure, bonus fix**

The \`19 checks\` documented in README and operational-guide.md had been stale since v1.10.3: the real count post-v1.11.0 was 21. v1.12.0 lands the true number (26) and rewrites the operational-guide enumeration block.

## Test plan

- [x] Lint clean (eslint src/ test/)
- [x] Unit tests: 332 pass (was 302; +30 for doctor-cross-file helper)
- [x] Integration tests: 864 pass (was 834; +30 from scenarioDoctorCrossFileValidation)
- [x] `doctor --report` on fresh tier-m scaffold: all 26 checks pass/skip (5 new ones visible)
- [x] Happy path + 5 corruption cases × 3 tiers verified green

## References

- Source prompt: \`docs/reviews/scaffold-verification-prompt.md\` §D (cross-file consistency) + §C4 (placeholders)
- ICE 294 (I:6 C:7 E:7)
- Follows the pattern established in v1.11.0 (#109)