### PR TITLE
feat: v1.15.0 — upgrade --anthropic + doctor anthropic-files-current (#93)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,32 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [1.15.0] — 2026-04-25
+
+### Added
+
+- **`upgrade --anthropic` flag** (Q3 #2, Issue #93, ICE 210): refreshes files that encode Anthropic spec / best practices, separately from the standard `upgrade` flow. Default behavior is dry-run with a colourized unified diff (via the `diff` npm package) so the contributor reviews the change before committing it. `--apply` writes the new content with a timestamped backup file (`<original>.bak.<ISO-timestamp>`) for the previous version. Combinable with the standard upgrade in a single invocation.
+- **`ANTHROPIC_FILES` registry** in `packages/cli/src/commands/upgrade.js`: a list of templates that are 1:1 copied to a scaffold (no placeholder interpolation, no flag-based section stripping) and therefore safe to compare raw. v1.15.0 scope is one file: `.claude/skills/arch-audit/advanced-checks.md`. Files that pass through the scaffold transformation pipeline (`pipeline-standards.md`, `claudemd-standards.md`, `arch-audit/SKILL.md`) stay in `REVIEW_REQUIRED` until a transformation-aware compare is implemented in a future release.
+- **Helper exports** from `upgrade.js`: `backupPath(originalPath, now)` and `detectScaffoldedTier(cwd)`. Used by both the upgrade command and the new doctor check.
+- **Doctor check `anthropic-files-current`**: warns when any of the `ANTHROPIC_FILES` differs from the installed CDK template. Doctor check count: 26 → 27.
+- **Integration scenario `scenarioUpgradeAnthropic`** in `test/integration/run.js`: scaffolds tier-m and tier-s projects, exercises the dry-run / `--apply` / `.bak` / no-tier-detected paths, and cross-checks the doctor `anthropic-files-current` status before and after refresh. ~11 new integration assertions.
+- **Unit tests** in `test/unit/upgrade-anthropic.test.js`: 11 cases for `ANTHROPIC_FILES` registry shape, `backupPath` ISO timestamp formatting, and `detectScaffoldedTier` against tier S / M / L / unrecognized H1 / missing pipeline.md.
+
 ### Changed
+
+- New dependency `diff` (^9.0.0) added to `packages/cli/package.json`. Unified-diff generation is cross-platform (no shell-out to system `diff`).
+- Integration test count: 979 → 990 (+11 from `scenarioUpgradeAnthropic`).
+- Unit test count: 332 → 343 (+11 from `upgrade-anthropic.test.js`).
+
+### Notes
+
+- The v1.15.0 `--anthropic` scope is intentionally narrow. It establishes the contract — flag, dry-run, backup, doctor wiring — on a single file that the scaffold copies 1:1 from the template. Expanding the registry to files that go through `interpolate()` or section stripping requires a transformation-aware compare (likely re-running the scaffold pipeline against the user's current config), tracked for v1.16+.
+
+### Documentation
+
+Rolled in from PR #114 (originally merged docs-only without version bump):
 
 - **CONTRIBUTING.md overhaul** (Q2 #6, ICE 256): full restructure to 11 sections aligned to v1.14.0 state. Closes the "Partial" status from PR #46 (2026-04-02).
   - Refreshed test counts (979 integration, 332 unit) and removed the stale "(currently 19)" doctor-check reference.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Node.js >= 22](https://img.shields.io/badge/node-%3E%3D22-brightgreen.svg)](https://nodejs.org)
 [![CI](https://github.com/marcoguillermaz/claude-dev-kit/actions/workflows/ci.yml/badge.svg)](https://github.com/marcoguillermaz/claude-dev-kit/actions/workflows/ci.yml)
-[![979 integration checks](https://img.shields.io/badge/integration-979%20checks-blue.svg)](#testing)
+[![990 integration checks](https://img.shields.io/badge/integration-990%20checks-blue.svg)](#testing)
 
 > Scaffold for legible, reviewable AI-assisted development.
 > Claude generates. Your team decides.
@@ -122,11 +122,13 @@ The Stop hook in `settings.json` is the core enforcement mechanism. It blocks Cl
 npx mg-claude-dev-kit init                    # scaffold wizard
 npx mg-claude-dev-kit init --dry-run          # preview without writing
 npx mg-claude-dev-kit init --answers file.json  # skip prompts (CI/automation)
-npx mg-claude-dev-kit doctor                  # validate setup (26 checks)
+npx mg-claude-dev-kit doctor                  # validate setup (27 checks)
 npx mg-claude-dev-kit doctor --report         # JSON output for CI
 npx mg-claude-dev-kit doctor --ci             # silent, exit 1 on failure
 npx mg-claude-dev-kit upgrade                 # update template files
 npx mg-claude-dev-kit upgrade --tier=m        # promote to higher tier
+npx mg-claude-dev-kit upgrade --anthropic     # show diff for Anthropic-influenced files (dry-run)
+npx mg-claude-dev-kit upgrade --anthropic --apply  # write the diff (with .bak backup)
 npx mg-claude-dev-kit add skill <name>        # install one skill
 npx mg-claude-dev-kit add rule <name>         # install one rule
 npx mg-claude-dev-kit new skill               # create a custom skill (wizard)
@@ -159,8 +161,8 @@ npx mg-claude-dev-kit new skill               # create a custom skill (wizard)
 ## Testing
 
 ```bash
-node packages/cli/test/integration/run.js    # 979 integration checks
-node --test packages/cli/test/unit/*.test.js   # 332 unit tests
+node packages/cli/test/integration/run.js    # 990 integration checks
+node --test packages/cli/test/unit/*.test.js   # 343 unit tests
 ```
 
 Covers: file structure per tier, Stop hook presence, pipeline gate counts, placeholder resolution, skill pruning, security variant selection, native stack adaptation, rubric scoring, cross-stack content invariants (10 stacks), golden-file assertions (Swift, Node-TS, Python), full CLI execution via `--answers` fixtures.
@@ -190,9 +192,9 @@ Covers: file structure per tier, Stop hook presence, pipeline gate counts, place
 
 See [GitHub Milestones](https://github.com/marcoguillermaz/claude-dev-kit/milestones) for the 12-month plan.
 
-**Current**: v1.14.0 ships the Q2 #7 bundle (Issue #66, ICE 245): three new skills, portfolio from 17 to 20. `/api-contract-audit` parses OpenAPI specs against runtime code and flags drift before clients notice (endpoints present in spec without handler, schema field mismatches, status-code divergence, breaking changes vs the previous committed spec via `git show HEAD~1`, security-scheme alignment, Richardson Maturity grading L0 to L3). Auto-gen coverage spans FastAPI, NestJS, Express with swagger-jsdoc, Next.js 13+ route handlers, and Django REST Framework. `/infra-audit` checks five layers, but only when markers exist (no N/A noise): GitHub Actions for pwn-request and secret-logging patterns, Dockerfile for root user and unpinned images, Kubernetes manifests for privileged containers and host-namespace breakouts, Terraform for IAM wildcards and state files committed to git, GitLab CI for equivalent script-injection vectors. The infra surface is stack-agnostic: it sits apart from backend language. `/compliance-audit` ships with the GDPR profile active: data-subject rights (delete, export, rectify), consent capture and lawful basis, PII identification with special-category encryption check (Article 9), logging hygiene, retention policy, sub-processor transparency. SOC 2 and HIPAA sit scaffolded in `PROFILES.md` as future markers, with their check taxonomies and backlog prefixes reserved, waiting on real enterprise validation before going live in v1.15+. `/api-contract-audit` attaches to Phase 5d Track B; `/compliance-audit` sits alongside it; `/infra-audit` joins Track C (renamed "Test + doc + infra audit"). Integration: 979 checks (+84 across three scenario suites); unit: 332 tests.
+**Current**: v1.15.0 ships the `upgrade --anthropic` flag (Q3 #2, Issue #93, ICE 210). The standard `upgrade` already refreshes 8 template files; `--anthropic` adds a separate flow for the files that encode Anthropic spec and best practices. Default is dry-run with a colourized unified diff (powered by the `diff` npm package); `--apply` writes the change with a timestamped `.bak` backup of the previous content. The two flows compose: `upgrade --anthropic --apply` runs both back to back. v1.15.0 scope is deliberately narrow, one file: `.claude/skills/arch-audit/advanced-checks.md`. The other Anthropic-touching files (`pipeline-standards.md`, `claudemd-standards.md`, `arch-audit/SKILL.md`) pass through the scaffold's placeholder substitution or section-stripping pipeline, so a raw template-vs-scaffold compare produces false positives on a clean install. Expanding the registry needs a transformation-aware compare, tracked for v1.16+. A new doctor check `anthropic-files-current` warns when the file drifts from the installed CDK template; doctor count goes from 26 to 27. Integration: 990 checks (+11 from `scenarioUpgradeAnthropic`); unit: 343 tests (+11 from `upgrade-anthropic.test.js`).
 
-**Next**: Q2 #6 CONTRIBUTING.md overhaul (ICE 256, currently Partial) or Q2 #8 external review prompt template update (ICE 162). Q2 #3 VitePress docs site (ICE 432) stays deferred.
+**Next**: Q3 #3 `team-settings.json` org-wide skill and model restrictions (Issue #94, ICE 175) or Q2 #8 external review prompt template update (ICE 162). Q2 #3 VitePress docs site (ICE 432) stays deferred.
 
 ---
 

--- a/docs/operational-guide.md
+++ b/docs/operational-guide.md
@@ -1166,10 +1166,14 @@ Imperative mood, under 72 characters. Scope is optional but encouraged.
 
 ```bash
 npx mg-claude-dev-kit upgrade
-npx mg-claude-dev-kit upgrade --tier=m    # promote to higher tier
+npx mg-claude-dev-kit upgrade --tier=m            # promote to higher tier
+npx mg-claude-dev-kit upgrade --anthropic         # show diff for Anthropic-influenced files (dry-run)
+npx mg-claude-dev-kit upgrade --anthropic --apply # write the diff with .bak backup
 ```
 
 Non-destructive files are updated to the latest template version (rules, context-review, files-guide, PR template). Files containing your customizations (`CLAUDE.md`, `pipeline.md`, `settings.json`, `SKILL.md` files) are flagged for manual review.
+
+**`--anthropic` flag** (added in v1.15.0): runs a separate refresh flow targeted at files that encode Anthropic spec / best practices. Default behavior is dry-run — prints a colourized unified diff for each file that differs from the installed template. `--apply` writes the new content with a timestamped backup (`<original>.bak.<ISO-timestamp>`) of the previous version. v1.15.0 scope is one file: `.claude/skills/arch-audit/advanced-checks.md`. Other Anthropic-touching files (`pipeline-standards.md`, `claudemd-standards.md`, `arch-audit/SKILL.md`) pass through the scaffold's placeholder substitution or section-stripping pipeline; expanding the registry needs a transformation-aware compare, tracked for v1.16+.
 
 **Custom skills are preserved** - any directory matching `.claude/skills/custom-*/` is never touched during upgrade. The CLI reports which custom skills were found and confirms they are unchanged.
 
@@ -1183,7 +1187,7 @@ npx mg-claude-dev-kit doctor --report  # JSON compliance output for CI pipelines
 npx mg-claude-dev-kit doctor --ci      # silent mode: exit 1 if any check fails
 ```
 
-Runs 26 checks:
+Runs 27 checks:
 
 1. Claude Code CLI is installed and reachable
 2. `CLAUDE.md` is present
@@ -1210,9 +1214,10 @@ Runs 26 checks:
 23. `security.md` variant matches the detected stack (warn on drift)
 24. `.claude/rules/context-review.md` includes C12 (warn if not present - upgrade needed)
 25. Stop hook has `timeout` configured and ≤ 600s (warn if missing - prevents hanging test commands)
-26. No duplicate entries in `permissions.deny` list (warn if duplicates found)
+26. Anthropic-influenced files match the installed CDK template — `arch-audit/advanced-checks.md` in v1.15.0 (warn on drift, suggest `upgrade --anthropic`)
+27. No duplicate entries in `permissions.deny` list (warn if duplicates found)
 
-Checks 12-26 are skipped for Tier 0 projects.
+Checks 12-27 are skipped for Tier 0 projects.
 
 **`--report` output**: machine-readable JSON with timestamp, cwd, summary (passed/warned/failed/skipped), and per-check details. Consumed by CI systems or external audit tools.
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mg-claude-dev-kit",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "Scaffold for legible, reviewable AI-assisted development",
   "type": "module",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "chalk": "^5.3.0",
     "commander": "^14.0.0",
+    "diff": "^9.0.0",
     "fs-extra": "^11.2.0",
     "inquirer": "^13.4.1",
     "ora": "^9.0.0"

--- a/packages/cli/src/commands/doctor.js
+++ b/packages/cli/src/commands/doctor.js
@@ -23,6 +23,11 @@ import {
   expectedSecurityVariant,
   detectStackSync,
 } from '../utils/doctor-cross-file.js';
+import { fileURLToPath } from 'url';
+import { ANTHROPIC_FILES, detectScaffoldedTier } from './upgrade.js';
+
+const __doctorDirname = path.dirname(fileURLToPath(import.meta.url));
+const TEMPLATES_DIR_FOR_DOCTOR = path.resolve(__doctorDirname, '../../templates');
 
 const checks = [
   {
@@ -522,6 +527,35 @@ const checks = [
       } catch {
         return { pass: true, skip: true };
       }
+    },
+  },
+  {
+    id: 'anthropic-files-current',
+    label:
+      'Anthropic-influenced files (arch-audit, claudemd-standards, pipeline-standards) match the installed CDK template',
+    check: (cwd) => {
+      const tier = detectScaffoldedTier(cwd);
+      if (!tier) return { pass: true, skip: true };
+      const drifted = [];
+      for (const entry of ANTHROPIC_FILES) {
+        const targetPath = path.join(cwd, entry.target);
+        if (!fs.existsSync(targetPath)) continue;
+        const templatePath = entry.template
+          ? path.join(TEMPLATES_DIR_FOR_DOCTOR, entry.template)
+          : entry.templateTierAware
+            ? path.join(TEMPLATES_DIR_FOR_DOCTOR, entry.templateTierAware.replace('{TIER}', tier))
+            : null;
+        if (!templatePath || !fs.existsSync(templatePath)) continue;
+        const tpl = fs.readFileSync(templatePath, 'utf8');
+        const tgt = fs.readFileSync(targetPath, 'utf8');
+        if (tpl !== tgt) drifted.push(entry.target);
+      }
+      return {
+        pass: drifted.length === 0,
+        warn: true,
+        info: drifted.length > 0 ? `drift: ${drifted.join(', ')}` : undefined,
+        fix: `Run \`claude-dev-kit upgrade --anthropic\` to view diff, then \`--anthropic --apply\` to refresh${drifted.length > 0 ? ` (${drifted.length} file${drifted.length === 1 ? '' : 's'})` : ''}.`,
+      };
     },
   },
   {

--- a/packages/cli/src/commands/upgrade.js
+++ b/packages/cli/src/commands/upgrade.js
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 import fs from 'fs-extra';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { createPatch } from 'diff';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const TEMPLATES_DIR = path.resolve(__dirname, '../../templates');
@@ -38,12 +39,81 @@ const REVIEW_REQUIRED = [
   '.claude/skills/ui-audit/SKILL.md',
 ];
 
+// Files that encode Anthropic spec / best practices and should be refreshed
+// when Anthropic publishes guidance updates.
+//
+// v1.15.0 scope is limited to files that the scaffold copies 1:1 from the
+// template, so a raw template vs scaffolded-content compare is meaningful.
+// Files that pass through `interpolate()` placeholder substitution or
+// flag-based section stripping (`pipeline-standards.md`, `claudemd-standards.md`,
+// `arch-audit/SKILL.md`) produce false-positive drift on a clean install and
+// stay in REVIEW_REQUIRED until a transformation-aware compare is implemented
+// in a future release.
+export const ANTHROPIC_FILES = [
+  {
+    // Tier resolved at runtime by detectScaffoldedTier(cwd). advanced-checks.md
+    // is byte-identical across the three tiers, but the path is tier-prefixed
+    // in the template tree.
+    templateTierAware: 'tier-{TIER}/.claude/skills/arch-audit/advanced-checks.md',
+    target: '.claude/skills/arch-audit/advanced-checks.md',
+  },
+];
+
+/**
+ * Builds a backup file path with an ISO timestamp suffix:
+ * `<original>.bak.2026-04-25T14-30-00`. Returns the absolute path.
+ */
+export function backupPath(originalPath, now = new Date()) {
+  const stamp = now
+    .toISOString()
+    .replace(/[:.]/g, '-')
+    .replace(/-\d{3}Z$/, '');
+  return `${originalPath}.bak.${stamp}`;
+}
+
+/**
+ * Detects which tier (s, m, or l) was scaffolded into cwd by inspecting
+ * `.claude/rules/pipeline.md`. Returns null when no scaffold is present.
+ */
+export function detectScaffoldedTier(cwd) {
+  const pipelinePath = path.join(cwd, '.claude/rules/pipeline.md');
+  if (!fs.existsSync(pipelinePath)) return null;
+  const head = fs.readFileSync(pipelinePath, 'utf8').split('\n').slice(0, 3).join('\n');
+  if (/Fast Lane Pipeline/.test(head)) return 's';
+  if (/Standard Development Pipeline - Tier M/.test(head)) return 'm';
+  if (/Full Development Pipeline - Tier L/.test(head)) return 'l';
+  return null;
+}
+
+/**
+ * Resolves a template path with tier substitution applied when the entry uses
+ * `templateTierAware`. Plain `template` entries pass through.
+ */
+function resolveTemplatePath(entry, tier) {
+  if (entry.template) return path.join(TEMPLATES_DIR, entry.template);
+  if (entry.templateTierAware && tier) {
+    return path.join(TEMPLATES_DIR, entry.templateTierAware.replace('{TIER}', tier));
+  }
+  return null;
+}
+
 export async function upgrade(options) {
   const cwd = process.cwd();
   console.log();
   console.log(chalk.bold('claude-dev-kit upgrade'));
   console.log();
 
+  await runStandardUpgrade(cwd, options);
+
+  if (options.anthropic) {
+    console.log();
+    console.log(chalk.bold('claude-dev-kit upgrade --anthropic'));
+    console.log();
+    await runAnthropicUpgrade(cwd, options);
+  }
+}
+
+async function runStandardUpgrade(cwd, options) {
   const updates = [];
 
   for (const file of UPGRADEABLE_FILES) {
@@ -117,4 +187,123 @@ export async function upgrade(options) {
   console.log(chalk.green('Upgrade complete.'));
   console.log(chalk.dim('Review the manual-review files above to pick up any improvements.'));
   console.log();
+}
+
+/**
+ * Refreshes the Anthropic-influenced files. Default behavior is dry-run with a
+ * unified diff per changed file; `--apply` writes the new content with a
+ * timestamped `.bak` backup of the previous version.
+ *
+ * Combines orthogonally with the standard upgrade flow above.
+ */
+async function runAnthropicUpgrade(cwd, options) {
+  const tier = detectScaffoldedTier(cwd);
+  if (!tier) {
+    console.log(
+      chalk.yellow(
+        '⚠ No scaffolded tier detected (`.claude/rules/pipeline.md` missing or unrecognized). Skipping --anthropic refresh.',
+      ),
+    );
+    return;
+  }
+
+  const changes = [];
+  for (const entry of ANTHROPIC_FILES) {
+    const templatePath = resolveTemplatePath(entry, tier);
+    if (!templatePath || !fs.existsSync(templatePath)) continue;
+
+    const targetPath = path.join(cwd, entry.target);
+    const templateContent = fs.readFileSync(templatePath, 'utf8');
+
+    if (!fs.existsSync(targetPath)) {
+      changes.push({
+        entry,
+        templatePath,
+        targetPath,
+        templateContent,
+        targetContent: '',
+        reason: 'new file',
+      });
+      continue;
+    }
+
+    const targetContent = fs.readFileSync(targetPath, 'utf8');
+    if (templateContent !== targetContent) {
+      changes.push({
+        entry,
+        templatePath,
+        targetPath,
+        templateContent,
+        targetContent,
+        reason: 'updated in template',
+      });
+    }
+  }
+
+  if (changes.length === 0) {
+    console.log(chalk.green('✓ Anthropic-influenced files are already current.'));
+    return;
+  }
+
+  console.log(chalk.bold(`${changes.length} Anthropic-influenced file(s) differ from template:`));
+  for (const c of changes) {
+    console.log(`  ${chalk.cyan('→')} ${c.entry.target} ${chalk.dim(`(${c.reason})`)}`);
+  }
+  console.log();
+
+  // Always show the diff (so the user can read what would change before applying)
+  for (const c of changes) {
+    const patch = createPatch(
+      c.entry.target,
+      c.targetContent,
+      c.templateContent,
+      'current',
+      'template',
+    );
+    console.log(chalk.bold(`── ${c.entry.target} ──`));
+    process.stdout.write(colourizePatch(patch));
+    console.log();
+  }
+
+  if (!options.apply) {
+    console.log(
+      chalk.yellow(
+        '⚠ Dry run. Re-run with `--anthropic --apply` to overwrite (a `.bak.<timestamp>` is created for each replaced file).',
+      ),
+    );
+    return;
+  }
+
+  // --apply: write each change with backup
+  const now = new Date();
+  for (const c of changes) {
+    if (c.targetContent !== '') {
+      const backup = backupPath(c.targetPath, now);
+      await fs.copy(c.targetPath, backup);
+      console.log(`  ${chalk.dim('backup:')} ${backup}`);
+    }
+    await fs.ensureDir(path.dirname(c.targetPath));
+    await fs.writeFile(c.targetPath, c.templateContent, 'utf8');
+    console.log(`  ${chalk.green('✓')} Updated ${c.entry.target}`);
+  }
+  console.log();
+  console.log(chalk.green('Anthropic refresh complete.'));
+}
+
+/**
+ * Colourizes a unified diff produced by `diff.createPatch`. Lines that start
+ * with `+` (additions) become green, `-` (removals) red, hunk headers cyan.
+ * Other lines pass through unchanged.
+ */
+function colourizePatch(patch) {
+  return patch
+    .split('\n')
+    .map((line) => {
+      if (line.startsWith('+++') || line.startsWith('---')) return chalk.bold(line);
+      if (line.startsWith('@@')) return chalk.cyan(line);
+      if (line.startsWith('+')) return chalk.green(line);
+      if (line.startsWith('-')) return chalk.red(line);
+      return line;
+    })
+    .join('\n');
 }

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -38,6 +38,14 @@ program
   .command('upgrade')
   .description('Update template files to the latest claude-dev-kit version')
   .option('--dry-run', 'Show what would change without writing any files')
+  .option(
+    '--anthropic',
+    'Also refresh files that encode Anthropic spec / best practices (currently arch-audit/advanced-checks.md; v1.15.0 scope)',
+  )
+  .option(
+    '--apply',
+    'Required with --anthropic: write changes to disk (default is dry-run with diff)',
+  )
   .action(upgrade);
 
 const add = program.command('add').description('Add a single skill or rule to the current project');

--- a/packages/cli/test/integration/run.js
+++ b/packages/cli/test/integration/run.js
@@ -2861,6 +2861,158 @@ async function scenarioComplianceAuditPresent() {
   }
 }
 
+async function scenarioUpgradeAnthropic() {
+  section('upgrade --anthropic refresh + dry-run + doctor anthropic-files-current (v1.15.0)');
+
+  const CLI = path.resolve(__dirname, '../../src/index.js');
+
+  function runCli(args, cwd) {
+    try {
+      return {
+        stdout: execFileSync('node', [CLI, ...args], { cwd, encoding: 'utf8' }),
+        code: 0,
+      };
+    } catch (e) {
+      return { stdout: (e.stdout || '').toString(), code: e.status || 1 };
+    }
+  }
+
+  // Scaffold a Tier M project to exercise the tier-aware ANTHROPIC_FILES entries
+  const config = { ...BASE, tier: 'm', isDiscovery: false };
+  const dir = await scaffold('upgrade-anthropic-tier-m', 'm', config);
+
+  // Sanity baseline: dry-run on a clean scaffold reports "already current"
+  {
+    const out = runCli(['upgrade', '--anthropic'], dir);
+    if (/Anthropic-influenced files are already current/.test(out.stdout)) {
+      pass('Clean scaffold: --anthropic dry-run reports up-to-date');
+    } else {
+      fail('Clean scaffold: --anthropic dry-run did not report up-to-date');
+    }
+  }
+
+  // Simulate stale arch-audit/advanced-checks.md by appending a marker line
+  const archSkillPath = path.join(dir, '.claude/skills/arch-audit/advanced-checks.md');
+  const originalArch = fs.readFileSync(archSkillPath, 'utf8');
+  const staleArch = originalArch + '\n<!-- intentional stale marker -->\n';
+  fs.writeFileSync(archSkillPath, staleArch);
+
+  // Dry-run: should print diff and NOT overwrite
+  {
+    const out = runCli(['upgrade', '--anthropic'], dir);
+    if (/arch-audit\/SKILL\.md/.test(out.stdout)) {
+      pass('Stale arch-audit: --anthropic dry-run lists the file');
+    } else {
+      fail('Stale arch-audit: --anthropic dry-run did not list the file');
+    }
+    if (/Dry run\. Re-run with `--anthropic --apply`/.test(out.stdout)) {
+      pass('Dry-run mode emits "--apply" hint');
+    } else {
+      fail('Dry-run mode missing "--apply" hint');
+    }
+    const after = fs.readFileSync(archSkillPath, 'utf8');
+    if (after === staleArch) {
+      pass('Dry-run: arch-audit/advanced-checks.md left untouched on disk');
+    } else {
+      fail('Dry-run: arch-audit/advanced-checks.md was modified - should be untouched');
+    }
+  }
+
+  // Doctor reports drift via anthropic-files-current
+  {
+    const out = runCli(['doctor', '--report'], dir);
+    let report = null;
+    try {
+      report = JSON.parse(out.stdout);
+    } catch {
+      // ignore
+    }
+    if (report) {
+      const check = report.checks?.find((c) => c.id === 'anthropic-files-current');
+      if (check && (check.status === 'warn' || check.status === 'fail')) {
+        pass(`doctor anthropic-files-current = ${check.status} on stale arch-audit`);
+      } else {
+        fail(`doctor anthropic-files-current = ${check?.status} (expected warn/fail)`);
+      }
+    } else {
+      fail('doctor --report did not emit valid JSON');
+    }
+  }
+
+  // Apply: overwrites file with template + creates .bak
+  {
+    const out = runCli(['upgrade', '--anthropic', '--apply'], dir);
+    if (/Anthropic refresh complete/.test(out.stdout)) {
+      pass('--anthropic --apply emits success message');
+    } else {
+      fail('--anthropic --apply did not emit success message');
+    }
+    const refreshed = fs.readFileSync(archSkillPath, 'utf8');
+    if (refreshed === originalArch) {
+      pass('--apply: arch-audit/advanced-checks.md restored to original template content');
+    } else {
+      fail('--apply: arch-audit/advanced-checks.md content does not match original template');
+    }
+    const after = fs.readdirSync(path.join(dir, '.claude/skills/arch-audit'));
+    const bakFiles = after.filter((f) => f.startsWith('advanced-checks.md.bak.'));
+    if (bakFiles.length === 1) {
+      pass(`--apply: exactly one .bak file created (${bakFiles[0]})`);
+    } else {
+      fail(`--apply: expected 1 .bak file, found ${bakFiles.length}`);
+    }
+  }
+
+  // Doctor anthropic-files-current passes after apply
+  {
+    const out = runCli(['doctor', '--report'], dir);
+    let report = null;
+    try {
+      report = JSON.parse(out.stdout);
+    } catch {
+      // ignore
+    }
+    if (report) {
+      const check = report.checks?.find((c) => c.id === 'anthropic-files-current');
+      if (check && (check.status === 'pass' || check.status === 'skip')) {
+        pass(`doctor anthropic-files-current = ${check.status} after --apply`);
+      } else {
+        fail(
+          `doctor anthropic-files-current = ${check?.status} (expected pass/skip after refresh)`,
+        );
+      }
+    } else {
+      fail('doctor --report did not emit valid JSON after refresh');
+    }
+  }
+
+  // Tier S scaffold: --anthropic uses tier-s/ template path
+  {
+    const dirS = await scaffold('upgrade-anthropic-tier-s', 's', {
+      ...BASE,
+      tier: 's',
+      isDiscovery: false,
+    });
+    const out = runCli(['upgrade', '--anthropic'], dirS);
+    if (/Anthropic-influenced files are already current/.test(out.stdout)) {
+      pass('Tier S scaffold: --anthropic dry-run reports up-to-date (tier-aware path)');
+    } else {
+      fail('Tier S scaffold: --anthropic dry-run did not report up-to-date');
+    }
+  }
+
+  // No tier detected: --anthropic skips gracefully
+  {
+    const dirNoTier = path.join(OUTPUT_DIR, 'upgrade-anthropic-no-tier');
+    await fs.ensureDir(dirNoTier);
+    const out = runCli(['upgrade', '--anthropic'], dirNoTier);
+    if (/No scaffolded tier detected/.test(out.stdout)) {
+      pass('No-scaffold dir: --anthropic skips with informative message');
+    } else {
+      fail('No-scaffold dir: --anthropic did not skip gracefully');
+    }
+  }
+}
+
 // ── Main ─────────────────────────────────────────────────────────────────────
 
 async function main() {
@@ -2910,6 +3062,7 @@ async function main() {
   await scenarioApiContractAuditPresent();
   await scenarioInfraAuditPresent();
   await scenarioComplianceAuditPresent();
+  await scenarioUpgradeAnthropic();
 
   // ── Summary ────────────────────────────────────────────────────────────────
 

--- a/packages/cli/test/unit/upgrade-anthropic.test.js
+++ b/packages/cli/test/unit/upgrade-anthropic.test.js
@@ -1,0 +1,119 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs-extra';
+import os from 'os';
+import path from 'path';
+import { ANTHROPIC_FILES, backupPath, detectScaffoldedTier } from '../../src/commands/upgrade.js';
+
+describe('ANTHROPIC_FILES registry', () => {
+  it('contains the v1.15.0 1:1-scaffolded Anthropic-influenced file', () => {
+    const targets = ANTHROPIC_FILES.map((e) => e.target).sort();
+    assert.deepEqual(targets, ['.claude/skills/arch-audit/advanced-checks.md']);
+  });
+
+  it('every entry resolves to either a static template or a tier-aware template path', () => {
+    for (const entry of ANTHROPIC_FILES) {
+      const hasStatic = typeof entry.template === 'string' && entry.template.length > 0;
+      const hasTierAware =
+        typeof entry.templateTierAware === 'string' && entry.templateTierAware.includes('{TIER}');
+      assert.ok(hasStatic || hasTierAware, `${entry.target} has no template path`);
+    }
+  });
+
+  it('tier-aware entries cover only the tier-specific skill directory', () => {
+    const tierAware = ANTHROPIC_FILES.filter((e) => e.templateTierAware);
+    for (const entry of tierAware) {
+      assert.match(entry.target, /^\.claude\/skills\/arch-audit\//);
+    }
+  });
+});
+
+describe('backupPath', () => {
+  it('appends .bak.<ISO timestamp without milliseconds and Z>', () => {
+    const fixed = new Date('2026-04-25T14:30:45.123Z');
+    const out = backupPath('/tmp/foo/file.md', fixed);
+    assert.equal(out, '/tmp/foo/file.md.bak.2026-04-25T14-30-45');
+  });
+
+  it('produces unique paths when called more than a second apart', () => {
+    const a = backupPath('/tmp/file.md', new Date('2026-04-25T14:30:00Z'));
+    const b = backupPath('/tmp/file.md', new Date('2026-04-25T14:30:01Z'));
+    assert.notEqual(a, b);
+  });
+
+  it('preserves the original extension in the suffix-free portion', () => {
+    const out = backupPath('/path/to/file.md', new Date('2026-04-25T14:30:00Z'));
+    // .bak suffix sits AFTER the original extension, so the original ext is still recoverable
+    assert.match(out, /file\.md\.bak\./);
+  });
+});
+
+describe('detectScaffoldedTier', () => {
+  let tmp;
+
+  function makeTmp() {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk-detect-tier-'));
+    return tmp;
+  }
+
+  function cleanup() {
+    if (tmp && fs.existsSync(tmp)) fs.removeSync(tmp);
+  }
+
+  it('returns null when pipeline.md is missing', () => {
+    const dir = makeTmp();
+    try {
+      assert.equal(detectScaffoldedTier(dir), null);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('detects tier S via "Fast Lane Pipeline" header', () => {
+    const dir = makeTmp();
+    try {
+      const p = path.join(dir, '.claude/rules/pipeline.md');
+      fs.ensureDirSync(path.dirname(p));
+      fs.writeFileSync(p, '# Fast Lane Pipeline\n\nUse for: ...');
+      assert.equal(detectScaffoldedTier(dir), 's');
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('detects tier M via "Standard Development Pipeline - Tier M" header', () => {
+    const dir = makeTmp();
+    try {
+      const p = path.join(dir, '.claude/rules/pipeline.md');
+      fs.ensureDirSync(path.dirname(p));
+      fs.writeFileSync(p, '# Standard Development Pipeline - Tier M\n');
+      assert.equal(detectScaffoldedTier(dir), 'm');
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('detects tier L via "Full Development Pipeline - Tier L" header', () => {
+    const dir = makeTmp();
+    try {
+      const p = path.join(dir, '.claude/rules/pipeline.md');
+      fs.ensureDirSync(path.dirname(p));
+      fs.writeFileSync(p, '# Full Development Pipeline - Tier L\n');
+      assert.equal(detectScaffoldedTier(dir), 'l');
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('returns null for an unrecognized H1', () => {
+    const dir = makeTmp();
+    try {
+      const p = path.join(dir, '.claude/rules/pipeline.md');
+      fs.ensureDirSync(path.dirname(p));
+      fs.writeFileSync(p, '# Custom Pipeline\n\nUnknown shape.');
+      assert.equal(detectScaffoldedTier(dir), null);
+    } finally {
+      cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

v1.15.0 ships `upgrade --anthropic`, a dedicated flow for refreshing files that encode Anthropic spec and best practices. The standard `upgrade` already covers 8 template files; this flag handles the ones that need to track Anthropic guidance updates.

The default is a dry run with a colourized unified diff (built on the `diff` npm package). `--apply` writes the change and leaves a timestamped `.bak` backup behind. The two flows compose: `upgrade --anthropic --apply` runs both, back to back.

Scope is intentionally narrow in v1.15.0, one file: `.claude/skills/arch-audit/advanced-checks.md`. The other Anthropic-touching files (`pipeline-standards.md`, `claudemd-standards.md`, `arch-audit/SKILL.md`) pass through the scaffold's placeholder substitution or section-stripping pipeline, so a raw template-vs-scaffold compare flags false positives on a clean install. Expanding the registry needs a transformation-aware compare, parked for v1.16+.

A new doctor check, `anthropic-files-current`, warns when the file drifts from the installed CDK template. Doctor count goes from 26 to 27.

## Changes

- `feat(upgrade)`: ANTHROPIC_FILES registry, tier-aware template path resolution, diff-based dry run, `.bak` backup on apply
- `feat(doctor)`: `anthropic-files-current` check (warn-level, fixable via `upgrade --anthropic --apply`)
- `test(upgrade)`: `scenarioUpgradeAnthropic` (+11 integration checks), `upgrade-anthropic.test.js` (+11 unit tests)
- `chore(release)`: 1.14.0 to 1.15.0, CHANGELOG, README, operational-guide

## Test plan

- [ ] CI: lint, unit (343), integration (990), verify-cli, drift-tracker, codeql all green
- [ ] Manual smoke: scaffold tier-m, mutate `.claude/skills/arch-audit/advanced-checks.md`, run `upgrade --anthropic` (dry run shows diff), then `upgrade --anthropic --apply` (writes file plus `.bak`)
- [ ] Manual smoke: doctor warns on the stale file, passes after apply

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)