### PR TITLE
feat: v1.16.0 — team-settings.json governance + doctor compliance check (#94)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,31 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.16.0] — 2026-04-25
+
+### Added
+
+- **`team-settings.json` governance file** (Q3 #3, Issue #94, ICE 175): opt-in `.claude/team-settings.json` for team-wide CLI policy. Schema v1: `minTier` (s | m | l), `allowedSkills`, `blockedSkills`, `requiredSkills`. Empty/absent file = unrestricted (full backward compatibility).
+- **CLI enforcement** across `init`, `upgrade`, and `add skill`. `init` refuses scaffolds that violate `minTier` and explains the violation. `upgrade` refuses on `minTier` violation in an existing scaffold and suggests `init --tier=<min>` to promote. `add skill` refuses skills that are blocked or absent from the `allowedSkills` whitelist (`custom-*` skills bypass the whitelist by design).
+- **Doctor check `team-settings-compliance`** (warn-level): flags `minTier` violations on the current scaffold, blocked skills present in `.claude/skills/`, missing `requiredSkills`, and reports schema parse errors with the exact field. Doctor check count: 27 → 28.
+- **Schema validation** with descriptive errors: malformed JSON, unknown `minTier` value, non-array skill lists, non-string skill entries, and `allowedSkills ∩ blockedSkills` overlap (mutual exclusion).
+- **Helpers** in `packages/cli/src/utils/team-settings.js`: `readTeamSettings`, `validateTeamSettings`, `violatesMinTier`, `isSkillBlocked`, `isSkillAllowed`, `getRequiredSkills`. CLI-side wrappers in `team-settings-cli.js` (`loadTeamSettingsOrExit`, `enforceTeamSettingsTier`).
+- **Integration scenario `scenarioTeamSettings`** in `test/integration/run.js`: 10 assertions covering absent file (skip), `minTier` violation (doctor warn + upgrade refuse), blocked skill add (refuse), allowed-list whitelist refuse, missing required skill (doctor warn), allowed/blocked overlap (doctor warn), malformed JSON (upgrade exit), and `custom-*` semantics (whitelist bypass + blocklist enforcement).
+- **Unit tests** in `test/unit/team-settings.test.js`: 22 cases covering parser, validator, mutual exclusion, `violatesMinTier` precedence, `isSkillBlocked`/`isSkillAllowed` semantics including `custom-*` bypass, and `getRequiredSkills` array immutability.
+
+### Changed
+
+- Doctor JSON `--report` now includes `info` on `warn` and `fail` results (previously only on `pass`). Existing checks gain diagnostic context in CI output without behavior change.
+- Integration test count: 990 → 1000 (+10 from `scenarioTeamSettings`).
+- Unit test count: 343 → 365 (+22 from `team-settings.test.js`).
+
+### Notes
+
+- v1.16.0 enforcement is **CDK-only**. Skill restrictions and model selection are not translated to native `permissions.allow/deny` in `.claude/settings.json` because Claude Code's `Skill()` permission rule is not part of the documented public schema. Generation of native rules will land once the upstream contract is verified, tracked for v1.17+. Until then, governance is enforced when the user runs the CDK CLI; Claude Code sessions can still invoke skills directly.
+- `init-from-context` does not enforce `team-settings.json`. The target directory is greenfield (newly created), so a parent `team-settings.json` does not propagate by design.
+
+---
+
 ## [1.15.0] — 2026-04-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Node.js >= 22](https://img.shields.io/badge/node-%3E%3D22-brightgreen.svg)](https://nodejs.org)
 [![CI](https://github.com/marcoguillermaz/claude-dev-kit/actions/workflows/ci.yml/badge.svg)](https://github.com/marcoguillermaz/claude-dev-kit/actions/workflows/ci.yml)
-[![990 integration checks](https://img.shields.io/badge/integration-990%20checks-blue.svg)](#testing)
+[![1000 integration checks](https://img.shields.io/badge/integration-1000%20checks-blue.svg)](#testing)
 
 > Scaffold for legible, reviewable AI-assisted development.
 > Claude generates. Your team decides.
@@ -122,7 +122,7 @@ The Stop hook in `settings.json` is the core enforcement mechanism. It blocks Cl
 npx mg-claude-dev-kit init                    # scaffold wizard
 npx mg-claude-dev-kit init --dry-run          # preview without writing
 npx mg-claude-dev-kit init --answers file.json  # skip prompts (CI/automation)
-npx mg-claude-dev-kit doctor                  # validate setup (27 checks)
+npx mg-claude-dev-kit doctor                  # validate setup (28 checks)
 npx mg-claude-dev-kit doctor --report         # JSON output for CI
 npx mg-claude-dev-kit doctor --ci             # silent, exit 1 on failure
 npx mg-claude-dev-kit upgrade                 # update template files
@@ -161,8 +161,8 @@ npx mg-claude-dev-kit new skill               # create a custom skill (wizard)
 ## Testing
 
 ```bash
-node packages/cli/test/integration/run.js    # 990 integration checks
-node --test packages/cli/test/unit/*.test.js   # 343 unit tests
+node packages/cli/test/integration/run.js    # 1000 integration checks
+node --test packages/cli/test/unit/*.test.js   # 365 unit tests
 ```
 
 Covers: file structure per tier, Stop hook presence, pipeline gate counts, placeholder resolution, skill pruning, security variant selection, native stack adaptation, rubric scoring, cross-stack content invariants (10 stacks), golden-file assertions (Swift, Node-TS, Python), full CLI execution via `--answers` fixtures.
@@ -192,9 +192,9 @@ Covers: file structure per tier, Stop hook presence, pipeline gate counts, place
 
 See [GitHub Milestones](https://github.com/marcoguillermaz/claude-dev-kit/milestones) for the 12-month plan.
 
-**Current**: v1.15.0 ships the `upgrade --anthropic` flag (Q3 #2, Issue #93, ICE 210). The standard `upgrade` already refreshes 8 template files; `--anthropic` adds a separate flow for the files that encode Anthropic spec and best practices. Default is dry-run with a colourized unified diff (powered by the `diff` npm package); `--apply` writes the change with a timestamped `.bak` backup of the previous content. The two flows compose: `upgrade --anthropic --apply` runs both back to back. v1.15.0 scope is deliberately narrow, one file: `.claude/skills/arch-audit/advanced-checks.md`. The other Anthropic-touching files (`pipeline-standards.md`, `claudemd-standards.md`, `arch-audit/SKILL.md`) pass through the scaffold's placeholder substitution or section-stripping pipeline, so a raw template-vs-scaffold compare produces false positives on a clean install. Expanding the registry needs a transformation-aware compare, tracked for v1.16+. A new doctor check `anthropic-files-current` warns when the file drifts from the installed CDK template; doctor count goes from 26 to 27. Integration: 990 checks (+11 from `scenarioUpgradeAnthropic`); unit: 343 tests (+11 from `upgrade-anthropic.test.js`).
+**Current**: v1.16.0 ships `team-settings.json` for team-wide CLI governance (Q3 #3, Issue #94, ICE 175). Schema v1: `minTier` (s/m/l), `allowedSkills`, `blockedSkills`, `requiredSkills`. An empty or absent file means no restrictions, so existing setups keep working untouched. Enforcement covers `init` (refuses scaffolds below `minTier`), `upgrade` (refuses promotion-required scaffolds and suggests an alternative), `add skill` (refuses blocked or non-whitelisted skills, with `custom-*` bypassing the whitelist), and a new warn-level doctor check, `team-settings-compliance`. The doctor count moves from 27 to 28. Validation rejects any allowed/blocked overlap as a mutual-exclusion error. Native `Skill()` permission rules don't ship this release: Claude Code's permission grammar for skills isn't part of the documented public schema, so v1.16.0 keeps enforcement strictly CLI-side. Native rule generation is on the table for v1.17+. Integration: 1000 checks (+10 from `scenarioTeamSettings`). Unit: 365 tests (+22 from `team-settings.test.js`).
 
-**Next**: Q3 #3 `team-settings.json` org-wide skill and model restrictions (Issue #94, ICE 175) or Q2 #8 external review prompt template update (ICE 162). Q2 #3 VitePress docs site (ICE 432) stays deferred.
+**Next**: Q3 #4 `cdk sync` for cross-project rules sync (ICE 168), or Q2 #8 external review prompt template update (ICE 162). Q2 #3 VitePress docs site (ICE 432) stays on hold.
 
 ---
 

--- a/docs/operational-guide.md
+++ b/docs/operational-guide.md
@@ -1187,7 +1187,7 @@ npx mg-claude-dev-kit doctor --report  # JSON compliance output for CI pipelines
 npx mg-claude-dev-kit doctor --ci      # silent mode: exit 1 if any check fails
 ```
 
-Runs 27 checks:
+Runs 28 checks:
 
 1. Claude Code CLI is installed and reachable
 2. `CLAUDE.md` is present
@@ -1215,15 +1215,46 @@ Runs 27 checks:
 24. `.claude/rules/context-review.md` includes C12 (warn if not present - upgrade needed)
 25. Stop hook has `timeout` configured and ≤ 600s (warn if missing - prevents hanging test commands)
 26. Anthropic-influenced files match the installed CDK template — `arch-audit/advanced-checks.md` in v1.15.0 (warn on drift, suggest `upgrade --anthropic`)
-27. No duplicate entries in `permissions.deny` list (warn if duplicates found)
+27. Repo state matches `.claude/team-settings.json` — minTier ≥ scaffold tier, no blocked skills installed, all required skills present (warn-level; skips when the file is absent)
+28. No duplicate entries in `permissions.deny` list (warn if duplicates found)
 
-Checks 12-27 are skipped for Tier 0 projects.
+Checks 12-28 are skipped for Tier 0 projects.
 
 **`--report` output**: machine-readable JSON with timestamp, cwd, summary (passed/warned/failed/skipped), and per-check details. Consumed by CI systems or external audit tools.
 
 **CI integration**: `.github/workflows/claude-dev-kit-verify.yml` (scaffolded by `init`) runs doctor on every PR. Prevents merging when the scaffold is broken or bypassed.
 
 ---
+
+### Team-wide policy with `team-settings.json`
+
+For teams that want to enforce a baseline across every member's clone, drop a `.claude/team-settings.json` into the repo. The file is opt-in: when absent, CDK behaves as before. When present, the CLI applies the policy at every relevant entry point.
+
+Schema (v1):
+
+```json
+{
+  "minTier": "m",
+  "allowedSkills": ["arch-audit", "security-audit", "test-audit"],
+  "blockedSkills": ["custom-experimental"],
+  "requiredSkills": ["arch-audit"]
+}
+```
+
+Field semantics:
+
+- `minTier` — `s` | `m` | `l`. The lowest tier the project may scaffold to. `init` refuses lower tiers. `upgrade` refuses to run on a current scaffold below the floor and points the user at `init --tier=<min>` to promote.
+- `allowedSkills` — whitelist for `add skill`. Skills outside the list are rejected. `custom-*` skills bypass this list by design (custom skills aren't part of CDK governance).
+- `blockedSkills` — denylist for `add skill` and the doctor compliance check. `custom-*` skills are NOT exempt from the blocklist (governance overrides the "custom skills preserved across upgrades" convention).
+- `requiredSkills` — must be installed in `.claude/skills/`. Doctor warns if any are missing; CDK does not auto-install on its own.
+
+`allowedSkills ∩ blockedSkills` is rejected at parse time as a mutual-exclusion error.
+
+Enforcement points: `init` (refuse + explain), `upgrade` (refuse + suggest), `add skill` (refuse + explain), and the warn-level doctor check `team-settings-compliance`.
+
+`init-from-context` does not enforce `team-settings.json` because the target directory is greenfield; a parent `team-settings.json` doesn't propagate by design.
+
+v1.16.0 keeps enforcement strictly CLI-side. Native `Skill()` permission rules in `.claude/settings.json` are not generated this release: Claude Code's permission grammar for skills is not part of the documented public schema. Native rule generation tracks for v1.17+, after upstream verification.
 
 ### Adding team-specific rules
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mg-claude-dev-kit",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "Scaffold for legible, reviewable AI-assisted development",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/add.js
+++ b/packages/cli/src/commands/add.js
@@ -4,6 +4,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { SKILL_REGISTRY } from '../scaffold/skill-registry.js';
 import { registerSkillInClaudeMd } from '../utils/claudemd-update.js';
+import { readTeamSettings, isSkillBlocked, isSkillAllowed } from '../utils/team-settings.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const TEMPLATES_DIR = path.resolve(__dirname, '../../templates');
@@ -50,6 +51,32 @@ export async function addSkill(name, options) {
     console.error(chalk.red('No .claude/ directory found.'));
     console.log(
       'Run ' + chalk.cyan('claude-dev-kit init') + ' first, or create .claude/ manually.',
+    );
+    process.exit(1);
+  }
+
+  let teamSettings = null;
+  try {
+    teamSettings = readTeamSettings(cwd);
+  } catch (err) {
+    console.error(chalk.red(`team-settings.json is invalid: ${err.message}`));
+    process.exit(1);
+  }
+
+  if (isSkillBlocked(teamSettings, name)) {
+    console.error(chalk.red(`✗ Skill ${name} is blocked by .claude/team-settings.json.`));
+    console.error(
+      `  Edit team-settings.json blockedSkills to allow it, or pick a different skill.`,
+    );
+    process.exit(1);
+  }
+
+  if (!isSkillAllowed(teamSettings, name)) {
+    console.error(
+      chalk.red(`✗ Skill ${name} is not in the allowedSkills list of .claude/team-settings.json.`),
+    );
+    console.error(
+      `  Allowed: ${teamSettings.allowedSkills.join(', ')}. Custom skills (custom-*) bypass this check.`,
     );
     process.exit(1);
   }

--- a/packages/cli/src/commands/doctor.js
+++ b/packages/cli/src/commands/doctor.js
@@ -25,6 +25,12 @@ import {
 } from '../utils/doctor-cross-file.js';
 import { fileURLToPath } from 'url';
 import { ANTHROPIC_FILES, detectScaffoldedTier } from './upgrade.js';
+import {
+  readTeamSettings,
+  violatesMinTier,
+  isSkillBlocked,
+  getRequiredSkills,
+} from '../utils/team-settings.js';
 
 const __doctorDirname = path.dirname(fileURLToPath(import.meta.url));
 const TEMPLATES_DIR_FOR_DOCTOR = path.resolve(__doctorDirname, '../../templates');
@@ -559,6 +565,62 @@ const checks = [
     },
   },
   {
+    id: 'team-settings-compliance',
+    label: 'Repo state matches .claude/team-settings.json (minTier, blockedSkills, requiredSkills)',
+    check: (cwd) => {
+      let settings;
+      try {
+        settings = readTeamSettings(cwd);
+      } catch (err) {
+        return {
+          pass: false,
+          warn: true,
+          info: err.message,
+          fix: 'Edit .claude/team-settings.json to match the schema (minTier: s|m|l, allowedSkills/blockedSkills/requiredSkills as string arrays).',
+        };
+      }
+      if (!settings) return { pass: true, skip: true };
+
+      const violations = [];
+      const tier = detectScaffoldedTier(cwd);
+      if (tier) {
+        const minViolation = violatesMinTier(settings, tier);
+        if (minViolation) {
+          violations.push(`minTier=${minViolation} but scaffold is tier ${tier}`);
+        }
+      }
+
+      const skillsDir = path.join(cwd, '.claude', 'skills');
+      const installed = fs.existsSync(skillsDir)
+        ? fs
+            .readdirSync(skillsDir, { withFileTypes: true })
+            .filter((e) => e.isDirectory())
+            .map((e) => e.name)
+        : [];
+
+      const blockedPresent = installed.filter((s) => isSkillBlocked(settings, s));
+      if (blockedPresent.length > 0) {
+        violations.push(`blocked skills installed: ${blockedPresent.join(', ')}`);
+      }
+
+      const required = getRequiredSkills(settings);
+      const missingRequired = required.filter((s) => !installed.includes(s));
+      if (missingRequired.length > 0) {
+        violations.push(`required skills missing: ${missingRequired.join(', ')}`);
+      }
+
+      return {
+        pass: violations.length === 0,
+        warn: true,
+        info: violations.length > 0 ? violations.join('; ') : undefined,
+        fix:
+          violations.length > 0
+            ? 'Resolve each violation: re-init at the higher tier, remove blocked skills with `rm -rf .claude/skills/<name>`, add required skills with `claude-dev-kit add skill <name>`.'
+            : undefined,
+      };
+    },
+  },
+  {
     id: 'permissions-no-duplicates',
     label: 'No duplicate entries in permissions deny list',
     check: (cwd) => {
@@ -612,10 +674,22 @@ export async function doctor(options = {}) {
       results.push({ id: item.id, label: item.label, status: 'pass', info: result.info || null });
     } else if (result.warn) {
       warned++;
-      results.push({ id: item.id, label: item.label, status: 'warn', fix: result.fix });
+      results.push({
+        id: item.id,
+        label: item.label,
+        status: 'warn',
+        info: result.info || null,
+        fix: result.fix,
+      });
     } else {
       failed++;
-      results.push({ id: item.id, label: item.label, status: 'fail', fix: result.fix });
+      results.push({
+        id: item.id,
+        label: item.label,
+        status: 'fail',
+        info: result.info || null,
+        fix: result.fix,
+      });
     }
   }
 

--- a/packages/cli/src/commands/init-greenfield.js
+++ b/packages/cli/src/commands/init-greenfield.js
@@ -9,6 +9,7 @@ import { scaffoldTier } from '../scaffold/index.js';
 import { printPlan, printNextSteps } from '../utils/print-plan.js';
 import { AUDIT_MODELS } from '../utils/constants.js';
 import { NATIVE_STACKS, WEB_STACKS } from '../scaffold/skill-registry.js';
+import { enforceTeamSettingsTier } from '../utils/team-settings-cli.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const TEMPLATES_DIR = path.resolve(__dirname, '../../templates');
@@ -328,6 +329,8 @@ export async function initGreenfield(options) {
   } // end else (interactive path)
 
   const tier = isDiscovery ? '0' : options.tier || answers.tier || 's';
+
+  enforceTeamSettingsTier(process.cwd(), tier);
 
   const config = {
     ...answers,

--- a/packages/cli/src/commands/init-in-place.js
+++ b/packages/cli/src/commands/init-in-place.js
@@ -5,6 +5,7 @@ import path from 'path';
 import { execSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { detectStack } from '../utils/detect-stack.js';
+import { enforceTeamSettingsTier } from '../utils/team-settings-cli.js';
 import { scaffoldTierSafe } from '../scaffold/index.js';
 import { generateClaudeMd } from '../generators/claude-md.js';
 import { generateContextImport } from '../generators/context-import.js';
@@ -314,9 +315,12 @@ export async function initInPlace(options) {
     ]);
   } // end else (interactive path)
 
+  const finalTier = options.tier || answers.tier;
+  enforceTeamSettingsTier(cwd, finalTier);
+
   const config = {
     ...answers,
-    tier: options.tier || answers.tier,
+    tier: finalTier,
     mode: 'in-place',
     // Pass detected values as fallbacks for the Stop hook interpolation
     buildCommand: answers.buildCommand || detected.buildCommand,

--- a/packages/cli/src/commands/upgrade.js
+++ b/packages/cli/src/commands/upgrade.js
@@ -3,6 +3,8 @@ import fs from 'fs-extra';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { createPatch } from 'diff';
+import { violatesMinTier } from '../utils/team-settings.js';
+import { loadTeamSettingsOrExit } from '../utils/team-settings-cli.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const TEMPLATES_DIR = path.resolve(__dirname, '../../templates');
@@ -102,6 +104,23 @@ export async function upgrade(options) {
   console.log();
   console.log(chalk.bold('claude-dev-kit upgrade'));
   console.log();
+
+  const settings = loadTeamSettingsOrExit(cwd);
+  const currentTier = detectScaffoldedTier(cwd);
+  if (currentTier) {
+    const required = violatesMinTier(settings, currentTier);
+    if (required) {
+      console.error(
+        chalk.red(
+          `✗ team-settings.json requires minTier=${required}, current scaffold is tier ${currentTier}.`,
+        ),
+      );
+      console.error(
+        `  Re-run ${chalk.cyan(`claude-dev-kit init --tier=${required}`)} to promote, or edit .claude/team-settings.json.`,
+      );
+      process.exit(1);
+    }
+  }
 
   await runStandardUpgrade(cwd, options);
 

--- a/packages/cli/src/utils/team-settings-cli.js
+++ b/packages/cli/src/utils/team-settings-cli.js
@@ -1,0 +1,28 @@
+import chalk from 'chalk';
+import { readTeamSettings, violatesMinTier } from './team-settings.js';
+
+export function loadTeamSettingsOrExit(cwd) {
+  try {
+    return readTeamSettings(cwd);
+  } catch (err) {
+    console.error(chalk.red(`team-settings.json is invalid: ${err.message}`));
+    process.exit(1);
+  }
+}
+
+export function enforceTeamSettingsTier(cwd, tier, { suggestUpgrade = false } = {}) {
+  const settings = loadTeamSettingsOrExit(cwd);
+  const required = violatesMinTier(settings, tier);
+  if (!required) return;
+  console.error(
+    chalk.red(`✗ team-settings.json requires minTier=${required}, current tier is ${tier}.`),
+  );
+  if (suggestUpgrade) {
+    console.error(
+      `  Promote first: ${chalk.cyan(`claude-dev-kit upgrade --tier=${required}`)}, then retry.`,
+    );
+  } else {
+    console.error(`  Choose tier ${required} or higher, or edit .claude/team-settings.json.`);
+  }
+  process.exit(1);
+}

--- a/packages/cli/src/utils/team-settings.js
+++ b/packages/cli/src/utils/team-settings.js
@@ -1,0 +1,87 @@
+import fs from 'fs';
+import path from 'path';
+
+export const TEAM_SETTINGS_FILE = '.claude/team-settings.json';
+
+const VALID_TIERS = ['s', 'm', 'l'];
+const TIER_RANK = { s: 1, m: 2, l: 3 };
+const SKILL_LIST_FIELDS = ['allowedSkills', 'blockedSkills', 'requiredSkills'];
+
+export function readTeamSettings(cwd) {
+  const filePath = path.join(cwd, TEAM_SETTINGS_FILE);
+  if (!fs.existsSync(filePath)) return null;
+  let raw;
+  try {
+    raw = fs.readFileSync(filePath, 'utf8');
+  } catch (err) {
+    throw new Error(`Cannot read ${TEAM_SETTINGS_FILE}: ${err.message}`, { cause: err });
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`${TEAM_SETTINGS_FILE} is not valid JSON: ${err.message}`, { cause: err });
+  }
+  validateTeamSettings(parsed);
+  return parsed;
+}
+
+export function validateTeamSettings(settings) {
+  if (typeof settings !== 'object' || settings === null || Array.isArray(settings)) {
+    throw new Error('team-settings.json must be a JSON object');
+  }
+
+  if (settings.minTier !== undefined && !VALID_TIERS.includes(settings.minTier)) {
+    throw new Error(
+      `team-settings.json: minTier must be one of ${VALID_TIERS.join(', ')}, got "${settings.minTier}"`,
+    );
+  }
+
+  for (const field of SKILL_LIST_FIELDS) {
+    if (settings[field] === undefined) continue;
+    if (!Array.isArray(settings[field])) {
+      throw new Error(`team-settings.json: ${field} must be an array of strings`);
+    }
+    for (const name of settings[field]) {
+      if (typeof name !== 'string' || name.length === 0) {
+        throw new Error(`team-settings.json: ${field} must contain only non-empty strings`);
+      }
+    }
+  }
+
+  if (Array.isArray(settings.allowedSkills) && Array.isArray(settings.blockedSkills)) {
+    const overlap = settings.allowedSkills.filter((s) => settings.blockedSkills.includes(s));
+    if (overlap.length > 0) {
+      throw new Error(
+        `team-settings.json: allowedSkills and blockedSkills must not overlap. Conflicts: ${overlap.join(', ')}`,
+      );
+    }
+  }
+
+  return settings;
+}
+
+export function violatesMinTier(settings, tier) {
+  if (!settings || !settings.minTier) return null;
+  const required = TIER_RANK[settings.minTier];
+  const provided = TIER_RANK[tier];
+  if (provided === undefined) return null;
+  if (provided < required) return settings.minTier;
+  return null;
+}
+
+export function isSkillBlocked(settings, skillName) {
+  if (!settings || !Array.isArray(settings.blockedSkills)) return false;
+  return settings.blockedSkills.includes(skillName);
+}
+
+export function isSkillAllowed(settings, skillName) {
+  if (!settings || !Array.isArray(settings.allowedSkills)) return true;
+  if (skillName.startsWith('custom-')) return true;
+  return settings.allowedSkills.includes(skillName);
+}
+
+export function getRequiredSkills(settings) {
+  if (!settings || !Array.isArray(settings.requiredSkills)) return [];
+  return [...settings.requiredSkills];
+}

--- a/packages/cli/test/integration/run.js
+++ b/packages/cli/test/integration/run.js
@@ -3013,6 +3013,227 @@ async function scenarioUpgradeAnthropic() {
   }
 }
 
+async function scenarioTeamSettings() {
+  section('team-settings.json governance: init / upgrade / add / doctor (v1.16.0)');
+
+  const CLI = path.resolve(__dirname, '../../src/index.js');
+
+  function runCli(args, cwd) {
+    try {
+      return {
+        stdout: execFileSync('node', [CLI, ...args], { cwd, encoding: 'utf8' }),
+        code: 0,
+      };
+    } catch (e) {
+      return {
+        stdout: (e.stdout || '').toString() + (e.stderr || '').toString(),
+        code: e.status || 1,
+      };
+    }
+  }
+
+  // Baseline: tier-m scaffold without team-settings.json (unrestricted)
+  const baseConfig = { ...BASE, tier: 'm', isDiscovery: false };
+  const dirNoSettings = await scaffold('team-settings-absent', 'm', baseConfig);
+  {
+    const out = runCli(['doctor', '--report'], dirNoSettings);
+    let report = null;
+    try {
+      report = JSON.parse(out.stdout);
+    } catch {
+      // ignore
+    }
+    const check = report?.checks?.find((c) => c.id === 'team-settings-compliance');
+    if (check && check.status === 'skip') {
+      pass('Absent team-settings.json: doctor team-settings-compliance = skip');
+    } else {
+      fail(`Absent team-settings.json: doctor check = ${check?.status} (expected skip)`);
+    }
+  }
+
+  // Tier-S scaffold + team-settings.json with minTier=m → doctor warn
+  const dirTierS = await scaffold('team-settings-mintier-violation', 's', {
+    ...BASE,
+    tier: 's',
+    isDiscovery: false,
+  });
+  fs.writeFileSync(
+    path.join(dirTierS, '.claude/team-settings.json'),
+    JSON.stringify({ minTier: 'm' }, null, 2),
+  );
+  {
+    const out = runCli(['doctor', '--report'], dirTierS);
+    let report = null;
+    try {
+      report = JSON.parse(out.stdout);
+    } catch {
+      // ignore
+    }
+    const check = report?.checks?.find((c) => c.id === 'team-settings-compliance');
+    if (check && check.status === 'warn' && /minTier=m/.test(check.info || '')) {
+      pass('Tier-S + minTier=m: doctor warn with minTier violation message');
+    } else {
+      fail(
+        `Tier-S + minTier=m: doctor check = ${check?.status}, info=${check?.info} (expected warn with minTier=m)`,
+      );
+    }
+  }
+
+  // upgrade refuses on minTier violation
+  {
+    const out = runCli(['upgrade'], dirTierS);
+    if (
+      out.code !== 0 &&
+      /requires minTier=m/.test(out.stdout) &&
+      /init --tier=m/.test(out.stdout)
+    ) {
+      pass('upgrade refuses minTier violation with promotion suggestion');
+    } else {
+      fail(`upgrade should refuse + suggest tier promotion (code=${out.code})`);
+    }
+  }
+
+  // Tier-M scaffold + team-settings.json blockedSkills → add skill refused
+  const dirTierM = await scaffold('team-settings-blocked', 'm', baseConfig);
+  fs.writeFileSync(
+    path.join(dirTierM, '.claude/team-settings.json'),
+    JSON.stringify({ blockedSkills: ['security-audit'] }, null, 2),
+  );
+  {
+    const out = runCli(['add', 'skill', 'security-audit'], dirTierM);
+    if (out.code !== 0 && /blocked by .claude\/team-settings\.json/.test(out.stdout)) {
+      pass('add skill: blocked skill is refused with reference to team-settings');
+    } else {
+      fail(`add skill blocked: code=${out.code}, stdout=${out.stdout.slice(0, 200)}`);
+    }
+  }
+
+  // allowedSkills whitelist refuses skill not in list
+  fs.writeFileSync(
+    path.join(dirTierM, '.claude/team-settings.json'),
+    JSON.stringify({ allowedSkills: ['arch-audit', 'visual-audit'] }, null, 2),
+  );
+  {
+    const out = runCli(['add', 'skill', 'security-audit'], dirTierM);
+    if (out.code !== 0 && /not in the allowedSkills/.test(out.stdout)) {
+      pass('add skill: skill outside allowedSkills is refused');
+    } else {
+      fail(`add skill not-allowed: code=${out.code}, stdout=${out.stdout.slice(0, 200)}`);
+    }
+  }
+
+  // Required skills missing → doctor warn
+  fs.writeFileSync(
+    path.join(dirTierM, '.claude/team-settings.json'),
+    JSON.stringify({ requiredSkills: ['nonexistent-skill'] }, null, 2),
+  );
+  {
+    const out = runCli(['doctor', '--report'], dirTierM);
+    let report = null;
+    try {
+      report = JSON.parse(out.stdout);
+    } catch {
+      // ignore
+    }
+    const check = report?.checks?.find((c) => c.id === 'team-settings-compliance');
+    if (check && check.status === 'warn' && /required skills missing/.test(check.info || '')) {
+      pass('requiredSkills missing: doctor warn with explicit message');
+    } else {
+      fail(
+        `requiredSkills missing: doctor = ${check?.status}, info=${check?.info} (expected warn)`,
+      );
+    }
+  }
+
+  // Mutual exclusion: invalid team-settings.json → doctor warn with parse error
+  fs.writeFileSync(
+    path.join(dirTierM, '.claude/team-settings.json'),
+    JSON.stringify({ allowedSkills: ['arch-audit'], blockedSkills: ['arch-audit'] }, null, 2),
+  );
+  {
+    const out = runCli(['doctor', '--report'], dirTierM);
+    let report = null;
+    try {
+      report = JSON.parse(out.stdout);
+    } catch {
+      // ignore
+    }
+    const check = report?.checks?.find((c) => c.id === 'team-settings-compliance');
+    if (check && check.status === 'warn' && /must not overlap/.test(check.info || '')) {
+      pass('allowed/blocked overlap: doctor warn with mutual-exclusion message');
+    } else {
+      fail(`overlap: doctor = ${check?.status}, info=${check?.info}`);
+    }
+  }
+
+  // Malformed JSON → upgrade exits with parse error
+  fs.writeFileSync(path.join(dirTierM, '.claude/team-settings.json'), '{not json');
+  {
+    const out = runCli(['upgrade'], dirTierM);
+    if (out.code !== 0 && /not valid JSON/.test(out.stdout)) {
+      pass('upgrade: malformed team-settings.json exits with descriptive error');
+    } else {
+      fail(`malformed: upgrade code=${out.code}, stdout=${out.stdout.slice(0, 200)}`);
+    }
+  }
+
+  // custom-* skills bypass allowedSkills whitelist (presence in add does not apply since no template;
+  // verify via doctor that custom-* installed is NOT flagged when allowedSkills omits it)
+  fs.writeFileSync(
+    path.join(dirTierM, '.claude/team-settings.json'),
+    JSON.stringify({ allowedSkills: ['arch-audit'] }, null, 2),
+  );
+  // Simulate a custom skill installed
+  await fs.ensureDir(path.join(dirTierM, '.claude/skills/custom-experimental'));
+  fs.writeFileSync(
+    path.join(dirTierM, '.claude/skills/custom-experimental/SKILL.md'),
+    '---\nname: custom-experimental\n---\n# stub\n',
+  );
+  {
+    const out = runCli(['doctor', '--report'], dirTierM);
+    let report = null;
+    try {
+      report = JSON.parse(out.stdout);
+    } catch {
+      // ignore
+    }
+    const check = report?.checks?.find((c) => c.id === 'team-settings-compliance');
+    // allowedSkills is not presence-required: custom-experimental should NOT cause warn here
+    if (check && check.status === 'pass') {
+      pass('custom-* skill present + allowedSkills set: doctor pass (custom bypass)');
+    } else {
+      fail(
+        `custom bypass: doctor = ${check?.status}, info=${check?.info} (expected pass; custom-* not presence-required)`,
+      );
+    }
+  }
+
+  // blockedSkills enforced even on custom-*
+  fs.writeFileSync(
+    path.join(dirTierM, '.claude/team-settings.json'),
+    JSON.stringify({ blockedSkills: ['custom-experimental'] }, null, 2),
+  );
+  {
+    const out = runCli(['doctor', '--report'], dirTierM);
+    let report = null;
+    try {
+      report = JSON.parse(out.stdout);
+    } catch {
+      // ignore
+    }
+    const check = report?.checks?.find((c) => c.id === 'team-settings-compliance');
+    if (
+      check &&
+      check.status === 'warn' &&
+      /blocked skills installed.*custom-experimental/.test(check.info || '')
+    ) {
+      pass('blockedSkills enforces custom-* (governance > preservation)');
+    } else {
+      fail(`blocked custom: doctor = ${check?.status}, info=${check?.info}`);
+    }
+  }
+}
+
 // ── Main ─────────────────────────────────────────────────────────────────────
 
 async function main() {
@@ -3063,6 +3284,7 @@ async function main() {
   await scenarioInfraAuditPresent();
   await scenarioComplianceAuditPresent();
   await scenarioUpgradeAnthropic();
+  await scenarioTeamSettings();
 
   // ── Summary ────────────────────────────────────────────────────────────────
 

--- a/packages/cli/test/unit/team-settings.test.js
+++ b/packages/cli/test/unit/team-settings.test.js
@@ -1,0 +1,181 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs-extra';
+import os from 'os';
+import path from 'path';
+import {
+  TEAM_SETTINGS_FILE,
+  readTeamSettings,
+  validateTeamSettings,
+  violatesMinTier,
+  isSkillBlocked,
+  isSkillAllowed,
+  getRequiredSkills,
+} from '../../src/utils/team-settings.js';
+
+let TMP;
+
+before(async () => {
+  TMP = await fs.mkdtemp(path.join(os.tmpdir(), 'team-settings-test-'));
+});
+
+after(async () => {
+  await fs.remove(TMP);
+});
+
+async function writeSettings(name, contents) {
+  const dir = path.join(TMP, name);
+  await fs.ensureDir(path.join(dir, '.claude'));
+  await fs.writeFile(path.join(dir, TEAM_SETTINGS_FILE), contents);
+  return dir;
+}
+
+describe('readTeamSettings', () => {
+  it('returns null when team-settings.json is absent (unrestricted)', async () => {
+    const dir = await fs.mkdtemp(path.join(TMP, 'absent-'));
+    assert.equal(readTeamSettings(dir), null);
+  });
+
+  it('parses a valid file with all four fields', async () => {
+    const dir = await writeSettings(
+      'valid-all',
+      JSON.stringify({
+        minTier: 'm',
+        allowedSkills: ['arch-audit', 'security-audit'],
+        blockedSkills: ['custom-experimental'],
+        requiredSkills: ['arch-audit'],
+      }),
+    );
+    const parsed = readTeamSettings(dir);
+    assert.equal(parsed.minTier, 'm');
+    assert.deepEqual(parsed.allowedSkills, ['arch-audit', 'security-audit']);
+    assert.deepEqual(parsed.blockedSkills, ['custom-experimental']);
+    assert.deepEqual(parsed.requiredSkills, ['arch-audit']);
+  });
+
+  it('throws on malformed JSON with descriptive message', async () => {
+    const dir = await writeSettings('bad-json', '{not json}');
+    assert.throws(() => readTeamSettings(dir), /not valid JSON/);
+  });
+});
+
+describe('validateTeamSettings', () => {
+  it('rejects non-object values', () => {
+    assert.throws(() => validateTeamSettings('a string'), /must be a JSON object/);
+    assert.throws(() => validateTeamSettings([]), /must be a JSON object/);
+    assert.throws(() => validateTeamSettings(null), /must be a JSON object/);
+  });
+
+  it('rejects an unknown minTier value', () => {
+    assert.throws(() => validateTeamSettings({ minTier: 'xl' }), /minTier must be one of/);
+  });
+
+  it('rejects skill list fields that are not arrays', () => {
+    assert.throws(
+      () => validateTeamSettings({ allowedSkills: 'arch-audit' }),
+      /allowedSkills must be an array/,
+    );
+  });
+
+  it('rejects skill list entries that are not non-empty strings', () => {
+    assert.throws(
+      () => validateTeamSettings({ requiredSkills: ['ok', ''] }),
+      /must contain only non-empty strings/,
+    );
+    assert.throws(
+      () => validateTeamSettings({ blockedSkills: ['ok', 42] }),
+      /must contain only non-empty strings/,
+    );
+  });
+
+  it('rejects allowedSkills and blockedSkills overlap', () => {
+    assert.throws(
+      () =>
+        validateTeamSettings({
+          allowedSkills: ['arch-audit', 'security-audit'],
+          blockedSkills: ['security-audit'],
+        }),
+      /must not overlap.*security-audit/,
+    );
+  });
+
+  it('accepts an empty object as valid (all fields optional)', () => {
+    assert.doesNotThrow(() => validateTeamSettings({}));
+  });
+});
+
+describe('violatesMinTier', () => {
+  it('returns null when no minTier is set', () => {
+    assert.equal(violatesMinTier({}, 's'), null);
+    assert.equal(violatesMinTier(null, 's'), null);
+  });
+
+  it('returns the violated minTier when tier is below', () => {
+    assert.equal(violatesMinTier({ minTier: 'm' }, 's'), 'm');
+    assert.equal(violatesMinTier({ minTier: 'l' }, 'm'), 'l');
+    assert.equal(violatesMinTier({ minTier: 'l' }, 's'), 'l');
+  });
+
+  it('returns null when tier meets or exceeds minTier', () => {
+    assert.equal(violatesMinTier({ minTier: 'm' }, 'm'), null);
+    assert.equal(violatesMinTier({ minTier: 'm' }, 'l'), null);
+    assert.equal(violatesMinTier({ minTier: 's' }, 's'), null);
+  });
+
+  it('returns null for an unknown tier value (graceful skip)', () => {
+    assert.equal(violatesMinTier({ minTier: 'm' }, 'unknown'), null);
+  });
+});
+
+describe('isSkillBlocked', () => {
+  it('returns false when no settings or no blockedSkills', () => {
+    assert.equal(isSkillBlocked(null, 'arch-audit'), false);
+    assert.equal(isSkillBlocked({}, 'arch-audit'), false);
+  });
+
+  it('returns true when skill is in blockedSkills (custom-* not exempt)', () => {
+    const s = { blockedSkills: ['arch-audit', 'custom-x'] };
+    assert.equal(isSkillBlocked(s, 'arch-audit'), true);
+    assert.equal(isSkillBlocked(s, 'custom-x'), true);
+  });
+
+  it('returns false for skills not in the list', () => {
+    assert.equal(isSkillBlocked({ blockedSkills: ['a'] }, 'b'), false);
+  });
+});
+
+describe('isSkillAllowed', () => {
+  it('returns true when no settings or no allowedSkills (unrestricted)', () => {
+    assert.equal(isSkillAllowed(null, 'arch-audit'), true);
+    assert.equal(isSkillAllowed({}, 'arch-audit'), true);
+  });
+
+  it('returns true for skills in allowedSkills', () => {
+    assert.equal(isSkillAllowed({ allowedSkills: ['arch-audit'] }, 'arch-audit'), true);
+  });
+
+  it('returns false for skills not in allowedSkills', () => {
+    assert.equal(isSkillAllowed({ allowedSkills: ['arch-audit'] }, 'security-audit'), false);
+  });
+
+  it('returns true for custom-* skills regardless of allowedSkills (whitelist bypass)', () => {
+    const s = { allowedSkills: ['arch-audit'] };
+    assert.equal(isSkillAllowed(s, 'custom-experimental'), true);
+    assert.equal(isSkillAllowed(s, 'custom-internal-audit'), true);
+  });
+});
+
+describe('getRequiredSkills', () => {
+  it('returns an empty array when no settings or no requiredSkills', () => {
+    assert.deepEqual(getRequiredSkills(null), []);
+    assert.deepEqual(getRequiredSkills({}), []);
+  });
+
+  it('returns a copy of the requiredSkills array', () => {
+    const s = { requiredSkills: ['arch-audit', 'security-audit'] };
+    const required = getRequiredSkills(s);
+    assert.deepEqual(required, ['arch-audit', 'security-audit']);
+    required.push('mutation');
+    assert.deepEqual(s.requiredSkills, ['arch-audit', 'security-audit']);
+  });
+});


### PR DESCRIPTION
## Summary

v1.16.0 ships `team-settings.json` for team-wide CLI governance (Q3 #3, Issue #94, ICE 175).

The schema stays small in v1: `minTier` (s/m/l), `allowedSkills`, `blockedSkills`, `requiredSkills`. An empty or absent file means no restrictions, so every existing setup keeps working untouched.

Enforcement covers four entry points:
- `init` refuses scaffolds below `minTier` and explains the violation.
- `upgrade` refuses promotion-required scaffolds and suggests `init --tier=<min>` to promote.
- `add skill` refuses blocked or non-whitelisted skills (`custom-*` bypasses the whitelist by design).
- doctor gains a warn-level check, `team-settings-compliance`, that flags drift after the fact.

Validation rejects allowed/blocked overlap as a mutual-exclusion error. The doctor count moves from 27 to 28.

## Notes

v1.16.0 keeps enforcement strictly CLI-side. Native `Skill()` permission rules in `.claude/settings.json` are not generated this release: Claude Code's permission grammar for skills isn't part of the documented public schema. Native rule generation tracks for v1.17+, after upstream verification.

`init-from-context` does not enforce `team-settings.json` because the target directory is greenfield (newly created), so a parent `team-settings.json` does not propagate by design.

## Changes

- `feat(cli)`: team-settings loader + tier enforcement utilities (`utils/team-settings.js`, `utils/team-settings-cli.js`)
- `feat(cli)`: enforce constraints across init, add, upgrade, doctor
- `test(team-settings)`: unit (+22) + integration scenarioTeamSettings (+10)
- `chore(release)`: 1.15.0 → 1.16.0, CHANGELOG + README + operational-guide

## Test plan

- [ ] CI: lint, unit (365), integration (1000), verify-cli, drift-tracker, codeql, dependency-review all green
- [ ] Manual smoke: scaffold tier-s, drop `team-settings.json` with `minTier=m`, run `upgrade` (refuses), run `doctor --report` (warn-level)
- [ ] Manual smoke: `add skill security-audit` with `blockedSkills: [security-audit]` (refuses), then `add skill custom-foo` with `allowedSkills: [arch-audit]` (allowed via custom-* bypass)

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)