### PR TITLE
v1.13.0: /doc-audit skill (Issue #61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,34 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.13.0] — 2026-04-24
+
+### Added
+
+- **New skill `/doc-audit`** (Issue #61, Tier M/L): static documentation drift audit. Seven checks:
+  - **D1 Relative-link resolution**: markdown links to local files must resolve. `http(s)://` and anchors excluded.
+  - **D2 Code-block syntax**: `json` / `yaml` / `toml` fenced blocks are parsed with a stack-appropriate tool (`node -e`, `python -c yaml.safe_load`, `python -c tomllib`). Blocks containing template markers (`<...>`, `{{...}}`, `[PLACEHOLDER]`) are skipped.
+  - **D3 CDK placeholder residuals**: pinned list of the ten scaffold tokens — `[TEST_COMMAND]`, `[FRAMEWORK_VALUE]`, `[LANGUAGE_VALUE]`, `[INSTALL_COMMAND]`, `[DEV_COMMAND]`, `[BUILD_COMMAND]`, `[TYPE_CHECK_COMMAND]`, `[E2E_COMMAND]`, `[ENUM_CASE_CONVENTION]`, `[MIGRATION_COMMAND]`. Every token on the list is grepped against `packages/cli/templates/**` — only tokens the scaffold actually writes are included. Generic `[UPPERCASE]` regex is intentionally avoided.
+  - **D4 Slash-command name match**: `/<skill>` mentions cross-verified against `.claude/skills/<skill>/`. CDK CLI verbs (`init`, `upgrade`, `doctor`, `add`, `new`) allowlisted.
+  - **D5 Skill-count consistency**: numeric claims (`\d+ skills`) cross-verified against `.claude/skills/` minus `custom-*`.
+  - **D6 ADR marker freshness**: if `[ADR_PATH]` set, frontmatter dates older than 180 days without a terminal `status:` flagged.
+  - **D7 Stack-specific doc sync**: top-3 stacks only (`node-ts`, `python`, `swift`). Patterns live in a sibling `PATTERNS.md` — Next.js routes, Django URLconf paths, Swift Package.swift products. Other stacks skip D7.
+- New skill directory scaffolded in `packages/cli/templates/tier-m/.claude/skills/doc-audit/` and `tier-l/.claude/skills/doc-audit/` (byte-identical across tiers): `SKILL.md` (271 body lines, inside the 500-line guardrail) + `PATTERNS.md` (agnostic D3 list + D7 stack-specific patterns).
+- Registry entry in `skill-registry.js`: `minTier: 'm'`, `requires: {}` (universal), `cheatsheet: true`, `excludeNative: false`.
+- Cheatsheet row for `/doc-audit` added in both Tier M and Tier L cheatsheet.md.
+- Integration scenario `scenarioDocAuditPresent`: scaffolds tier-s/m/l and verifies SKILL.md + PATTERNS.md presence (or pruning on tier-s), cheatsheet row presence, pipeline.md Track C invocation, `allowed-tools` syntax spec-compliance, and SKILL.md body size budget.
+
+### Changed
+
+- `pipeline.md` Track C in both Tier M and Tier L renamed from `Track C - Test suite audit` to `Track C - Test + doc audit`, with `/doc-audit` invocation added alongside `/test-audit`.
+- `README.md` skill count reference updated from `16 audit skills` to `17 audit skills`; `/doc-audit` row added to the skills table; Testing section updated to `895 integration checks` and `332 unit tests`; shields.io badge updated to `895 checks`.
+- `docs/operational-guide.md` audit-skill table updated with a `/doc-audit` row (universal tier-M/L install, no `requires`); Phase 5d Track C renamed to "Test + doc audit"; full `/doc-audit` skill detail section added after `/test-audit`.
+- Integration test count: 864 → 895 (+31 from `scenarioDocAuditPresent`).
+- CLAUDE.md line-count regression guard in `scenarioPlaceholderNoiseReduction` loosened from `< 80` to `< 85` to accommodate the extra Active Skills row (one line per new skill in the registry). The guard still catches stripping regressions vs. the ~92-line raw template.
+- `skill-registry.test.js` entry-count assertion updated from 18 to 19.
+
+---
+
 ## [1.12.0] — 2026-04-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Node.js >= 22](https://img.shields.io/badge/node-%3E%3D22-brightgreen.svg)](https://nodejs.org)
 [![CI](https://github.com/marcoguillermaz/claude-dev-kit/actions/workflows/ci.yml/badge.svg)](https://github.com/marcoguillermaz/claude-dev-kit/actions/workflows/ci.yml)
-[![834 integration checks](https://img.shields.io/badge/integration-834%20checks-blue.svg)](#testing)
+[![895 integration checks](https://img.shields.io/badge/integration-895%20checks-blue.svg)](#testing)
 
 > Scaffold for legible, reviewable AI-assisted development.
 > Claude generates. Your team decides.
@@ -46,7 +46,7 @@ After init, open Claude Code and start working. The scaffold is active immediate
 
 Start at Tier 0. Move up when you need more structure: `npx mg-claude-dev-kit upgrade --tier=m`
 
-### 16 audit skills
+### 17 audit skills
 
 Executable multi-step programs that run inside Claude Code. Not prompt instructions - structured audit workflows with model routing (haiku for mechanical checks, sonnet for analysis).
 
@@ -67,6 +67,7 @@ Executable multi-step programs that run inside Claude Code. Not prompt instructi
 | `/ui-audit`            | M L   | Design token compliance, component adoption, empty states.                                                                              |
 | `/accessibility-audit` | M L   | axe-core WCAG 2.2, APCA contrast, static a11y (aria, tabindex, focus, labels).                                                          |
 | `/test-audit`          | M L   | Coverage (lcov/Istanbul/Cobertura/go/tarpaulin/xcresult), pyramid shape, anti-patterns (`.only`, skipped, empty, no-assertion, sleeps). |
+| `/doc-audit`           | M L   | Doc drift: link resolution, code-block syntax (json/yaml/toml), CDK placeholder residuals, slash-command name match, skill-count consistency, ADR freshness, stack-sync (Next.js/Django/Swift). |
 | `/skill-review`        | M L   | Quality review pipeline for skill portfolios. Spec compliance, cross-tier coherence, behavioral fixtures.                               |
 
 Skills are conditionally installed based on your project: `hasApi`, `hasDatabase`, `hasFrontend`, `hasDesignSystem`.
@@ -155,8 +156,8 @@ npx mg-claude-dev-kit new skill               # create a custom skill (wizard)
 ## Testing
 
 ```bash
-node packages/cli/test/integration/run.js    # 834 integration checks
-node --test packages/cli/test/unit/*.test.js   # 270 unit tests
+node packages/cli/test/integration/run.js    # 895 integration checks
+node --test packages/cli/test/unit/*.test.js   # 332 unit tests
 ```
 
 Covers: file structure per tier, Stop hook presence, pipeline gate counts, placeholder resolution, skill pruning, security variant selection, native stack adaptation, rubric scoring, cross-stack content invariants (10 stacks), golden-file assertions (Swift, Node-TS, Python), full CLI execution via `--answers` fixtures.
@@ -186,9 +187,9 @@ Covers: file structure per tier, Stop hook presence, pipeline gate counts, place
 
 See [GitHub Milestones](https://github.com/marcoguillermaz/claude-dev-kit/milestones) for the 12-month plan.
 
-**Current**: v1.11.0 ships Anthropic spec compliance. The `allowed-tools` frontmatter syntax is now space-separated across every scaffolded SKILL.md; the fix was surgical (only 2 files still used the comma form — under a spec-conformant parser it resolves to a YAML scalar with literal commas, silently dropping tool pre-authorisation). The `arch-audit` body drops from 508 to 360 lines across all three tiers: Step 3c, 3d, and H1 now live in a sibling `advanced-checks.md`. Two new `doctor` checks (`skill-md-size-budget`, `skill-allowed-tools-syntax`) plus a CDK-internal integration scenario guard against regression. A new shared helper, `skill-frontmatter.js`, consolidates frontmatter parsing. 834 integration + 302 unit tests.
+**Current**: v1.13.0 ships the `/doc-audit` skill (Issue #61, ICE 320): the Q1 skill-expansion spillover, rank #4 in the 3-model consensus, now closed. Doc drift normally stays silent until a new contributor trips over it. `/doc-audit` runs in Phase 5d Track C next to `/test-audit`, so drift gets caught while the change is still fresh. Seven static checks: relative-link resolution, code-block syntax (json, yaml, toml), CDK placeholder residuals (the D3 list is pinned to the ten scaffold tokens, every entry verified against `packages/cli/templates/**`, no generic `[UPPERCASE]` false positives), slash-command name match, skill-count consistency, ADR marker freshness, and stack-specific doc sync for Next.js, Django, and Swift via a sibling `PATTERNS.md`. The SKILL.md body lands at 271 lines, well inside the 500-line guardrail from v1.11.0. Track C in `pipeline.md` tier-M/L is renamed to "Test + doc audit" to reflect the pairing. Integration: 895 checks (+31 from `scenarioDocAuditPresent`); unit: 332 tests.
 
-**Next**: Q2 #3 public documentation site (VitePress, ICE 432) and the `/doc-audit` skill (ICE 320) to close the Q1 skill spillover.
+**Next**: Q2 #7 (Issue #66, ICE 245) adds three more skills on the expansion track: `/compliance-audit`, `/api-contract-audit`, `/infra-audit`. Q2 #3, the public docs site (VitePress, ICE 432), stays deferred on purpose.
 
 ---
 

--- a/docs/operational-guide.md
+++ b/docs/operational-guide.md
@@ -40,7 +40,7 @@ Claude Code is a powerful CLI assistant that can read, write, and reason about y
 - A development pipeline Claude follows strictly - requirements reviewed before code is written, tests verified before declaring done
 - Pre-wired hooks that enforce the pipeline mechanically, not just as instructions
 - A tiered system matching process overhead to task complexity: a two-line bugfix does not go through the same process as a multi-week feature
-- 16 audit skills - executable multi-step programs with model routing (haiku for mechanical checks, sonnet for analysis)
+- 17 audit skills - executable multi-step programs with model routing (haiku for mechanical checks, sonnet for analysis)
 - Audit trails, commit attribution, secret scanning, and CODEOWNERS gates for full visibility over AI-generated changes
 - A discovery mechanism that teaches Claude about your existing codebase in a single structured session
 
@@ -712,7 +712,7 @@ Defined in the `CLAUDE.md` template for Tier M/L. Governs how Claude handles non
 
 ## 10. Audit skills
 
-Sixteen audit skills are scaffolded across the tiers. Run them as slash commands in Claude Code at any time - no pipeline phase required. Skills are **conditionally installed** based on wizard answers at init time.
+Seventeen audit skills are scaffolded across the tiers. Run them as slash commands in Claude Code at any time - no pipeline phase required. Skills are **conditionally installed** based on wizard answers at init time.
 
 All skill applicability rules are managed by a central skill registry (`packages/cli/src/scaffold/skill-registry.js`). Each skill declares which tiers and project conditions it requires.
 
@@ -735,6 +735,7 @@ All skill applicability rules are managed by a central skill registry (`packages
 | `/ui-audit`            | -   | x   | x   | `hasFrontend=true` AND `hasDesignSystem=true` | - (static)                                                                   |
 | `/accessibility-audit` | -   | x   | x   | `hasFrontend=true`                            | Dev server + Playwright MCP (for full/wcag modes; static mode needs nothing) |
 | `/test-audit`          | -   | x   | x   | always (no `requires`)                        | - (static analysis)                                                          |
+| `/doc-audit`           | -   | x   | x   | always (no `requires`)                        | - (static analysis)                                                          |
 | `/skill-review`        | -   | x   | x   | always                                        | - (static analysis)                                                          |
 
 ### General rules
@@ -756,8 +757,9 @@ After the smoke test and before the outcome checklist, three tracks can run:
 **Track B - API/DB** (if the block touches API routes or applies migrations):
 `/security-audit` and `/api-design` (concurrent, static); `/migration-audit` (if the block applies migrations); `/skill-db` (if the block changes schema or adds new tables).
 
-**Track C - Test suite** (runs for every block after Phase 3 is green):
-`/test-audit` - static analysis of coverage reports (lcov / Istanbul / Cobertura / go / tarpaulin / xcresult), pyramid shape (unit/integration/e2e ratio), and anti-patterns (`.only` leaks, skipped tests, empty bodies, no-assertion tests, hardcoded sleeps). Critical findings (`.only` committed, 0% coverage on a changed file) block Phase 6.
+**Track C - Test + doc audit** (runs for every block after Phase 3 is green):
+`/test-audit` - static analysis of coverage reports (lcov / Istanbul / Cobertura / go / tarpaulin / xcresult), pyramid shape (unit/integration/e2e ratio), and anti-patterns (`.only` leaks, skipped tests, empty bodies, no-assertion tests, hardcoded sleeps).
+`/doc-audit` - static doc-drift check: relative-link resolution, code-block syntax (json/yaml/toml), CDK placeholder residuals, slash-command name match, skill-count consistency, ADR freshness, and stack-specific doc sync (Next.js / Django / Swift). Critical findings from either skill (`.only` committed, 0% coverage on a changed file, CDK placeholder in README, broken link to a user-visible flow doc) block Phase 6.
 
 ### Severity handling
 
@@ -875,6 +877,29 @@ Checks:
 - **Anti-patterns (T1-T8, all stack-adapted)**: T1 `.only`/`fit`/`fdescribe` committed (Critical), T2 skipped tests (Medium; High if > 10% of suite), T3 `.todo` placeholders (Low), T4 empty test bodies (High), T5 tests without assertions (High), T6 hardcoded sleeps ≥ 500ms (Medium), T7 debug output left in tests (Low), T8 multi-file `.only` pattern (Critical).
 
 Universal gating: installed on every Tier M/L project regardless of feature flags (no `requires`). Backlog prefix: `TEST-`. Flaky-test detection and live re-run analysis are deferred - v1 is static-only.
+
+#### /doc-audit
+
+**File**: `.claude/skills/doc-audit/SKILL.md` | **Tier**: M, L
+
+Static documentation drift audit. Grep / file parsing / filesystem reads only - no URL fetches, no builds, no code execution. Runs in Phase 5d Track C alongside `/test-audit`: drift caught while the change is fresh in memory, not six weeks later when a new contributor trips over it.
+
+Checks:
+
+- **D1 Relative-link resolution**: markdown links to local files (`[text](./path)`, `[text](../path)`) resolve to existing paths. `http(s)://`, `mailto:`, and anchor-only links skipped. Severity: Critical for broken links to user-visible flow docs (CONTRIBUTING, SECURITY, linked guides); High otherwise.
+- **D2 Code-block syntax**: fenced blocks tagged `json`, `yaml`, `toml` are parsed with a stack-appropriate tool (`node -e 'JSON.parse'`, `python -c 'yaml.safe_load'`, `python -c 'tomllib.loads'`). Blocks tagged `bash`, `sh`, `text`, unlabelled, or containing template markers (`<...>`, `{{...}}`) are skipped. Severity: High per unparseable block.
+- **D3 CDK placeholder residuals**: uses a pinned list of the ten scaffold tokens (`[TEST_COMMAND]`, `[FRAMEWORK_VALUE]`, `[LANGUAGE_VALUE]`, `[INSTALL_COMMAND]`, `[DEV_COMMAND]`, `[BUILD_COMMAND]`, `[TYPE_CHECK_COMMAND]`, `[E2E_COMMAND]`, `[ENUM_CASE_CONVENTION]`, `[MIGRATION_COMMAND]`). Every entry is verified against `packages/cli/templates/**` so only tokens the scaffold actually writes are included. Generic `[UPPERCASE]` regex is deliberately avoided to prevent false positives on legitimate user conventions (`[API_KEY]`, `[YOUR_DOMAIN]`, `[FEATURE_FLAG]`). Severity: Critical in `README.md`, High in other user-facing docs.
+- **D4 Slash-command name match**: every `/name` reference in docs is cross-checked against `.claude/skills/<name>/`. Allowlist covers CDK CLI verbs (`init`, `upgrade`, `doctor`, `add`, `new`). Severity: Medium per orphan.
+- **D5 Skill-count consistency**: numeric claims like "16 skills" in README / docs are cross-verified against `ls .claude/skills/ | grep -v '^custom-' | wc -l`. Severity: Medium if mismatch ≤ 2; High if > 2. Scope is intentionally narrow - doctor / test counts are source-specific to the CDK codebase and not in scope for user-project audits.
+- **D6 ADR marker freshness**: if an ADR directory is configured, frontmatter `date:` / `updated:` fields older than 180 days without a terminal `status:` (`accepted`, `deprecated`, `superseded`, `rejected`) are flagged. Severity: Low.
+- **D7 Stack-specific doc sync**: runs only for `node-ts`, `python`, `swift` - other stacks skip D7 and run only D1-D6. Patterns live in a sibling `PATTERNS.md`:
+  - **node-ts**: Next.js `app/` or `pages/` routes cross-referenced against `docs/sitemap.md` and README; `package.json` dependencies cross-referenced against README.
+  - **python**: Django `urls.py` paths cross-referenced against `docs/sitemap.md` and README; `pyproject.toml` / `requirements.txt` top-level deps cross-referenced against README.
+  - **swift**: `Package.swift` products and targets cross-referenced against README; DocC presence hint for library targets.
+
+Severity: Medium per orphan surface (D7 patterns are best-effort hints, not hard validation).
+
+Universal gating: installed on every Tier M/L project regardless of feature flags (no `requires`). Backlog prefix: `DOC-`. Live link check (HTTP/HTTPS), semantic drift reasoning, and doc-bloat judgement are deferred - v1 is static only. Read-only: the skill produces a markdown report; corrections are proposed but never applied.
 
 #### /skill-review
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mg-claude-dev-kit",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "Scaffold for legible, reviewable AI-assisted development",
   "type": "module",
   "bin": {

--- a/packages/cli/src/scaffold/skill-registry.js
+++ b/packages/cli/src/scaffold/skill-registry.js
@@ -73,6 +73,7 @@ export const SKILL_REGISTRY = [
     cheatsheet: true,
   },
   { name: 'test-audit', minTier: 'm', requires: {}, cheatsheet: true },
+  { name: 'doc-audit', minTier: 'm', requires: {}, cheatsheet: true },
   { name: 'dependency-scan', minTier: 'm', requires: {}, cheatsheet: false },
   { name: 'context-review', minTier: 'l', requires: {}, cheatsheet: false },
   { name: 'skill-review', minTier: 'm', requires: {}, cheatsheet: false },

--- a/packages/cli/templates/tier-l/.claude/cheatsheet.md
+++ b/packages/cli/templates/tier-l/.claude/cheatsheet.md
@@ -48,6 +48,7 @@ Run these on demand. Each skill reads the codebase, produces a structured report
 | `/ux-audit` | Task completion paths, feedback clarity, cognitive load, error recovery | After adding user flows; before usability reviews |
 | `/ui-audit` | Design system token compliance, component adoption, empty/error/loading states | After UI changes; when design system is configured |
 | `/test-audit` | Coverage (lcov/Istanbul/Cobertura/go/tarpaulin/xcresult), pyramid shape, anti-patterns (`.only`, skipped, empty, no-assertion, sleeps) | After Phase 3 tests green; every block |
+| `/doc-audit` | Relative-link resolution, code-block syntax (json/yaml/toml), CDK placeholder residuals, slash-command name match, skill-count consistency, ADR freshness, stack-specific doc sync (Next.js / Django / Swift) | After doc changes; every block that touches README or `docs/` |
 | `/simplify` | Early returns, nesting depth, local duplication, dead code, magic values | After writing code (Phase 2); on demand |
 | `/dependency-scan` | Route hrefs, import consumers, shared type consumers, test refs, FK refs, access control | Phase 1 mandatory; before finalizing file list |
 | `/skill-review` | Skill quality audit: structural review, severity calibration, fix verification | After modifying skills; quarterly review cycle |

--- a/packages/cli/templates/tier-l/.claude/rules/pipeline.md
+++ b/packages/cli/templates/tier-l/.claude/rules/pipeline.md
@@ -214,9 +214,10 @@ If either condition is false: **skip this phase and state so explicitly** - do n
 - Run `/migration-audit` if the block applies migrations - static analysis of migration files.
 - Run `/skill-db` if the block changes the schema or adds new tables - live verification of schema state, access control policies, and query patterns.
 
-**Track C - Test suite audit** *(runs for every block after Phase 3 is green - static analysis, no dev server needed)*
+**Track C - Test + doc audit** *(runs for every block after Phase 3 is green - static analysis, no dev server needed)*
 - Run `/test-audit` - static analysis of coverage (auto-detects lcov / Istanbul / Cobertura / go / tarpaulin / xcresult), pyramid shape (unit/integration/e2e ratio), anti-patterns (`.only` leaks, skipped tests, empty bodies, no-assertion tests, hardcoded sleeps).
-- Output: one-paragraph summary. Critical findings (`.only` committed, 0% coverage on a file changed in this block) block Phase 6.
+- Run `/doc-audit` - static doc-drift check (relative-link resolution, code-block syntax, CDK placeholder residuals, slash-command name match, skill-count consistency, ADR freshness). Stack-aware for Next.js / Django / Swift.
+- Output: one-paragraph summary per skill. Critical findings (`.only` committed, 0% coverage on a file changed in this block, CDK placeholder in README, broken link to user-visible flow doc) block Phase 6.
 
 **Severity handling - all tracks**:
 - **Critical**: fix before Phase 6. Do not proceed with open Critical issues.

--- a/packages/cli/templates/tier-l/.claude/skills/doc-audit/PATTERNS.md
+++ b/packages/cli/templates/tier-l/.claude/skills/doc-audit/PATTERNS.md
@@ -1,0 +1,115 @@
+# Doc Audit - Patterns
+
+Reference file for `/doc-audit`. Contains the pinned CDK placeholder list (agnostic) and stack-specific grep patterns for D7 doc-sync checks.
+The executing agent reads this file at the start of Step 3. For D3, use the placeholder list verbatim. For D7, select the section matching the detected stack; if the detected stack is not in the top 3 (`node-ts`, `python`, `swift`), skip D7 entirely.
+
+---
+
+## D3 - CDK placeholder list (agnostic)
+
+The CDK scaffold emits these placeholder tokens. Readers are expected to replace each one with a concrete value. A token left in place after first-run configuration signals an incomplete adoption, not an intentional user convention.
+
+```
+[TEST_COMMAND]
+[FRAMEWORK_VALUE]
+[LANGUAGE_VALUE]
+[INSTALL_COMMAND]
+[DEV_COMMAND]
+[BUILD_COMMAND]
+[TYPE_CHECK_COMMAND]
+[E2E_COMMAND]
+[ENUM_CASE_CONVENTION]
+[MIGRATION_COMMAND]
+```
+
+**Extension rule**: this list is grepped against the CDK template tree (`packages/cli/templates/**`) - only tokens that are actually emitted by the scaffold belong here. When a new CDK release adds a placeholder to any scaffold template, append it to this list and bump the skill's internal version note in the next release. Generic `[UPPERCASE]` regex is deliberately avoided - it produces false positives on legitimate user conventions (`[API_KEY]`, `[YOUR_DOMAIN]`, `[FEATURE_FLAG]`).
+
+**Exclusion**: skip files under `packages/cli/templates/**` (the CDK template source itself - placeholders are intentional there). Apply this exclusion only when auditing the CDK repo itself; in user projects, the exclusion is a no-op.
+
+---
+
+## D7 - Stack-specific doc sync
+
+Best-effort hints, not hard validation. Atypical layouts (custom routing, monorepos, non-conventional directory naming) will produce false positives; default severity for D7 findings is **Medium** so they are discussable rather than blocking.
+
+### node-ts
+
+**Surface A - Next.js routes**
+
+Marker: `next.config.js`, `next.config.mjs`, `next.config.ts`, or `"next"` in `package.json` dependencies.
+
+Route discovery patterns:
+
+```
+app/**/page.{ts,tsx,js,jsx}        # App Router (Next.js 13+)
+pages/**/*.{ts,tsx,js,jsx}         # Pages Router (legacy)
+```
+
+Exclude: `app/api/**`, `pages/api/**`, `_app`, `_document`, `_error`, `layout.*`, `loading.*`, `error.*`, `not-found.*`, `[...catchall]` style dynamic segments.
+
+Compare the derived route list against:
+- `docs/sitemap.md` entries (grep for route paths `/<segment>`)
+- README "Tech Stack" or "Routes" sections
+
+Flag any route that does not appear in either doc source.
+
+**Surface B - Dependency mentions**
+
+For top-level dependencies in `package.json` (merge `dependencies` and `devDependencies`, exclude `@types/*`), check whether the dependency name appears at least once in README (case-insensitive). Limit to the top 15 by install size if the dep list is > 15. Absence is a Medium orphan.
+
+### python
+
+**Surface A - Django URLconf**
+
+Marker: `manage.py` + any `*/urls.py` OR `django` in `pyproject.toml` / `requirements.txt`.
+
+Route discovery pattern:
+
+```python
+path\([\'"]([^\'\"]+)[\'"]
+re_path\([\'"]([^\'\"]+)[\'"]
+```
+
+Extract the URL pattern (first regex capture). Exclude admin-prefixed routes (`admin/`, `^admin/`) and API-only prefixes declared under `api/v\d+/`.
+
+Compare extracted paths against `docs/sitemap.md` and README. Flag missing paths.
+
+**Surface B - Dependency mentions**
+
+From `pyproject.toml` `[project.dependencies]` or `[tool.poetry.dependencies]`, or top-level entries in `requirements.txt` (exclude version pins `==`, `>=`, `~=` - just the package name). Check whether the package name appears in README. Limit to top 15. Absence is a Medium orphan.
+
+### swift
+
+**Surface A - Package products and targets**
+
+Marker: `Package.swift` in repo root (Swift Package Manager).
+
+Patterns:
+
+```swift
+.library\(\s*name:\s*"([^"]+)"
+.executable\(\s*name:\s*"([^"]+)"
+.target\(\s*name:\s*"([^"]+)"
+```
+
+Exclude test targets: any name ending in `Tests` or explicitly declared via `.testTarget`.
+
+Compare the derived product and target list against README. Flag missing entries.
+
+**Surface B - DocC presence**
+
+If `Package.swift` declares at least one `.library(...)` product, check for the presence of a `Docs/`, `docs/`, or `Documentation/` directory. Absence is a Low hint (not Medium): Swift library packages conventionally ship DocC catalogs; absence is worth mentioning but not blocking.
+
+**Surface C - Xcode scheme mentions**
+
+If an `*.xcodeproj` or `*.xcworkspace` exists, the primary scheme name is usually the repo name. No automatic extraction in v1 (would require parsing the Xcode project file format). Deferred.
+
+---
+
+## Notes for future stacks
+
+When adding a new stack to D7 (`node-js`, `go`, `rust`, `kotlin`, `dotnet`, `ruby`, `java`):
+
+1. Add a new section here with Surface A (routes or modules), Surface B (dependencies), Surface C (if applicable).
+2. Update the Step 1 announcement in `SKILL.md` to include the stack in the top-3 list.
+3. Keep patterns conservative: the goal is to surface high-confidence orphans, not to flag every possible mismatch.

--- a/packages/cli/templates/tier-l/.claude/skills/doc-audit/SKILL.md
+++ b/packages/cli/templates/tier-l/.claude/skills/doc-audit/SKILL.md
@@ -1,0 +1,271 @@
+---
+name: doc-audit
+description: Static documentation drift audit - relative-link resolution, code-block syntax, CDK placeholder residuals, slash-command name match, skill-count consistency, ADR marker freshness, stack-specific doc sync (Next.js / Django / Swift).
+user-invocable: true
+model: sonnet
+context: fork
+argument-hint: [target:path:<dir>|target:file:<glob>|mode:all]
+allowed-tools: Read Glob Grep Bash
+---
+
+## Scope for v1
+
+- **Static analysis only.** Grep, file parsing, filesystem reads. Does not fetch URLs, does not run builds, does not execute code examples.
+- **No auto-fix.** Produces a markdown report; corrections are proposed but never applied.
+- **Live link check deferred.** HTTP/HTTPS targets are out of scope (flaky, rate-limited). Tracked as `DOC-live-links`.
+- **Semantic drift deferred.** Prose obsolescence, deprecation-age reasoning, and doc-bloat judgement are judgment-heavy and out of scope for v1.
+
+---
+
+## Configuration (adapt before first run)
+
+> Replace these placeholders:
+> - `[DOC_PATH]` - primary location of user-facing docs (e.g. `docs/`, `documentation/`, `website/`). Always included.
+> - `[README_PATH]` - repository README (usually `README.md` at project root).
+> - `[ADR_PATH]` - ADR directory if present (e.g. `docs/adr/`, `docs/decisions/`). Leave empty if none.
+
+---
+
+## Step 0 - Target resolution
+
+Parse `$ARGUMENTS` for a `target:` or `mode:` token.
+
+| Pattern | Meaning |
+|---|---|
+| `target:path:<dir>` | Audit docs under a specific directory only (e.g. `target:path:docs/api`) |
+| `target:file:<glob>` | Audit files matching the glob (e.g. `target:file:docs/**/*.md`) |
+| `mode:all` / no argument | **Full audit - README, CHANGELOG, every `.md` under `[DOC_PATH]`, and ADRs under `[ADR_PATH]` if set.** |
+
+**STRICT PARSING**: derive target ONLY from explicit text in `$ARGUMENTS`. Do NOT infer from conversation context, recent blocks, or memory.
+
+Announce: `Running doc-audit - scope: [FULL | target: <resolved>] - stack: <pending detection>`
+
+---
+
+## Step 1 - Stack detection
+
+Detect the primary stack in this priority order. First matching marker wins.
+
+| Stack | Marker file(s) |
+|---|---|
+| **node-ts** | `tsconfig.json` + `package.json` |
+| **node-js** | `package.json` (no `tsconfig.json`) |
+| **python** | `pyproject.toml` or `requirements.txt` or `setup.py` |
+| **go** | `go.mod` |
+| **rust** | `Cargo.toml` |
+| **swift** | `Package.swift` or `*.xcodeproj` / `*.xcworkspace` |
+| **kotlin** | `build.gradle.kts` or `build.gradle` with `kotlin(` plugin |
+| **dotnet** | `*.csproj` or `*.sln` |
+| **ruby** | `Gemfile` |
+| **java** | `pom.xml` or `build.gradle` (no Kotlin plugin) |
+| **generic** | None of the above |
+
+**Stack-specific depth** (D7 only): patterns are loaded from `PATTERNS.md` for `node-ts`, `python`, and `swift`. For every other stack, announce `Stack <name> detected - D7 stack-specific doc sync skipped; running D1-D6 universal checks.` and continue.
+
+Update announcement: `Running doc-audit - scope: [...] - stack: <detected>`
+
+---
+
+## Step 2 - Doc file discovery
+
+Collect the audit scope by this priority:
+
+1. Explicit target from Step 0 (`target:path` / `target:file`) wins and skips the rest.
+2. `[README_PATH]` if set (defaults to `README.md`).
+3. `CHANGELOG.md` at repo root if present.
+4. Every `*.md` and `*.mdx` under `[DOC_PATH]` (default `docs/`), excluding `node_modules/`, `dist/`, `build/`, `.next/`, `target/`, `vendor/`, and any path matched by `.gitignore`.
+5. Every `*.md` under `[ADR_PATH]` if set.
+
+Announce: `Discovered N documentation files. Auditing: <scope>`
+
+If `N == 0` and no target was passed: output `No documentation files found. Set [DOC_PATH] in Configuration or pass target:file:<glob>.` and exit.
+
+---
+
+## Step 3 - D1-D7 static checks
+
+Run each check below against the files from Step 2. Record findings with SEVERITY / ID / FILE:LINE / EVIDENCE / IMPACT / FIX.
+
+### D1 - Relative-link resolution
+
+**Critical if a link points to a file that governs user-visible flow (`CONTRIBUTING.md`, `SECURITY.md`, a referenced guide); High otherwise.** Broken relative links misdirect readers.
+
+Grep each doc for markdown link targets that do not start with `http://`, `https://`, `mailto:`, `#`, or `<`: pattern `\]\(([./][^)#]+)(?:#[^)]*)?\)`. For each match, resolve the target relative to the file's directory and check `fs.existsSync`. Skip targets that are image placeholders (`![...](...)`) only if they match `\.(png|jpg|jpeg|gif|svg|webp)$` **and** the file exists in a common asset directory - otherwise flag as D1.
+
+Report: each broken link with `FILE:LINE - [link text] -> <target> (not found)`.
+
+### D2 - Code-block syntax validity
+
+**High per unparseable block.** Broken code blocks copied into terminals or configs fail silently until a user hits them.
+
+Scan for fenced code blocks with a known declarative language tag: ` ```json `, ` ```yaml `, ` ```yml `, ` ```toml `. Extract the body. Parse with a stack-appropriate tool:
+
+- `json`: `node -e "JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'))"` via `Bash`, or reject on first syntax error.
+- `yaml` / `yml`: `python3 -c "import sys,yaml; yaml.safe_load(sys.stdin)"` if `python3` and `pyyaml` are on PATH; else skip with `N/A - yaml parser unavailable`.
+- `toml`: `python3 -c "import sys,tomllib; tomllib.loads(sys.stdin.read())"` on Python 3.11+; else skip with `N/A - toml parser unavailable`.
+
+Skip `bash`, `sh`, `shell`, `text`, `console`, `diff`, and any unlabelled fence. Skip blocks that contain an obvious template marker (`<...>`, `[PLACEHOLDER]`, `{{...}}`) - those are illustrative, not meant to parse.
+
+Report: each failing block with `FILE:LINE - lang=<tag> - <parser error excerpt>`.
+
+### D3 - CDK placeholder residuals
+
+**High per occurrence in user-facing docs; Critical if found in `README.md`.** Placeholders shipped unfilled indicate an incomplete scaffold adoption.
+
+The CDK scaffold emits a **fixed set** of `[UPPERCASE]` tokens that the user is expected to resolve. Generic `[UPPERCASE]` regex would produce false positives on legitimate user conventions (`[API_KEY]`, `[YOUR_DOMAIN]`, `[FEATURE_FLAG_NAME]`). Use the pinned list from `PATTERNS.md` (agnostic section, `D3 CDK placeholder list`):
+
+```
+[TEST_COMMAND] [FRAMEWORK_VALUE] [LANGUAGE_VALUE] [INSTALL_COMMAND]
+[DEV_COMMAND] [BUILD_COMMAND] [TYPE_CHECK_COMMAND] [E2E_COMMAND]
+[ENUM_CASE_CONVENTION] [MIGRATION_COMMAND]
+```
+
+Grep each doc for any exact token from the list. Exclude files under `packages/cli/templates/**` (the CDK template source itself - placeholders are intentional there).
+
+Report: each match with `FILE:LINE - <token> - replace with concrete value`.
+
+### D4 - Slash-command name match
+
+**Medium per orphan reference.** Readers click / copy a skill name that does not exist in `.claude/skills/`.
+
+Grep every doc for `/[a-z][a-z0-9-]+` occurrences inside prose (filter: must be preceded by whitespace or start-of-line and followed by a word boundary; ignore URL paths by excluding matches inside a `(...)` link target). For each unique command name, verify `.claude/skills/<name>/` exists. Allowlist CDK CLI verbs that are not skills: `init`, `upgrade`, `doctor`, `add`, `new` (these live in `packages/cli/src/commands/`, not in `.claude/skills/`).
+
+Report: each orphan with `FILE:LINE - /<name> - no matching skill directory`.
+
+### D5 - Skill-count consistency
+
+**Medium if mismatch ≤ 2; High if > 2.** A stale count signals an unmaintained README.
+
+Grep README and `[DOC_PATH]` for numeric skill claims: `\b(\d+)\s+(audit\s+)?skills?\b`. For each match, cross-verify against the filesystem:
+
+```bash
+ls .claude/skills/ | grep -v '^custom-' | wc -l
+```
+
+If the claimed count does not match the actual directory count, flag the mismatch. Note: this check intentionally scopes to **skill count only** - doctor/test counts are source-specific to the CDK codebase and are not in scope for user-project audits.
+
+Report: `FILE:LINE - claim "<N> skills" - actual <M> in .claude/skills/`.
+
+### D6 - ADR marker freshness
+
+**Low per stale file.** Only runs if `[ADR_PATH]` is set and the directory exists.
+
+For each `*.md` under `[ADR_PATH]`:
+
+- Parse YAML frontmatter for a `date:` or `updated:` field.
+- If the parsed date is older than 180 days AND the frontmatter `status:` field is not one of `accepted`, `deprecated`, `superseded`, `rejected`: flag as stale.
+
+Skip files without a frontmatter date field (freshness cannot be determined).
+
+Report: each stale file with `FILE - date: <YYYY-MM-DD> - status: <value | missing>`.
+
+### D7 - Stack-specific doc sync
+
+**Medium per orphan surface.** Only runs for `node-ts`, `python`, `swift` (see Step 1). Load `PATTERNS.md` → D7 section for the detected stack.
+
+The patterns cover:
+
+- **node-ts**: Next.js `app/` or `pages/` routes vs. mentions in `docs/sitemap.md` (if present) or README Tech Stack; `package.json` dependencies vs. README Tech Stack mentions.
+- **python**: Django `urls.py` paths vs. mentions in `docs/sitemap.md` or README; `pyproject.toml` / `requirements.txt` top-level deps vs. README mentions.
+- **swift**: `Package.swift` products / targets vs. README mentions; `Docs/` (DocC) presence if `Package.swift` declares `.target(...)` targets.
+
+Stack patterns are **best-effort hints**, not hard validation. Atypical project layouts (custom routing, monorepos) may produce false positives; default severity is Medium so findings are discussable, not blocking.
+
+Report: each orphan with `FILE:LINE - <surface> - not mentioned in docs/README`.
+
+---
+
+## Step 4 - Report
+
+```
+## Doc Audit - [DATE] - [SCOPE] - stack: [DETECTED]
+
+### Executive summary
+[2-5 bullets. Critical + High findings only. Concrete facts: file names, line numbers, counts.
+If nothing Critical/High: state that explicitly ("No Critical or High findings - docs are consistent with the code").]
+
+### Documentation maturity assessment
+| Dimension | Rating | Notes |
+|---|---|---|
+| Link hygiene | strong / adequate / weak | [D1 broken link count] |
+| Code-block validity | strong / adequate / weak | [D2 unparseable blocks] |
+| Placeholder discipline | strong / adequate / weak | [D3 CDK tokens remaining] |
+| Skill coherence | strong / adequate / weak | [D4 orphans + D5 count mismatch] |
+| ADR freshness | strong / adequate / weak | [D6 stale count; N/A if ADR_PATH unset] |
+| Stack sync | strong / adequate / weak | [D7 orphans; N/A for non-top-3 stacks] |
+| Release readiness | ready / conditional / blocked | [blocked = any Critical; conditional = High findings exist] |
+
+### Check verdicts
+| # | Check | Verdict | Findings |
+|---|---|---|---|
+| D1 | Relative-link resolution | ✅/⚠️ | [N broken] |
+| D2 | Code-block syntax | ✅/⚠️ | [N unparseable] |
+| D3 | CDK placeholder residuals | ✅/⚠️ | [N occurrences] |
+| D4 | Slash-command name match | ✅/⚠️ | [N orphans] |
+| D5 | Skill-count consistency | ✅/⚠️ | [mismatch or OK] |
+| D6 | ADR marker freshness | ✅/⚠️ / N/A | [N stale; N/A if no ADR_PATH] |
+| D7 | Stack-specific doc sync | ✅/⚠️ / N/A | [N orphans; N/A for non-top-3] |
+
+### Prioritized findings
+For each finding with severity Medium or above:
+[SEVERITY] [ID] [check] - [file:line] - [evidence excerpt] - [impact] - [fix] - [effort: S=<1h / M=half day / L=day+]
+
+### Quick wins
+[Findings that meet all three: (a) Medium or High, (b) effort S, (c) single-file fix]
+Format: "DOC-[n]: [one-line description]"
+If no quick wins: state explicitly.
+```
+
+---
+
+## Step 5 - Backlog decision gate
+
+Present all findings with severity Medium or above as a numbered decision list, sorted Critical → High → Medium:
+
+```
+Found N findings at Medium or above. Which to add to backlog?
+
+[1] [CRITICAL] DOC-? - file:line - one-line description
+[2] [HIGH]     DOC-? - file:line - one-line description
+[3] [MEDIUM]   DOC-? - file:line - one-line description
+...
+
+Reply with numbers to include (e.g. "1 2 4"), "all", or "none".
+```
+
+**Wait for explicit user response before writing anything.**
+
+Then write ONLY the approved entries to `docs/refactoring-backlog.md`:
+- Assign ID: `DOC-[n]` (next available after existing DOC entries)
+- Add row to priority index
+- Add full detail section with: issue, evidence (file:line + excerpt), fix suggestion, effort, risk
+
+### Severity guide
+
+- **Critical**: broken link to a user-visible flow doc (CONTRIBUTING, SECURITY, linked guide) (D1); CDK placeholder in `README.md` (D3)
+- **High**: unparseable `json` / `yaml` / `toml` code block (D2); CDK placeholder in any other user-facing doc (D3); skill-count mismatch > 2 (D5)
+- **Medium**: orphan `/skill-name` reference (D4); skill-count mismatch ≤ 2 (D5); stack-specific orphan surface (D7); broken link to non-critical asset (D1)
+- **Low**: stale ADR without terminal status (D6)
+
+---
+
+## Execution notes
+
+- Do NOT modify any doc file. Audit only.
+- Do NOT fetch URLs. HTTP / HTTPS link resolution is out of scope for v1.
+- `target:path:<dir>` and `target:file:<glob>` bypass the default scope from Step 2.
+- If git history is available, cross-reference D3 Critical findings against `git diff HEAD~1` - a placeholder on a file modified in the current block is more actionable than one left over from a prior release.
+- This skill complements `/arch-audit` (governance-file compliance) and `/test-audit` (suite quality). Run in Phase 5d Track C after Phase 3 passes - drift flagged when the modification is fresh in memory beats drift caught by a new contributor six weeks later.
+- After the report, ask: "Do you want me to prepare the corrections for the identified findings?" Reply with `yes` only after the user has signed off on the specific findings.
+
+---
+
+## Stack adaptation
+
+D1-D6 run on every stack. D7 is stack-specific and loads patterns from `${CLAUDE_SKILL_DIR}/PATTERNS.md`:
+
+- **node-ts**: Next.js route layout (`app/`, `pages/`) cross-referenced against `docs/sitemap.md` and README Tech Stack; `package.json` dependencies cross-referenced against README.
+- **python**: Django `urls.py` paths cross-referenced against `docs/sitemap.md` and README; `pyproject.toml` / `requirements.txt` top-level deps cross-referenced against README.
+- **swift**: `Package.swift` products and targets cross-referenced against README; DocC (`Docs/`) presence check for projects that declare library targets.
+
+For `node-js`, `go`, `rust`, `kotlin`, `dotnet`, `ruby`, `java`, and `generic`: D7 is skipped. Patterns for these stacks can be added in a future release; the Step 1 announcement already tells the user D7 is not running.

--- a/packages/cli/templates/tier-m/.claude/cheatsheet.md
+++ b/packages/cli/templates/tier-m/.claude/cheatsheet.md
@@ -48,6 +48,7 @@ Run these on demand. Each skill reads the codebase, produces a structured report
 | `/ux-audit` | Task completion paths, feedback clarity, cognitive load, error recovery | After adding user flows; before usability reviews |
 | `/ui-audit` | Design system token compliance, component adoption, empty/error/loading states | After UI changes; when design system is configured |
 | `/test-audit` | Coverage (lcov/Istanbul/Cobertura/go/tarpaulin/xcresult), pyramid shape, anti-patterns (`.only`, skipped, empty, no-assertion, sleeps) | After Phase 3 tests green; every block |
+| `/doc-audit` | Relative-link resolution, code-block syntax (json/yaml/toml), CDK placeholder residuals, slash-command name match, skill-count consistency, ADR freshness, stack-specific doc sync (Next.js / Django / Swift) | After doc changes; every block that touches README or `docs/` |
 | `/simplify` | Early returns, nesting depth, local duplication, dead code, magic values | After writing code (Phase 2); on demand |
 | `/dependency-scan` | Route hrefs, import consumers, shared type consumers, test refs, FK refs, access control | Phase 1 mandatory; before finalizing file list |
 | `/skill-review` | Skill quality audit: structural review, severity calibration, fix verification | After modifying skills; quarterly review cycle |

--- a/packages/cli/templates/tier-m/.claude/rules/pipeline.md
+++ b/packages/cli/templates/tier-m/.claude/rules/pipeline.md
@@ -190,9 +190,10 @@ If either condition is false: **skip this phase and state so explicitly** - do n
 - Run `/migration-audit` if the block applies migrations - static analysis of migration files.
 - Run `/skill-db` if the block changes the schema or adds new tables - live verification of schema state, access control policies, and query patterns.
 
-**Track C - Test suite audit** *(runs for every block after Phase 3 is green - static analysis, no dev server needed)*
+**Track C - Test + doc audit** *(runs for every block after Phase 3 is green - static analysis, no dev server needed)*
 - Run `/test-audit` - static analysis of coverage (auto-detects lcov / Istanbul / Cobertura / go / tarpaulin / xcresult), pyramid shape (unit/integration/e2e ratio), anti-patterns (`.only` leaks, skipped tests, empty bodies, no-assertion tests, hardcoded sleeps).
-- Output: one-paragraph summary. Critical findings (`.only` committed, 0% coverage on a file changed in this block) block Phase 6.
+- Run `/doc-audit` - static doc-drift check (relative-link resolution, code-block syntax, CDK placeholder residuals, slash-command name match, skill-count consistency, ADR freshness). Stack-aware for Next.js / Django / Swift.
+- Output: one-paragraph summary per skill. Critical findings (`.only` committed, 0% coverage on a file changed in this block, CDK placeholder in README, broken link to user-visible flow doc) block Phase 6.
 
 **Severity handling - all tracks**:
 - **Critical**: fix before Phase 6. Do not proceed with open Critical issues.

--- a/packages/cli/templates/tier-m/.claude/skills/doc-audit/PATTERNS.md
+++ b/packages/cli/templates/tier-m/.claude/skills/doc-audit/PATTERNS.md
@@ -1,0 +1,115 @@
+# Doc Audit - Patterns
+
+Reference file for `/doc-audit`. Contains the pinned CDK placeholder list (agnostic) and stack-specific grep patterns for D7 doc-sync checks.
+The executing agent reads this file at the start of Step 3. For D3, use the placeholder list verbatim. For D7, select the section matching the detected stack; if the detected stack is not in the top 3 (`node-ts`, `python`, `swift`), skip D7 entirely.
+
+---
+
+## D3 - CDK placeholder list (agnostic)
+
+The CDK scaffold emits these placeholder tokens. Readers are expected to replace each one with a concrete value. A token left in place after first-run configuration signals an incomplete adoption, not an intentional user convention.
+
+```
+[TEST_COMMAND]
+[FRAMEWORK_VALUE]
+[LANGUAGE_VALUE]
+[INSTALL_COMMAND]
+[DEV_COMMAND]
+[BUILD_COMMAND]
+[TYPE_CHECK_COMMAND]
+[E2E_COMMAND]
+[ENUM_CASE_CONVENTION]
+[MIGRATION_COMMAND]
+```
+
+**Extension rule**: this list is grepped against the CDK template tree (`packages/cli/templates/**`) - only tokens that are actually emitted by the scaffold belong here. When a new CDK release adds a placeholder to any scaffold template, append it to this list and bump the skill's internal version note in the next release. Generic `[UPPERCASE]` regex is deliberately avoided - it produces false positives on legitimate user conventions (`[API_KEY]`, `[YOUR_DOMAIN]`, `[FEATURE_FLAG]`).
+
+**Exclusion**: skip files under `packages/cli/templates/**` (the CDK template source itself - placeholders are intentional there). Apply this exclusion only when auditing the CDK repo itself; in user projects, the exclusion is a no-op.
+
+---
+
+## D7 - Stack-specific doc sync
+
+Best-effort hints, not hard validation. Atypical layouts (custom routing, monorepos, non-conventional directory naming) will produce false positives; default severity for D7 findings is **Medium** so they are discussable rather than blocking.
+
+### node-ts
+
+**Surface A - Next.js routes**
+
+Marker: `next.config.js`, `next.config.mjs`, `next.config.ts`, or `"next"` in `package.json` dependencies.
+
+Route discovery patterns:
+
+```
+app/**/page.{ts,tsx,js,jsx}        # App Router (Next.js 13+)
+pages/**/*.{ts,tsx,js,jsx}         # Pages Router (legacy)
+```
+
+Exclude: `app/api/**`, `pages/api/**`, `_app`, `_document`, `_error`, `layout.*`, `loading.*`, `error.*`, `not-found.*`, `[...catchall]` style dynamic segments.
+
+Compare the derived route list against:
+- `docs/sitemap.md` entries (grep for route paths `/<segment>`)
+- README "Tech Stack" or "Routes" sections
+
+Flag any route that does not appear in either doc source.
+
+**Surface B - Dependency mentions**
+
+For top-level dependencies in `package.json` (merge `dependencies` and `devDependencies`, exclude `@types/*`), check whether the dependency name appears at least once in README (case-insensitive). Limit to the top 15 by install size if the dep list is > 15. Absence is a Medium orphan.
+
+### python
+
+**Surface A - Django URLconf**
+
+Marker: `manage.py` + any `*/urls.py` OR `django` in `pyproject.toml` / `requirements.txt`.
+
+Route discovery pattern:
+
+```python
+path\([\'"]([^\'\"]+)[\'"]
+re_path\([\'"]([^\'\"]+)[\'"]
+```
+
+Extract the URL pattern (first regex capture). Exclude admin-prefixed routes (`admin/`, `^admin/`) and API-only prefixes declared under `api/v\d+/`.
+
+Compare extracted paths against `docs/sitemap.md` and README. Flag missing paths.
+
+**Surface B - Dependency mentions**
+
+From `pyproject.toml` `[project.dependencies]` or `[tool.poetry.dependencies]`, or top-level entries in `requirements.txt` (exclude version pins `==`, `>=`, `~=` - just the package name). Check whether the package name appears in README. Limit to top 15. Absence is a Medium orphan.
+
+### swift
+
+**Surface A - Package products and targets**
+
+Marker: `Package.swift` in repo root (Swift Package Manager).
+
+Patterns:
+
+```swift
+.library\(\s*name:\s*"([^"]+)"
+.executable\(\s*name:\s*"([^"]+)"
+.target\(\s*name:\s*"([^"]+)"
+```
+
+Exclude test targets: any name ending in `Tests` or explicitly declared via `.testTarget`.
+
+Compare the derived product and target list against README. Flag missing entries.
+
+**Surface B - DocC presence**
+
+If `Package.swift` declares at least one `.library(...)` product, check for the presence of a `Docs/`, `docs/`, or `Documentation/` directory. Absence is a Low hint (not Medium): Swift library packages conventionally ship DocC catalogs; absence is worth mentioning but not blocking.
+
+**Surface C - Xcode scheme mentions**
+
+If an `*.xcodeproj` or `*.xcworkspace` exists, the primary scheme name is usually the repo name. No automatic extraction in v1 (would require parsing the Xcode project file format). Deferred.
+
+---
+
+## Notes for future stacks
+
+When adding a new stack to D7 (`node-js`, `go`, `rust`, `kotlin`, `dotnet`, `ruby`, `java`):
+
+1. Add a new section here with Surface A (routes or modules), Surface B (dependencies), Surface C (if applicable).
+2. Update the Step 1 announcement in `SKILL.md` to include the stack in the top-3 list.
+3. Keep patterns conservative: the goal is to surface high-confidence orphans, not to flag every possible mismatch.

--- a/packages/cli/templates/tier-m/.claude/skills/doc-audit/SKILL.md
+++ b/packages/cli/templates/tier-m/.claude/skills/doc-audit/SKILL.md
@@ -1,0 +1,271 @@
+---
+name: doc-audit
+description: Static documentation drift audit - relative-link resolution, code-block syntax, CDK placeholder residuals, slash-command name match, skill-count consistency, ADR marker freshness, stack-specific doc sync (Next.js / Django / Swift).
+user-invocable: true
+model: sonnet
+context: fork
+argument-hint: [target:path:<dir>|target:file:<glob>|mode:all]
+allowed-tools: Read Glob Grep Bash
+---
+
+## Scope for v1
+
+- **Static analysis only.** Grep, file parsing, filesystem reads. Does not fetch URLs, does not run builds, does not execute code examples.
+- **No auto-fix.** Produces a markdown report; corrections are proposed but never applied.
+- **Live link check deferred.** HTTP/HTTPS targets are out of scope (flaky, rate-limited). Tracked as `DOC-live-links`.
+- **Semantic drift deferred.** Prose obsolescence, deprecation-age reasoning, and doc-bloat judgement are judgment-heavy and out of scope for v1.
+
+---
+
+## Configuration (adapt before first run)
+
+> Replace these placeholders:
+> - `[DOC_PATH]` - primary location of user-facing docs (e.g. `docs/`, `documentation/`, `website/`). Always included.
+> - `[README_PATH]` - repository README (usually `README.md` at project root).
+> - `[ADR_PATH]` - ADR directory if present (e.g. `docs/adr/`, `docs/decisions/`). Leave empty if none.
+
+---
+
+## Step 0 - Target resolution
+
+Parse `$ARGUMENTS` for a `target:` or `mode:` token.
+
+| Pattern | Meaning |
+|---|---|
+| `target:path:<dir>` | Audit docs under a specific directory only (e.g. `target:path:docs/api`) |
+| `target:file:<glob>` | Audit files matching the glob (e.g. `target:file:docs/**/*.md`) |
+| `mode:all` / no argument | **Full audit - README, CHANGELOG, every `.md` under `[DOC_PATH]`, and ADRs under `[ADR_PATH]` if set.** |
+
+**STRICT PARSING**: derive target ONLY from explicit text in `$ARGUMENTS`. Do NOT infer from conversation context, recent blocks, or memory.
+
+Announce: `Running doc-audit - scope: [FULL | target: <resolved>] - stack: <pending detection>`
+
+---
+
+## Step 1 - Stack detection
+
+Detect the primary stack in this priority order. First matching marker wins.
+
+| Stack | Marker file(s) |
+|---|---|
+| **node-ts** | `tsconfig.json` + `package.json` |
+| **node-js** | `package.json` (no `tsconfig.json`) |
+| **python** | `pyproject.toml` or `requirements.txt` or `setup.py` |
+| **go** | `go.mod` |
+| **rust** | `Cargo.toml` |
+| **swift** | `Package.swift` or `*.xcodeproj` / `*.xcworkspace` |
+| **kotlin** | `build.gradle.kts` or `build.gradle` with `kotlin(` plugin |
+| **dotnet** | `*.csproj` or `*.sln` |
+| **ruby** | `Gemfile` |
+| **java** | `pom.xml` or `build.gradle` (no Kotlin plugin) |
+| **generic** | None of the above |
+
+**Stack-specific depth** (D7 only): patterns are loaded from `PATTERNS.md` for `node-ts`, `python`, and `swift`. For every other stack, announce `Stack <name> detected - D7 stack-specific doc sync skipped; running D1-D6 universal checks.` and continue.
+
+Update announcement: `Running doc-audit - scope: [...] - stack: <detected>`
+
+---
+
+## Step 2 - Doc file discovery
+
+Collect the audit scope by this priority:
+
+1. Explicit target from Step 0 (`target:path` / `target:file`) wins and skips the rest.
+2. `[README_PATH]` if set (defaults to `README.md`).
+3. `CHANGELOG.md` at repo root if present.
+4. Every `*.md` and `*.mdx` under `[DOC_PATH]` (default `docs/`), excluding `node_modules/`, `dist/`, `build/`, `.next/`, `target/`, `vendor/`, and any path matched by `.gitignore`.
+5. Every `*.md` under `[ADR_PATH]` if set.
+
+Announce: `Discovered N documentation files. Auditing: <scope>`
+
+If `N == 0` and no target was passed: output `No documentation files found. Set [DOC_PATH] in Configuration or pass target:file:<glob>.` and exit.
+
+---
+
+## Step 3 - D1-D7 static checks
+
+Run each check below against the files from Step 2. Record findings with SEVERITY / ID / FILE:LINE / EVIDENCE / IMPACT / FIX.
+
+### D1 - Relative-link resolution
+
+**Critical if a link points to a file that governs user-visible flow (`CONTRIBUTING.md`, `SECURITY.md`, a referenced guide); High otherwise.** Broken relative links misdirect readers.
+
+Grep each doc for markdown link targets that do not start with `http://`, `https://`, `mailto:`, `#`, or `<`: pattern `\]\(([./][^)#]+)(?:#[^)]*)?\)`. For each match, resolve the target relative to the file's directory and check `fs.existsSync`. Skip targets that are image placeholders (`![...](...)`) only if they match `\.(png|jpg|jpeg|gif|svg|webp)$` **and** the file exists in a common asset directory - otherwise flag as D1.
+
+Report: each broken link with `FILE:LINE - [link text] -> <target> (not found)`.
+
+### D2 - Code-block syntax validity
+
+**High per unparseable block.** Broken code blocks copied into terminals or configs fail silently until a user hits them.
+
+Scan for fenced code blocks with a known declarative language tag: ` ```json `, ` ```yaml `, ` ```yml `, ` ```toml `. Extract the body. Parse with a stack-appropriate tool:
+
+- `json`: `node -e "JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'))"` via `Bash`, or reject on first syntax error.
+- `yaml` / `yml`: `python3 -c "import sys,yaml; yaml.safe_load(sys.stdin)"` if `python3` and `pyyaml` are on PATH; else skip with `N/A - yaml parser unavailable`.
+- `toml`: `python3 -c "import sys,tomllib; tomllib.loads(sys.stdin.read())"` on Python 3.11+; else skip with `N/A - toml parser unavailable`.
+
+Skip `bash`, `sh`, `shell`, `text`, `console`, `diff`, and any unlabelled fence. Skip blocks that contain an obvious template marker (`<...>`, `[PLACEHOLDER]`, `{{...}}`) - those are illustrative, not meant to parse.
+
+Report: each failing block with `FILE:LINE - lang=<tag> - <parser error excerpt>`.
+
+### D3 - CDK placeholder residuals
+
+**High per occurrence in user-facing docs; Critical if found in `README.md`.** Placeholders shipped unfilled indicate an incomplete scaffold adoption.
+
+The CDK scaffold emits a **fixed set** of `[UPPERCASE]` tokens that the user is expected to resolve. Generic `[UPPERCASE]` regex would produce false positives on legitimate user conventions (`[API_KEY]`, `[YOUR_DOMAIN]`, `[FEATURE_FLAG_NAME]`). Use the pinned list from `PATTERNS.md` (agnostic section, `D3 CDK placeholder list`):
+
+```
+[TEST_COMMAND] [FRAMEWORK_VALUE] [LANGUAGE_VALUE] [INSTALL_COMMAND]
+[DEV_COMMAND] [BUILD_COMMAND] [TYPE_CHECK_COMMAND] [E2E_COMMAND]
+[ENUM_CASE_CONVENTION] [MIGRATION_COMMAND]
+```
+
+Grep each doc for any exact token from the list. Exclude files under `packages/cli/templates/**` (the CDK template source itself - placeholders are intentional there).
+
+Report: each match with `FILE:LINE - <token> - replace with concrete value`.
+
+### D4 - Slash-command name match
+
+**Medium per orphan reference.** Readers click / copy a skill name that does not exist in `.claude/skills/`.
+
+Grep every doc for `/[a-z][a-z0-9-]+` occurrences inside prose (filter: must be preceded by whitespace or start-of-line and followed by a word boundary; ignore URL paths by excluding matches inside a `(...)` link target). For each unique command name, verify `.claude/skills/<name>/` exists. Allowlist CDK CLI verbs that are not skills: `init`, `upgrade`, `doctor`, `add`, `new` (these live in `packages/cli/src/commands/`, not in `.claude/skills/`).
+
+Report: each orphan with `FILE:LINE - /<name> - no matching skill directory`.
+
+### D5 - Skill-count consistency
+
+**Medium if mismatch ≤ 2; High if > 2.** A stale count signals an unmaintained README.
+
+Grep README and `[DOC_PATH]` for numeric skill claims: `\b(\d+)\s+(audit\s+)?skills?\b`. For each match, cross-verify against the filesystem:
+
+```bash
+ls .claude/skills/ | grep -v '^custom-' | wc -l
+```
+
+If the claimed count does not match the actual directory count, flag the mismatch. Note: this check intentionally scopes to **skill count only** - doctor/test counts are source-specific to the CDK codebase and are not in scope for user-project audits.
+
+Report: `FILE:LINE - claim "<N> skills" - actual <M> in .claude/skills/`.
+
+### D6 - ADR marker freshness
+
+**Low per stale file.** Only runs if `[ADR_PATH]` is set and the directory exists.
+
+For each `*.md` under `[ADR_PATH]`:
+
+- Parse YAML frontmatter for a `date:` or `updated:` field.
+- If the parsed date is older than 180 days AND the frontmatter `status:` field is not one of `accepted`, `deprecated`, `superseded`, `rejected`: flag as stale.
+
+Skip files without a frontmatter date field (freshness cannot be determined).
+
+Report: each stale file with `FILE - date: <YYYY-MM-DD> - status: <value | missing>`.
+
+### D7 - Stack-specific doc sync
+
+**Medium per orphan surface.** Only runs for `node-ts`, `python`, `swift` (see Step 1). Load `PATTERNS.md` → D7 section for the detected stack.
+
+The patterns cover:
+
+- **node-ts**: Next.js `app/` or `pages/` routes vs. mentions in `docs/sitemap.md` (if present) or README Tech Stack; `package.json` dependencies vs. README Tech Stack mentions.
+- **python**: Django `urls.py` paths vs. mentions in `docs/sitemap.md` or README; `pyproject.toml` / `requirements.txt` top-level deps vs. README mentions.
+- **swift**: `Package.swift` products / targets vs. README mentions; `Docs/` (DocC) presence if `Package.swift` declares `.target(...)` targets.
+
+Stack patterns are **best-effort hints**, not hard validation. Atypical project layouts (custom routing, monorepos) may produce false positives; default severity is Medium so findings are discussable, not blocking.
+
+Report: each orphan with `FILE:LINE - <surface> - not mentioned in docs/README`.
+
+---
+
+## Step 4 - Report
+
+```
+## Doc Audit - [DATE] - [SCOPE] - stack: [DETECTED]
+
+### Executive summary
+[2-5 bullets. Critical + High findings only. Concrete facts: file names, line numbers, counts.
+If nothing Critical/High: state that explicitly ("No Critical or High findings - docs are consistent with the code").]
+
+### Documentation maturity assessment
+| Dimension | Rating | Notes |
+|---|---|---|
+| Link hygiene | strong / adequate / weak | [D1 broken link count] |
+| Code-block validity | strong / adequate / weak | [D2 unparseable blocks] |
+| Placeholder discipline | strong / adequate / weak | [D3 CDK tokens remaining] |
+| Skill coherence | strong / adequate / weak | [D4 orphans + D5 count mismatch] |
+| ADR freshness | strong / adequate / weak | [D6 stale count; N/A if ADR_PATH unset] |
+| Stack sync | strong / adequate / weak | [D7 orphans; N/A for non-top-3 stacks] |
+| Release readiness | ready / conditional / blocked | [blocked = any Critical; conditional = High findings exist] |
+
+### Check verdicts
+| # | Check | Verdict | Findings |
+|---|---|---|---|
+| D1 | Relative-link resolution | ✅/⚠️ | [N broken] |
+| D2 | Code-block syntax | ✅/⚠️ | [N unparseable] |
+| D3 | CDK placeholder residuals | ✅/⚠️ | [N occurrences] |
+| D4 | Slash-command name match | ✅/⚠️ | [N orphans] |
+| D5 | Skill-count consistency | ✅/⚠️ | [mismatch or OK] |
+| D6 | ADR marker freshness | ✅/⚠️ / N/A | [N stale; N/A if no ADR_PATH] |
+| D7 | Stack-specific doc sync | ✅/⚠️ / N/A | [N orphans; N/A for non-top-3] |
+
+### Prioritized findings
+For each finding with severity Medium or above:
+[SEVERITY] [ID] [check] - [file:line] - [evidence excerpt] - [impact] - [fix] - [effort: S=<1h / M=half day / L=day+]
+
+### Quick wins
+[Findings that meet all three: (a) Medium or High, (b) effort S, (c) single-file fix]
+Format: "DOC-[n]: [one-line description]"
+If no quick wins: state explicitly.
+```
+
+---
+
+## Step 5 - Backlog decision gate
+
+Present all findings with severity Medium or above as a numbered decision list, sorted Critical → High → Medium:
+
+```
+Found N findings at Medium or above. Which to add to backlog?
+
+[1] [CRITICAL] DOC-? - file:line - one-line description
+[2] [HIGH]     DOC-? - file:line - one-line description
+[3] [MEDIUM]   DOC-? - file:line - one-line description
+...
+
+Reply with numbers to include (e.g. "1 2 4"), "all", or "none".
+```
+
+**Wait for explicit user response before writing anything.**
+
+Then write ONLY the approved entries to `docs/refactoring-backlog.md`:
+- Assign ID: `DOC-[n]` (next available after existing DOC entries)
+- Add row to priority index
+- Add full detail section with: issue, evidence (file:line + excerpt), fix suggestion, effort, risk
+
+### Severity guide
+
+- **Critical**: broken link to a user-visible flow doc (CONTRIBUTING, SECURITY, linked guide) (D1); CDK placeholder in `README.md` (D3)
+- **High**: unparseable `json` / `yaml` / `toml` code block (D2); CDK placeholder in any other user-facing doc (D3); skill-count mismatch > 2 (D5)
+- **Medium**: orphan `/skill-name` reference (D4); skill-count mismatch ≤ 2 (D5); stack-specific orphan surface (D7); broken link to non-critical asset (D1)
+- **Low**: stale ADR without terminal status (D6)
+
+---
+
+## Execution notes
+
+- Do NOT modify any doc file. Audit only.
+- Do NOT fetch URLs. HTTP / HTTPS link resolution is out of scope for v1.
+- `target:path:<dir>` and `target:file:<glob>` bypass the default scope from Step 2.
+- If git history is available, cross-reference D3 Critical findings against `git diff HEAD~1` - a placeholder on a file modified in the current block is more actionable than one left over from a prior release.
+- This skill complements `/arch-audit` (governance-file compliance) and `/test-audit` (suite quality). Run in Phase 5d Track C after Phase 3 passes - drift flagged when the modification is fresh in memory beats drift caught by a new contributor six weeks later.
+- After the report, ask: "Do you want me to prepare the corrections for the identified findings?" Reply with `yes` only after the user has signed off on the specific findings.
+
+---
+
+## Stack adaptation
+
+D1-D6 run on every stack. D7 is stack-specific and loads patterns from `${CLAUDE_SKILL_DIR}/PATTERNS.md`:
+
+- **node-ts**: Next.js route layout (`app/`, `pages/`) cross-referenced against `docs/sitemap.md` and README Tech Stack; `package.json` dependencies cross-referenced against README.
+- **python**: Django `urls.py` paths cross-referenced against `docs/sitemap.md` and README; `pyproject.toml` / `requirements.txt` top-level deps cross-referenced against README.
+- **swift**: `Package.swift` products and targets cross-referenced against README; DocC (`Docs/`) presence check for projects that declare library targets.
+
+For `node-js`, `go`, `rust`, `kotlin`, `dotnet`, `ruby`, `java`, and `generic`: D7 is skipped. Patterns for these stacks can be added in a future release; the Step 1 announcement already tells the user D7 is not running.

--- a/packages/cli/test/integration/run.js
+++ b/packages/cli/test/integration/run.js
@@ -213,6 +213,11 @@ function assertNoUnfilledWizardPlaceholders(dir) {
     // for Claude to fill in pipeline.md - not actual unfilled wizard placeholders
     if (path.basename(f) === 'CONTEXT_IMPORT.md') continue;
 
+    // doc-audit's SKILL.md and PATTERNS.md enumerate the CDK placeholder tokens
+    // verbatim as part of the audit specification (D3 check). Not unfilled.
+    const rel = path.relative(dir, f);
+    if (rel.includes(path.join('skills', 'doc-audit'))) continue;
+
     const ext = path.extname(f);
     if (!['.md', '.json', '.yaml', '.yml', ''].includes(ext)) continue;
     const content = fs.readFileSync(f, 'utf8');
@@ -1254,12 +1259,14 @@ async function scenarioPlaceholderNoiseReduction() {
     }
   }
 
-  // Verify CLAUDE.md line count reduced (raw template ~92 lines with injections, stripped should be < 80)
+  // Verify CLAUDE.md line count reduced (raw template ~92 lines with injections, stripped should be < 85).
+  // The threshold scales linearly with the Active Skills list (one line per skill); raise it as new skills
+  // are added to the registry so this guard catches regressions, not growth.
   const lineCountM = claudeM.split('\n').length;
-  if (lineCountM < 80) {
+  if (lineCountM < 85) {
     pass(`Tier M: CLAUDE.md line count reduced (${lineCountM} lines)`);
   } else {
-    fail(`Tier M: CLAUDE.md still ${lineCountM} lines - expected < 80 after stripping`);
+    fail(`Tier M: CLAUDE.md still ${lineCountM} lines - expected < 85 after stripping`);
   }
 
   // Tier S - Known Patterns stripped (only section applicable)
@@ -2622,6 +2629,91 @@ async function scenarioDoctorCrossFileValidation() {
   }
 }
 
+async function scenarioDocAuditPresent() {
+  section('doc-audit skill presence + tier pruning (v1.13.0)');
+
+  for (const tier of ['s', 'm', 'l']) {
+    const config = { ...BASE, tier, isDiscovery: false };
+    const dir = await scaffold(`doc-audit-tier-${tier}`, tier, config);
+    const skillDir = path.join(dir, '.claude/skills/doc-audit');
+    const shouldExist = tier === 'm' || tier === 'l';
+
+    if (shouldExist) {
+      if (fs.existsSync(path.join(skillDir, 'SKILL.md'))) {
+        pass(`Tier ${tier}: doc-audit/SKILL.md scaffolded`);
+      } else {
+        fail(`Tier ${tier}: doc-audit/SKILL.md missing`);
+      }
+      if (fs.existsSync(path.join(skillDir, 'PATTERNS.md'))) {
+        pass(`Tier ${tier}: doc-audit/PATTERNS.md scaffolded`);
+      } else {
+        fail(`Tier ${tier}: doc-audit/PATTERNS.md missing`);
+      }
+
+      const cheatsheetPath = path.join(dir, '.claude/cheatsheet.md');
+      if (fs.existsSync(cheatsheetPath)) {
+        const cheatsheet = fs.readFileSync(cheatsheetPath, 'utf8');
+        if (/`\/doc-audit`/.test(cheatsheet)) {
+          pass(`Tier ${tier}: cheatsheet row for /doc-audit present`);
+        } else {
+          fail(`Tier ${tier}: cheatsheet row for /doc-audit missing`);
+        }
+      } else {
+        fail(`Tier ${tier}: .claude/cheatsheet.md missing`);
+      }
+
+      const pipelinePath = path.join(dir, '.claude/rules/pipeline.md');
+      if (fs.existsSync(pipelinePath)) {
+        const pipeline = fs.readFileSync(pipelinePath, 'utf8');
+        if (/\/doc-audit/.test(pipeline)) {
+          pass(`Tier ${tier}: pipeline.md Track C references /doc-audit`);
+        } else {
+          fail(`Tier ${tier}: pipeline.md Track C missing /doc-audit invocation`);
+        }
+        if (/Track C - Test \+ doc audit/.test(pipeline)) {
+          pass(`Tier ${tier}: pipeline.md Track C renamed to "Test + doc audit"`);
+        } else {
+          fail(`Tier ${tier}: pipeline.md Track C header not renamed`);
+        }
+      } else {
+        fail(`Tier ${tier}: .claude/rules/pipeline.md missing`);
+      }
+
+      const skillMd = fs.readFileSync(path.join(skillDir, 'SKILL.md'), 'utf8');
+      const parsed = parseSkillFile(skillMd);
+      if (parsed.fields.allowedTools && !allowedToolsHasCommas(parsed.fields.allowedTools)) {
+        pass(`Tier ${tier}: doc-audit allowed-tools is space-separated`);
+      } else {
+        fail(`Tier ${tier}: doc-audit allowed-tools uses commas or missing`);
+      }
+      const bodyLines = countBodyLines(parsed.body);
+      if (bodyLines <= SKILL_MD_MAX_LINES) {
+        pass(`Tier ${tier}: doc-audit body ${bodyLines} lines (<= ${SKILL_MD_MAX_LINES})`);
+      } else {
+        fail(
+          `Tier ${tier}: doc-audit body ${bodyLines} lines exceeds ${SKILL_MD_MAX_LINES} budget`,
+        );
+      }
+    } else {
+      if (!fs.existsSync(skillDir)) {
+        pass(`Tier ${tier}: doc-audit pruned (not installed on tier S)`);
+      } else {
+        fail(`Tier ${tier}: doc-audit present but should be pruned`);
+      }
+
+      const cheatsheetPath = path.join(dir, '.claude/cheatsheet.md');
+      if (fs.existsSync(cheatsheetPath)) {
+        const cheatsheet = fs.readFileSync(cheatsheetPath, 'utf8');
+        if (!/\/doc-audit/.test(cheatsheet)) {
+          pass(`Tier ${tier}: cheatsheet row for /doc-audit pruned`);
+        } else {
+          fail(`Tier ${tier}: cheatsheet still references /doc-audit`);
+        }
+      }
+    }
+  }
+}
+
 // ── Main ─────────────────────────────────────────────────────────────────────
 
 async function main() {
@@ -2667,6 +2759,7 @@ async function main() {
   await scenarioCrossStackInvariants();
   await scenarioSkillMdSpecCompliance();
   await scenarioDoctorCrossFileValidation();
+  await scenarioDocAuditPresent();
 
   // ── Summary ────────────────────────────────────────────────────────────────
 

--- a/packages/cli/test/unit/add.test.js
+++ b/packages/cli/test/unit/add.test.js
@@ -76,7 +76,7 @@ describe('add skill', () => {
     await fs.remove(noClaudeDir);
   });
 
-  it('installs all 12 registry skills', async () => {
+  it('installs every universal Tier S registry skill', async () => {
     const skills = [
       'arch-audit',
       'commit',

--- a/packages/cli/test/unit/skill-registry.test.js
+++ b/packages/cli/test/unit/skill-registry.test.js
@@ -23,8 +23,8 @@ describe('NATIVE_STACKS', () => {
 // ---------------------------------------------------------------------------
 
 describe('SKILL_REGISTRY', () => {
-  it('has 18 entries', () => {
-    assert.equal(SKILL_REGISTRY.length, 18);
+  it('has 19 entries', () => {
+    assert.equal(SKILL_REGISTRY.length, 19);
   });
 
   it('every entry has required fields', () => {


### PR DESCRIPTION
## v1.13.0 — /doc-audit skill (Issue #61)

Closes #61 (ICE 320). Third Q2 item, and the rank #4 skill from the 3-model consensus. This closes the Q1 skill-expansion spillover.

## What ships

`/doc-audit` is a static documentation-drift audit that runs in Phase 5d Track C next to `/test-audit`. Seven checks, all filesystem-only: no URL fetches, no builds, no code execution.

- **D1 Relative-link resolution**: markdown links to local files must resolve on disk. `http(s)://`, `mailto:`, and anchor-only links excluded.
- **D2 Code-block syntax**: `json`, `yaml`, `toml` fenced blocks are parsed with a stack-appropriate tool. Blocks with template markers (`<...>`, `{{...}}`, `[PLACEHOLDER]`) are skipped so illustrative examples don't flake.
- **D3 CDK placeholder residuals**: a pinned list of the ten scaffold tokens (`[TEST_COMMAND]`, `[FRAMEWORK_VALUE]`, `[LANGUAGE_VALUE]`, `[INSTALL_COMMAND]`, `[DEV_COMMAND]`, `[BUILD_COMMAND]`, `[TYPE_CHECK_COMMAND]`, `[E2E_COMMAND]`, `[ENUM_CASE_CONVENTION]`, `[MIGRATION_COMMAND]`). Every entry was verified against `packages/cli/templates/**`. The plan originally listed eleven, but `[AUDIT_MODEL]` has no emitting `.replace()` in the scaffold and was dropped as dead weight. Generic `[UPPERCASE]` regex is deliberately avoided to prevent false positives on legitimate user conventions (`[API_KEY]`, `[YOUR_DOMAIN]`).
- **D4 Slash-command name match**: every `/skill-name` mention cross-verified against `.claude/skills/`. CDK CLI verbs (`init`, `upgrade`, `doctor`, `add`, `new`) allowlisted.
- **D5 Skill-count consistency**: numeric claims like "16 skills" cross-verified against `ls .claude/skills/ | grep -v '^custom-' | wc -l`. Scope intentionally narrow, since doctor / test counts are source-specific to CDK and not in scope for user-project audits.
- **D6 ADR marker freshness**: frontmatter dates older than 180 days without a terminal `status:` flagged.
- **D7 Stack-specific doc sync**: top-3 stacks only (`node-ts`, `python`, `swift`). Patterns live in a sibling `PATTERNS.md`: Next.js `app/`/`pages/` routes, Django URLconf paths, Swift `Package.swift` products/targets, each cross-referenced against README + `docs/sitemap.md`. Severity intentionally Medium, since these are best-effort hints, not hard validation, and atypical project layouts will produce false positives.

## Test plan

- [x] `npm run lint`: clean
- [x] `npm test` (integration): 895/895 (+31 from `scenarioDocAuditPresent`: SKILL.md/PATTERNS.md presence, tier pruning, cheatsheet row, pipeline.md Track C invocation, allowed-tools syntax, body size budget)
- [x] `npm run test:unit`: 332/332 (skill-registry.test.js entry count 18 → 19)
- [x] SKILL.md body = 271 lines (well inside the 500-line guardrail from v1.11.0)
- [x] Tier M and Tier L `doc-audit/SKILL.md` + `PATTERNS.md` byte-identical (pattern coherent with test-audit)

## Scope boundaries

Deferred to v1.14+ or later: live HTTP link check (flakiness + rate limits), semantic drift reasoning (ADR obsolescence, doc bloat), D7 stack adaptation for the 7 non-top-3 stacks, JSON `--report` mode (no other audit skill has one), auto-fix (skill produces findings, never modifies).

## Ancillary touches

- `WIZARD_PLACEHOLDERS` integration check exempts `.claude/skills/doc-audit/*`, since the skill enumerates CDK tokens verbatim as part of the audit specification.
- `scenarioPlaceholderNoiseReduction` CLAUDE.md line-count regression guard: loosened `< 80` → `< 85` to absorb the extra Active Skills row. Still catches stripping regressions vs the ~92-line raw template.
- `add.test.js` test title desugared from stale "12 registry skills" to "every universal Tier S registry skill" (pre-existing drift, fixed now to avoid shipping an inconsistent pair with `skill-registry.test.js`).
- `pipeline.md` Track C in both Tier M and Tier L renamed "Test suite audit" → "Test + doc audit" to reflect the pairing.

## Commits

- `feat(scaffold)`: add /doc-audit skill (Tier M/L), templates + registry + cheatsheet + pipeline.md
- `test(cli)`: scenarioDocAuditPresent + registry count sync
- `chore(release)`: v1.13.0, /doc-audit skill (Issue #61)

Closes #61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)