### PR TITLE
feat(external-review): /external-review skill with quick + full modes (Q2 #8)

### DIFF
--- a/.claude/skills/external-review/SKILL.md
+++ b/.claude/skills/external-review/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: external-review
+description: Run a fresh-context review of CDK before a release. --mode=quick spawns a Claude general-purpose subagent with no project memory and an auto-bundled snapshot. --mode=full fans out the same bundle to GPT-4.1, Gemini 2.5 Pro, Mistral Large, and Perplexity Sonar Pro for cross-LLM coverage. Maintainer-only; not shipped to user projects.
+user-invocable: true
+model: sonnet
+context: fork
+allowed-tools: Bash Read Write Glob Agent
+argument-hint: --mode=quick|full [--focus=<area>]
+---
+
+# external-review
+
+Pre-release sanity pass for CDK. Two modes:
+
+- `--mode=quick` (default) — single fresh-context Claude review. Cost: ~$0.10, ~60 seconds. Use on every release.
+- `--mode=full` — cross-LLM (GPT-4.1 / Gemini 2.5 Pro / Mistral Large / Perplexity Sonar Pro) via `scripts/external-review.mjs`. Cost: ~$0.50–2, ~5 minutes. Use at milestones (v2.0, every 4–6 minor releases, before strategic pivots).
+
+## Why two modes
+
+Cross-LLM catches two distinct blind-spot classes: (a) memory-isolation / fresh-eyes — replaceable by a Claude subagent with no transcript context — and (b) architectural diversity from different model families and training corpora. `quick` covers (a) cheaply on every release; `full` adds (b) at milestone gates. Running `full` weekly is wasteful redundancy.
+
+## Configuration
+
+- Prompt source: `docs/reviews/external-review-prompt.md` (single living file, frontmatter `version:` synced to current CDK release)
+- Bundle script: `scripts/external-review-bundle.mjs` (auto-curated: README + CHANGELOG slice + 1 SKILL sample + Tier-M pipeline + roadmap-status)
+- Cross-LLM script: `scripts/external-review.mjs` (existing, providers via env keys)
+- Output base: `docs/reviews/<YYYY-MM-DD>-<mode>/` (committed; cite in PRs and roadmap entries)
+
+## Steps
+
+### Step 0 — Parse arguments
+
+Parse `--mode` (default `quick`) and `--focus` (default `general`). Accepted modes: `quick`, `full`. Accepted focus tokens: `general`, `architecture`, `competitive-position`, `team-adoption`, `pricing`, `enterprise-readiness`. Unknown focus is allowed — it gets passed through verbatim to the prompt.
+
+### Step 1 — Resolve run directory
+
+Compute `RUN_DIR=docs/reviews/$(date -u +%Y-%m-%d)-<mode>/`. If it already exists, append `-<n>` until unique. Create `RUN_DIR/bundle/` and `RUN_DIR/responses/`.
+
+### Step 2 — Verify prompt freshness
+
+Read frontmatter of `docs/reviews/external-review-prompt.md`. If `version` does not match the current CDK release (read from `packages/cli/package.json`), STOP and print: "Prompt is stale (prompt={X}, CDK={Y}). Update docs/reviews/external-review-prompt.md frontmatter and content before running." Do NOT auto-update — the prompt body has CDK-state numbers that need a human review.
+
+### Step 3 — Auto-bundle
+
+Run `node scripts/external-review-bundle.mjs --out RUN_DIR/bundle/`. Verify exit 0 and that the expected 5 files are present.
+
+### Step 4 — Materialize the prompt
+
+Read `docs/reviews/external-review-prompt.md`, substitute `{VERSION}` → current CDK version (from `package.json`) and `{FOCUS_AREA}` → the resolved focus token. Write to `RUN_DIR/prompt.md`.
+
+### Step 5a — Quick mode (default)
+
+Use the Agent tool with `subagent_type=general-purpose`. Compose the agent prompt as:
+
+```
+You have NO prior memory of the claude-dev-kit project. The only context you have is the bundle below. Treat any claim not grounded in the bundle as unverified.
+
+[contents of RUN_DIR/prompt.md]
+
+---
+
+BUNDLE FILES (each is a separate file in the same review snapshot):
+
+=== README.md ===
+[contents]
+
+=== CHANGELOG.md ===
+[contents]
+
+=== security-audit-SKILL.md ===
+[contents]
+
+=== pipeline-tier-m.md ===
+[contents]
+
+=== roadmap-status.md ===
+[contents]
+```
+
+Inline the bundle contents (read from `RUN_DIR/bundle/`). Spawn a single agent. Capture its response. Write to `RUN_DIR/responses/claude-fresh.md` with a header line: `## Claude (general-purpose, fresh context) — CDK <VERSION> — Focus: <FOCUS_AREA> — <ISO date>`.
+
+### Step 5b — Full mode
+
+Run:
+
+```bash
+node scripts/external-review.mjs \
+  --prompt RUN_DIR/prompt.md \
+  --bundle RUN_DIR/bundle/ \
+  --out    RUN_DIR/responses/
+```
+
+Verify the script's preflight: 0 providers = abort with the printed instruction. 1–3 providers = proceed with the warning the script already prints. 4 providers = full coverage.
+
+### Step 6 — Synthesis
+
+Read every file in `RUN_DIR/responses/`. Produce `RUN_DIR/synthesis.md` with this structure:
+
+```
+# CDK <VERSION> — External Review Synthesis
+Date: <ISO>
+Mode: <mode>
+Focus: <focus>
+Reviewers: <comma-separated list>
+
+## Convergence (≥ 2 reviewers agree)
+- [point with reviewer attribution]
+
+## Divergence (each reviewer has a unique angle)
+- **<reviewer>**: [point]
+
+## Action items (prioritized)
+1. [high-leverage, name reviewer who flagged it]
+2. ...
+
+## Overall verdict
+[SHIP / SHIP-WITH-RESERVATIONS / DO-NOT-SHIP — mode aggregation]
+```
+
+Synthesis is markdown only — no JSON, no metrics. The maintainer reads it manually and decides which action items to file as issues.
+
+### Step 7 — Stage for review
+
+Print the path to `RUN_DIR/`, list every file produced, and the suggested `git add` invocation. Do not auto-commit. The maintainer reviews the synthesis, may decide to drop a noisy reviewer, and commits manually.
+
+## Execution notes
+
+- Output directory `docs/reviews/<run>/` is committed by exception in `.gitignore`. Existing legacy artifacts in `docs/reviews/` stay gitignored.
+- The skill never edits the prompt file. Stale prompts are surfaced in Step 2 and stop the run by design.
+- Quick mode does not require any external API key. Full mode skips providers whose keys are missing and prints a warning per missing provider.
+- A milestone run can be reproduced from any commit: prompt + bundle script live in the repo at the commit, so re-running on `git checkout <tag>` yields the same input shape.
+
+## Cost guidance
+
+- `quick` is bounded by Anthropic API pricing on Sonnet-equivalent. Treat as a free pre-release reflex.
+- `full` adds 4 external API calls. Mistral and Perplexity are the cheapest; GPT-4.1 and Gemini 2.5 Pro dominate the bill.
+
+## Output
+
+A populated `docs/reviews/<YYYY-MM-DD>-<mode>/` directory and a printed summary. No git commit, no version bump, no modification to other CDK files.

--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,9 @@ CLAUDE.md
 .claude/worktrees/
 
 # Claude Code — regenerable scaffold output (canonical source: packages/cli/templates/)
-.claude/skills/
+.claude/skills/*
+!.claude/skills/external-review/
+!.claude/skills/external-review/**
 .claude/cheatsheet.md
 .claude/files-guide.md
 .claude/commands/
@@ -65,8 +67,10 @@ packages/cli/test/integration/output/
 
 # Local-only scripts (not part of published CLI)
 packages/cli/src/commands/sync-from-pilot.js
-scripts/
+scripts/*
 !scripts/lint-templates.mjs
+!scripts/external-review.mjs
+!scripts/external-review-bundle.mjs
 
 # Internal project management (not product docs)
 FIRST_SESSION.md
@@ -75,7 +79,12 @@ MEMORY.md
 .env.example
 .sync-report.md
 tasks/
-docs/reviews/
+docs/reviews/*
+!docs/reviews/external-review-prompt.md
+!docs/reviews/[0-9]*-quick/
+!docs/reviews/[0-9]*-quick/**
+!docs/reviews/[0-9]*-full/
+!docs/reviews/[0-9]*-full/**
 docs/specs/
 docs/implementation-checklist.md
 docs/refactoring-backlog.md

--- a/docs/reviews/2026-04-26-quick/bundle/CHANGELOG.md
+++ b/docs/reviews/2026-04-26-quick/bundle/CHANGELOG.md
@@ -1,0 +1,106 @@
+# Changelog
+
+All notable changes to claude-dev-kit are documented here.
+
+Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+## [Unreleased]
+
+---
+
+> Bundle note: trimmed to the last three releases for review compactness.
+
+## [1.16.0] — 2026-04-25
+
+### Added
+
+- **`team-settings.json` governance file** (Q3 #3, Issue #94, ICE 175): opt-in `.claude/team-settings.json` for team-wide CLI policy. Schema v1: `minTier` (s | m | l), `allowedSkills`, `blockedSkills`, `requiredSkills`. Empty/absent file = unrestricted (full backward compatibility).
+- **CLI enforcement** across `init`, `upgrade`, and `add skill`. `init` refuses scaffolds that violate `minTier` and explains the violation. `upgrade` refuses on `minTier` violation in an existing scaffold and suggests `init --tier=<min>` to promote. `add skill` refuses skills that are blocked or absent from the `allowedSkills` whitelist (`custom-*` skills bypass the whitelist by design).
+- **Doctor check `team-settings-compliance`** (warn-level): flags `minTier` violations on the current scaffold, blocked skills present in `.claude/skills/`, missing `requiredSkills`, and reports schema parse errors with the exact field. Doctor check count: 27 → 28.
+- **Schema validation** with descriptive errors: malformed JSON, unknown `minTier` value, non-array skill lists, non-string skill entries, and `allowedSkills ∩ blockedSkills` overlap (mutual exclusion).
+- **Helpers** in `packages/cli/src/utils/team-settings.js`: `readTeamSettings`, `validateTeamSettings`, `violatesMinTier`, `isSkillBlocked`, `isSkillAllowed`, `getRequiredSkills`. CLI-side wrappers in `team-settings-cli.js` (`loadTeamSettingsOrExit`, `enforceTeamSettingsTier`).
+- **Integration scenario `scenarioTeamSettings`** in `test/integration/run.js`: 10 assertions covering absent file (skip), `minTier` violation (doctor warn + upgrade refuse), blocked skill add (refuse), allowed-list whitelist refuse, missing required skill (doctor warn), allowed/blocked overlap (doctor warn), malformed JSON (upgrade exit), and `custom-*` semantics (whitelist bypass + blocklist enforcement).
+- **Unit tests** in `test/unit/team-settings.test.js`: 22 cases covering parser, validator, mutual exclusion, `violatesMinTier` precedence, `isSkillBlocked`/`isSkillAllowed` semantics including `custom-*` bypass, and `getRequiredSkills` array immutability.
+
+### Changed
+
+- Doctor JSON `--report` now includes `info` on `warn` and `fail` results (previously only on `pass`). Existing checks gain diagnostic context in CI output without behavior change.
+- Integration test count: 990 → 1000 (+10 from `scenarioTeamSettings`).
+- Unit test count: 343 → 365 (+22 from `team-settings.test.js`).
+
+### Notes
+
+- v1.16.0 enforcement is **CDK-only**. Skill restrictions and model selection are not translated to native `permissions.allow/deny` in `.claude/settings.json` because Claude Code's `Skill()` permission rule is not part of the documented public schema. Generation of native rules will land once the upstream contract is verified, tracked for v1.17+. Until then, governance is enforced when the user runs the CDK CLI; Claude Code sessions can still invoke skills directly.
+- `init-from-context` does not enforce `team-settings.json`. The target directory is greenfield (newly created), so a parent `team-settings.json` does not propagate by design.
+
+---
+
+## [1.15.0] — 2026-04-25
+
+### Added
+
+- **`upgrade --anthropic` flag** (Q3 #2, Issue #93, ICE 210): refreshes files that encode Anthropic spec / best practices, separately from the standard `upgrade` flow. Default behavior is dry-run with a colourized unified diff (via the `diff` npm package) so the contributor reviews the change before committing it. `--apply` writes the new content with a timestamped backup file (`<original>.bak.<ISO-timestamp>`) for the previous version. Combinable with the standard upgrade in a single invocation.
+- **`ANTHROPIC_FILES` registry** in `packages/cli/src/commands/upgrade.js`: a list of templates that are 1:1 copied to a scaffold (no placeholder interpolation, no flag-based section stripping) and therefore safe to compare raw. v1.15.0 scope is one file: `.claude/skills/arch-audit/advanced-checks.md`. Files that pass through the scaffold transformation pipeline (`pipeline-standards.md`, `claudemd-standards.md`, `arch-audit/SKILL.md`) stay in `REVIEW_REQUIRED` until a transformation-aware compare is implemented in a future release.
+- **Helper exports** from `upgrade.js`: `backupPath(originalPath, now)` and `detectScaffoldedTier(cwd)`. Used by both the upgrade command and the new doctor check.
+- **Doctor check `anthropic-files-current`**: warns when any of the `ANTHROPIC_FILES` differs from the installed CDK template. Doctor check count: 26 → 27.
+- **Integration scenario `scenarioUpgradeAnthropic`** in `test/integration/run.js`: scaffolds tier-m and tier-s projects, exercises the dry-run / `--apply` / `.bak` / no-tier-detected paths, and cross-checks the doctor `anthropic-files-current` status before and after refresh. ~11 new integration assertions.
+- **Unit tests** in `test/unit/upgrade-anthropic.test.js`: 11 cases for `ANTHROPIC_FILES` registry shape, `backupPath` ISO timestamp formatting, and `detectScaffoldedTier` against tier S / M / L / unrecognized H1 / missing pipeline.md.
+
+### Changed
+
+- New dependency `diff` (^9.0.0) added to `packages/cli/package.json`. Unified-diff generation is cross-platform (no shell-out to system `diff`).
+- Integration test count: 979 → 990 (+11 from `scenarioUpgradeAnthropic`).
+- Unit test count: 332 → 343 (+11 from `upgrade-anthropic.test.js`).
+
+### Notes
+
+- The v1.15.0 `--anthropic` scope is intentionally narrow. It establishes the contract — flag, dry-run, backup, doctor wiring — on a single file that the scaffold copies 1:1 from the template. Expanding the registry to files that go through `interpolate()` or section stripping requires a transformation-aware compare (likely re-running the scaffold pipeline against the user's current config), tracked for v1.16+.
+
+### Documentation
+
+Rolled in from PR #114 (originally merged docs-only without version bump):
+
+- **CONTRIBUTING.md overhaul** (Q2 #6, ICE 256): full restructure to 11 sections aligned to v1.14.0 state. Closes the "Partial" status from PR #46 (2026-04-02).
+  - Refreshed test counts (979 integration, 332 unit) and removed the stale "(currently 19)" doctor-check reference.
+  - Expanded project structure with `docs/`, `scripts/`, recent utilities (`skill-frontmatter.js`, `doctor-cross-file.js`, `constants.js`, `stack-commands.js`).
+  - New section "Design principles": mechanical over judgment-heavy, stack-aware depth, agnostic-only patterns in templates, byte-identical Tier M/L, 500-line `SKILL.md` body budget, spec-compliant `allowed-tools` syntax.
+  - New section "Process governance" exposes R1 (`/commit` skill mandatory) and R2 (`/humanize` on user-facing GitHub prose) publicly. Documents atomic-commits-per-skill convention with the per-commit `skill-registry.test.js` length-assertion bump pattern. Notes prettier-before-staging and mid-feature `wc -l` budget checkpoints.
+  - New section "Adding a new skill" with a 9-step inline walkthrough: registry entry shape, frontmatter schema, sibling files (`PATTERNS.md` / `REPORT.md` / `PROFILES.md` / `advanced-checks.md`), Tier M/L copy verification, cheatsheet row, pipeline.md Track A/B/C invocation, integration scenario via `assertSkillPresent` helper, backlog ID prefix selection, documentation touch points. Includes minimal but compilable code examples.
+  - New section "Testing strategy" describes the unit/integration two-layer setup, fixture conventions, the custom `pass()`/`fail()` reporter, output-dir gitignore.
+  - New section "How PRs are reviewed" with explicit must-have / nice-to-have / auto-reject criteria.
+  - New section "For maintainers" at end of document: release process (tag, humanized GitHub Release, issue close, roadmap sync, GitHub Project Status update), npm publish guidance, `gh auth` switching protocol, branch protection notes, pre-release smoke-test protocol.
+  - Welcoming intro paragraph framing the moat principle (mechanical > judgment-heavy) for first-time contributors.
+  - 387 lines (was 116).
+
+---
+
+## [1.14.0] — 2026-04-25
+
+### Added
+
+- **Three new skills** (Issue #66, Tier M/L) — closes the Q2 #7 bundle:
+  - **`/api-contract-audit`** — requires `hasApi: true`. Static OpenAPI contract audit. Eight checks AC1-AC8: endpoint drift (spec vs code set-diff), schema drift (field-level compare of Zod / Pydantic / io-ts / class-validator against spec), status-code mismatch, breaking-change detection vs previous spec (`git show HEAD~1:<spec-path>` diff; required field removed, enum value removed, path removed, type change = Critical), versioning consistency, security scheme alignment, deprecation markers, Richardson Maturity Model scoring L0-L3 (HATEOAS detected via `_links` / `rel` / `href` / HAL / JSON:API patterns in response schema). Framework auto-gen: FastAPI (`/openapi.json` endpoint or decorator parsing), NestJS (`@ApiProperty` decorators), Express + swagger-jsdoc (JSDoc annotations), Next.js 13+ route handlers (`app/api/*/route.ts` + Zod inference), Django REST Framework (`drf-spectacular` / `drf-yasg`). Patterns in sibling `PATTERNS.md`. Backlog prefix `API-`. Runs in Phase 5d Track B.
+  - **`/infra-audit`** — universal (no `requires`). Static infra-security audit across five layers, each running only if its markers are detected: **GitHub Actions** (GHA-1..7: pwn-request, secret logging, unpinned actions, permissions overreach, self-hosted runner on public PR, untrusted input in run, workflow modification permission); **Dockerfile** (D-1..6: latest tag, root user, ADD with URL, unpinned base image, secret in build arg, apt without cleanup); **Kubernetes** (K-1..7: runAsNonRoot missing, allowPrivilegeEscalation, privileged container, hostNetwork/hostPID/hostIPC, writable rootfs, secret as env var, imagePullPolicy mismatch); **Terraform** (T-1..6: IAM wildcard action, IAM wildcard resource, public S3, state in git, module without version pin, hardcoded secret); **GitLab CI** (GL-1..4: secret logging, unpinned image, unprotected runner, script injection). Patterns in sibling `PATTERNS.md`. Backlog prefix `INFRA-`. Runs in Phase 5d Track C on every block. Stack-agnostic.
+  - **`/compliance-audit`** — universal (no `requires`). Static compliance audit with regulatory profiles. v1.14 ships the **GDPR profile active** (10 checks G1-G10 across 4 pillars: data-subject rights delete/export/rectify, lawful basis + consent, PII identification + encryption-at-rest for Article 9 special-category + logging hygiene, retention + sub-processors). Output includes a mechanical **GDPR readiness tier** (foundational / operational / mature); explicit caveat that the tier is mechanical and does not constitute legal attestation. **SOC 2 and HIPAA profiles scaffolded** in sibling `PROFILES.md` as future-markers with check IDs `SOC2-1..10` / `HIPAA-1..10`, reserved backlog prefixes, and enablement blockers documented (SOC 2: pattern validation against a real enterprise audit engagement; HIPAA: PHI vocabulary validation in a healthcare-domain project). Backlog prefix `GDPR-` (SOC 2 / HIPAA reserved). Runs in Phase 5d Track B. Stack-agnostic.
+- New skill scaffolded in `packages/cli/templates/tier-m/.claude/skills/` and `tier-l/.claude/skills/` for each of the three skills (byte-identical across tiers):
+  - `api-contract-audit/` — SKILL.md (279 body lines) + PATTERNS.md (framework auto-gen + route discovery + schema extraction + L3 HATEOAS detection)
+  - `infra-audit/` — SKILL.md (185 body lines) + PATTERNS.md (5 layer sections)
+  - `compliance-audit/` — SKILL.md (285 body lines) + PROFILES.md (GDPR active + SOC 2 / HIPAA future-marker scaffolding)
+- Three registry entries in `skill-registry.js`: `api-contract-audit` (`minTier: 'm'`, `requires: { hasApi: true }`, `cheatsheet: true`); `infra-audit` (`minTier: 'm'`, `requires: {}`, `cheatsheet: true`); `compliance-audit` (`minTier: 'm'`, `requires: {}`, `cheatsheet: true`).
+- Cheatsheet rows for all three skills in tier-M and tier-L `cheatsheet.md`.
+- Three integration scenarios in `test/integration/run.js` — `scenarioApiContractAuditPresent`, `scenarioInfraAuditPresent`, `scenarioComplianceAuditPresent` — plus a shared `assertSkillPresent()` helper. Each verifies tier pruning (absent on tier S), presence (SKILL.md + siblings on tier M/L), cheatsheet row presence, pipeline.md invocation, `allowed-tools` spec compliance, and body size budget. `scenarioApiContractAuditPresent` additionally verifies `hasApi: false` pruning; `scenarioComplianceAuditPresent` additionally verifies `PROFILES.md` scaffolds SOC 2 / HIPAA as future-markers.
+
+### Changed
+
+- `pipeline.md` Track B in tier-M/L renamed `Track B - API/DB audit` → `Track B - API/DB + compliance audit`, with `/api-contract-audit` and `/compliance-audit` added to the invocation list.
+- `pipeline.md` Track C in tier-M/L renamed `Track C - Test + doc audit` → `Track C - Test + doc + infra audit`, with `/infra-audit` added to the invocation list.
+- `README.md` skill count `17 audit skills` → `20 audit skills`; three rows added to the skills table; Current/Next roadmap rewritten; Testing section updated to `979 integration checks` and `332 unit tests`; shields.io badge updated to `979 checks`.
+- `docs/operational-guide.md` audit-skill table updated with three new rows; Phase 5d Track B renamed "API/DB + compliance audit"; Phase 5d Track C renamed "Test + doc + infra audit"; three full skill detail sections added after `/doc-audit`.
+- Integration test count: 895 → 979 (+84 across three scenario suites).
+- `CLAUDE.md` line-count regression guard in `scenarioPlaceholderNoiseReduction` loosened from `< 85` to `< 90` to accommodate three additional Active Skills rows.
+- `skill-registry.test.js` entry-count assertion updated from 19 to 22.
+
+---

--- a/docs/reviews/2026-04-26-quick/bundle/README.md
+++ b/docs/reviews/2026-04-26-quick/bundle/README.md
@@ -1,0 +1,209 @@
+# claude-dev-kit
+
+[![npm version](https://img.shields.io/npm/v/mg-claude-dev-kit.svg)](https://www.npmjs.com/package/mg-claude-dev-kit)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Node.js >= 22](https://img.shields.io/badge/node-%3E%3D22-brightgreen.svg)](https://nodejs.org)
+[![CI](https://github.com/marcoguillermaz/claude-dev-kit/actions/workflows/ci.yml/badge.svg)](https://github.com/marcoguillermaz/claude-dev-kit/actions/workflows/ci.yml)
+[![1000 integration checks](https://img.shields.io/badge/integration-1000%20checks-blue.svg)](#testing)
+
+> Scaffold for legible, reviewable AI-assisted development.
+> Claude generates. Your team decides.
+
+Claude Code is a powerful CLI that reads, writes, and reasons about your entire codebase. Without shared process, it makes autonomous decisions that are hard to track and harder to review.
+
+**claude-dev-kit** scaffolds a structured, reviewable development process on top of Claude Code. It enforces one non-negotiable rule mechanically: Claude cannot declare a task complete until your tests pass. Everything else scales with your needs.
+
+---
+
+## Quick Start
+
+```bash
+npx mg-claude-dev-kit init
+```
+
+The wizard detects your project state and guides you through setup. Three paths available:
+
+| Path                   | Use when                                                         |
+| ---------------------- | ---------------------------------------------------------------- |
+| **Existing project**   | Add structure to a project that already has code                 |
+| **New project**        | Starting from scratch                                            |
+| **From existing docs** | Share repos or docs - Claude reads them and populates everything |
+
+After init, open Claude Code and start working. The scaffold is active immediately.
+
+---
+
+## What it does
+
+### Tiered pipelines matched to risk
+
+| Tier              | Pipeline                | Best for                              |
+| ----------------- | ----------------------- | ------------------------------------- |
+| **0 - Discovery** | Stop hook only          | First exploration - zero process      |
+| **S - Fast Lane** | 4 steps, scope-confirm  | Single dev, low risk, quick fixes     |
+| **M - Standard**  | 8 phases, 2 STOP gates  | Feature blocks, 1-2 collaborators     |
+| **L - Full**      | 14 phases, 4 STOP gates | Team projects, complex domain changes |
+
+Start at Tier 0. Move up when you need more structure: `npx mg-claude-dev-kit upgrade --tier=m`
+
+### 20 audit skills
+
+Executable multi-step programs that run inside Claude Code. Not prompt instructions - structured audit workflows with model routing (haiku for mechanical checks, sonnet for analysis).
+
+| Skill                  | Tiers | Purpose                                                                                                                                 |
+| ---------------------- | ----- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `/arch-audit`          | S M L | Governance files vs Anthropic docs. Auto-fixes deprecations.                                                                            |
+| `/security-audit`      | S M L | Auth, input validation, RLS, CVE scan. 3-path: WEB / NATIVE / HYBRID.                                                                   |
+| `/perf-audit`          | S M L | Bundle size, serial awaits, query efficiency. 8-stack patterns.                                                                         |
+| `/skill-dev`           | S M L | Coupling, duplication, dead code, debt-density.                                                                                         |
+| `/simplify`            | S M L | Early returns, nesting, dead code. Applies changes directly.                                                                            |
+| `/commit`              | S M L | Conventional Commits - auto-detects type, scope, description.                                                                           |
+| `/api-design`          | M L   | URL naming, HTTP verbs, response envelope, pagination.                                                                                  |
+| `/skill-db`            | M L   | Schema normalization, indexes, N+1 queries, RLS.                                                                                        |
+| `/migration-audit`     | M L   | Stack-aware migration safety: data loss, rollback, lock-heavy DDL. Prisma/Drizzle/Supabase/SQL.                                         |
+| `/visual-audit`        | M L   | Typography, spacing, hierarchy, dark-mode, micro-polish.                                                                                |
+| `/ux-audit`            | M L   | ISO 9241-11, Nielsen heuristics, user confidence.                                                                                       |
+| `/responsive-audit`    | M L   | Layout at 320-1024px, tap targets, WCAG.                                                                                                |
+| `/ui-audit`            | M L   | Design token compliance, component adoption, empty states.                                                                              |
+| `/accessibility-audit` | M L   | axe-core WCAG 2.2, APCA contrast, static a11y (aria, tabindex, focus, labels).                                                          |
+| `/test-audit`          | M L   | Coverage (lcov/Istanbul/Cobertura/go/tarpaulin/xcresult), pyramid shape, anti-patterns (`.only`, skipped, empty, no-assertion, sleeps). |
+| `/doc-audit`           | M L   | Doc drift: link resolution, code-block syntax (json/yaml/toml), CDK placeholder residuals, slash-command name match, skill-count consistency, ADR freshness, stack-sync (Next.js/Django/Swift). |
+| `/api-contract-audit`  | M L   | OpenAPI contract drift (endpoints, schemas, status), breaking-change detection vs previous spec, versioning consistency, security scheme alignment, Richardson Maturity L0-L3 scoring. Auto-gen for FastAPI / NestJS / Express+swagger-jsdoc / Next.js route handlers / Django REST. |
+| `/infra-audit`         | M L   | Infrastructure security across GitHub Actions (pwn-request, secret logging, pinning, permissions), Dockerfile (root, latest tag, URL add), K8s (runAsNonRoot, privileged, hostNetwork), Terraform (IAM wildcards, state in git), GitLab CI. Stack-agnostic. |
+| `/compliance-audit`    | M L   | GDPR profile: data-subject rights (delete, export, rectify), consent, lawful basis, PII identification, encryption-at-rest on special-category, logging hygiene, retention, sub-processors. SOC 2 / HIPAA scaffolded for v1.15+. |
+| `/skill-review`        | M L   | Quality review pipeline for skill portfolios. Spec compliance, cross-tier coherence, behavioral fixtures.                               |
+
+Skills are conditionally installed based on your project: `hasApi`, `hasDatabase`, `hasFrontend`, `hasDesignSystem`.
+
+### 11 tech stacks auto-detected
+
+Node.js/TS, Node.js/JS, Python, Go, Swift, Kotlin, Rust, .NET, Ruby, Java - plus generic fallback. Security rules, permissions, and CLAUDE.md fields adapt automatically.
+
+### Incremental adoption
+
+Install individual components without a full scaffold:
+
+```bash
+npx mg-claude-dev-kit add skill security-audit   # install one skill
+npx mg-claude-dev-kit add rule git                # install one rule
+npx mg-claude-dev-kit add rule security --stack swift  # stack-specific variant
+```
+
+Custom skills (`custom-*` prefix) are preserved across upgrades. See [Custom Skills Guide](docs/custom-skills.md).
+
+---
+
+## Architecture
+
+```
+your-project/
+├── CLAUDE.md                    # Project context (<200 lines)
+├── .claude/
+│   ├── settings.json            # Permissions + Stop hook (mechanical enforcement)
+│   ├── rules/
+│   │   ├── pipeline.md          # Development workflow (tier-appropriate)
+│   │   ├── security.md          # Stack-aware: web / apple / android / systems
+│   │   ├── git.md               # Commit format, branch rules
+│   │   └── output-style.md      # Communication rules
+│   ├── skills/                  # Audit skills (conditional per project)
+│   └── session/                 # Session recovery (gitignored)
+├── docs/                        # Requirements, specs, backlog (M/L)
+├── .github/                     # PR template, CODEOWNERS
+└── .pre-commit-config.yaml      # Secret scanning
+```
+
+The Stop hook in `settings.json` is the core enforcement mechanism. It blocks Claude from completing any task until tests pass. Present in every tier, including Discovery.
+
+---
+
+## CLI Commands
+
+```bash
+npx mg-claude-dev-kit init                    # scaffold wizard
+npx mg-claude-dev-kit init --dry-run          # preview without writing
+npx mg-claude-dev-kit init --answers file.json  # skip prompts (CI/automation)
+npx mg-claude-dev-kit doctor                  # validate setup (28 checks)
+npx mg-claude-dev-kit doctor --report         # JSON output for CI
+npx mg-claude-dev-kit doctor --ci             # silent, exit 1 on failure
+npx mg-claude-dev-kit upgrade                 # update template files
+npx mg-claude-dev-kit upgrade --tier=m        # promote to higher tier
+npx mg-claude-dev-kit upgrade --anthropic     # show diff for Anthropic-influenced files (dry-run)
+npx mg-claude-dev-kit upgrade --anthropic --apply  # write the diff (with .bak backup)
+npx mg-claude-dev-kit add skill <name>        # install one skill
+npx mg-claude-dev-kit add rule <name>         # install one rule
+npx mg-claude-dev-kit new skill               # create a custom skill (wizard)
+```
+
+---
+
+## Process controls
+
+**Stop hook** (every tier) - Claude cannot declare done until tests pass:
+
+```json
+"Stop": [{ "hooks": [{ "type": "command",
+  "command": "npm test || echo '{\"decision\": \"block\", \"reason\": \"Tests must pass.\"}'"
+}] }]
+```
+
+**STOP gates** (Tier M/L) - Requirements reviewed before implementation. Spec-first or scope-confirm mode auto-selected per block.
+
+**Audit logging** - Every tool use appended to `~/.claude/audit/project.jsonl`.
+
+**AI attribution** - Every Claude-assisted commit tagged with `Co-authored-by`.
+
+**Weekly arch-audit** - SessionStart hook checks if `/arch-audit` ran in the last 7 days.
+
+**CODEOWNERS** - Changes to `.claude/` require tech lead review.
+
+---
+
+## Testing
+
+```bash
+node packages/cli/test/integration/run.js    # 1000 integration checks
+node --test packages/cli/test/unit/*.test.js   # 365 unit tests
+```
+
+Covers: file structure per tier, Stop hook presence, pipeline gate counts, placeholder resolution, skill pruning, security variant selection, native stack adaptation, rubric scoring, cross-stack content invariants (10 stacks), golden-file assertions (Swift, Node-TS, Python), full CLI execution via `--answers` fixtures.
+
+---
+
+## Requirements
+
+- Node.js >= 22
+- [Claude Code CLI](https://claude.ai/code)
+- Git
+
+---
+
+## Documentation
+
+| Document                                           | Audience                    | Content                                                        |
+| -------------------------------------------------- | --------------------------- | -------------------------------------------------------------- |
+| [Operational Guide](docs/operational-guide.md)     | Teams adopting CDK          | Full reference: installation, tiers, workflow, governance, FAQ |
+| [Custom Skills Guide](docs/custom-skills.md)       | Developers extending CDK    | SKILL.md format, frontmatter schema, authoring patterns        |
+| [Product Brief](docs/product-brief.md)             | Stakeholders                | Strategic positioning, target users, scope                     |
+| [Quality Rubric](docs/workspace-quality-rubric.md) | Teams evaluating workspaces | 8-dimension scoring (D1-D8, 0-100%)                            |
+
+---
+
+## Roadmap
+
+See [GitHub Milestones](https://github.com/marcoguillermaz/claude-dev-kit/milestones) for the 12-month plan.
+
+**Current**: v1.16.0 ships `team-settings.json` for team-wide CLI governance (Q3 #3, Issue #94, ICE 175). Schema v1: `minTier` (s/m/l), `allowedSkills`, `blockedSkills`, `requiredSkills`. An empty or absent file means no restrictions, so existing setups keep working untouched. Enforcement covers `init` (refuses scaffolds below `minTier`), `upgrade` (refuses promotion-required scaffolds and suggests an alternative), `add skill` (refuses blocked or non-whitelisted skills, with `custom-*` bypassing the whitelist), and a new warn-level doctor check, `team-settings-compliance`. The doctor count moves from 27 to 28. Validation rejects any allowed/blocked overlap as a mutual-exclusion error. Native `Skill()` permission rules don't ship this release: Claude Code's permission grammar for skills isn't part of the documented public schema, so v1.16.0 keeps enforcement strictly CLI-side. Native rule generation is on the table for v1.17+. Integration: 1000 checks (+10 from `scenarioTeamSettings`). Unit: 365 tests (+22 from `team-settings.test.js`).
+
+**Next**: Q3 #4 `cdk sync` for cross-project rules sync (ICE 168), or Q2 #8 external review prompt template update (ICE 162). Q2 #3 VitePress docs site (ICE 432) stays on hold.
+
+---
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, project structure, and PR guidelines.
+
+To report a security issue, see [SECURITY.md](SECURITY.md).
+
+## License
+
+[MIT](LICENSE)

--- a/docs/reviews/2026-04-26-quick/bundle/pipeline-tier-m.md
+++ b/docs/reviews/2026-04-26-quick/bundle/pipeline-tier-m.md
@@ -1,0 +1,294 @@
+# Standard Development Pipeline - Tier M
+
+Use for: single feature blocks with moderate blast radius - 1–2 collaborators, no complex domain model changes, impact contained to the current feature area.
+Branch prefix `feature/` activates this pipeline automatically.
+
+---
+
+## Which pipeline to use
+
+| Work type | Branch | Pipeline |
+|---|---|---|
+| Low blast radius, single dev, reversible in minutes | `fix/description` | Fast Lane (Tier S) |
+| Single feature, moderate impact, 1–2 collaborators | `feature/block-name` | This pipeline |
+| High blast radius, team, complex domain, shared systems | - | Tier L (full pipeline) |
+
+---
+
+## Phase 0 - Session orientation
+
+- **FIRST**: check for `CONTEXT_IMPORT.md` in the project root. If it exists and contains `Status: PENDING_DISCOVERY`, run the Discovery Workflow inside that file **before any other work**. Do not proceed to Phase 1 until discovery is marked `COMPLETE`.
+- **Session file - non-negotiable**: check `.claude/session/` for existing `block-*.md` files.
+  - If one exists: read it immediately - a previous session was interrupted. Resume from the recorded state. Do NOT create a new file.
+  - If none exists: create `.claude/session/block-new-session.md` with the current date and a placeholder skeleton. Rename to `block-[name].md` in Phase 1 once the block name is known.
+  - The session file must exist before any other Phase 0 action runs.
+- Read `.claude/CLAUDE.local.md` to confirm active overrides (if file exists).
+- Read `MEMORY.md` (project root): Active plan + relevant Lessons.
+- If context was compressed: read `docs/implementation-checklist.md` to re-align on current state.
+- **Branch check**: if on `main` or `staging`, stop. Create `feature/block-name` first.
+
+## Phase 1 - Requirements ⏸ STOP
+
+- **Rename session file**: once the block name is determined, rename `block-new-session.md` → `block-[name].md`. Skip if already named correctly (resumed session).
+- Update the session file after every significant decision during requirements definition.
+- Read `docs/implementation-checklist.md` to verify block dependencies.
+- Read the relevant section of `docs/requirements.md`.
+- Check `docs/refactoring-backlog.md` for intersecting entries.
+
+- **Block mode selection** - auto-select based on block signals, declare the selected mode with a one-line rationale, then proceed. User can override at any point before the STOP gate.
+
+  **Mode A - Spec-first** (auto-selected when any signal is present):
+  - Tier 2 sweep is triggered (>5 files, new entity, migration, multi-role change)
+  - New feature with unclear or evolving shape
+  - New API endpoint or contract change
+  - Multi-component work
+
+  **Mode B - Scope-confirm** (auto-selected when all signals are absent):
+  - Tier 1 sweep (≤5 files, single entity, no migration, no new pattern)
+  - Refactor, bug fix, or isolated change with clearly bounded scope
+
+  Declare: *"Mode A - Spec-first [or B - Scope-confirm]: [one-line rationale]. Override if needed."* Then proceed immediately to the scope sweep.
+
+- **Scope sweep** - select Tier 1 or Tier 2 based on block signals, declare it, allow the user to override:
+
+  **Tier 1 - Standard Sweep** (≤5 files, single entity, no migration, no new pattern):
+  - **Roles & permissions**: which roles are in scope? Any implicit inclusion?
+  - **Data**: entities read/written? Silent data loss possible?
+  - **Triggers**: what user action activates this? Secondary triggers?
+  - **Error conditions**: invalid input, missing data, concurrent edits - behavior defined?
+  - **UI states**: empty, error, loading covered?
+  - **Integrations**: emails, notifications, external systems affected?
+  - **Reversibility**: any irreversible operation? Rollback defined?
+  - **Explicit exclusions**: what is NOT being done that a reader might assume is included?
+
+  **Tier 2 - Deep Sweep** (>5 files, OR new entity, OR migration, OR multi-role change):
+  - All Tier 1 dimensions, plus:
+  - **States** `WHILE`: which entity states or user states affect behavior?
+  - **Conditions** `IF/THEN`: preconditions that change behavior? Edge cases?
+  - **Optional / role-gated** `WHERE`: what is conditional on role or config?
+  - **Pre-mortem**: if this plan fails in implementation due to scope ambiguity, what caused it?
+
+  Also declare: **does this block include critical UI flows?** (yes/no). Determines whether Phase 4 activates.
+  - If **yes** and `[E2E_COMMAND]` is configured: ask the user to list numbered UAT scenarios (1–5). Claude tests exactly those - no invented scenarios.
+  - If **no** or `[E2E_COMMAND]` is `# not configured`: Phase 4 is skipped. State this explicitly.
+
+  Compose one `AskUserQuestion` with all open items from the sweep. Do NOT proceed to the dependency scan until an execution keyword is received.
+
+- **Dependency scan** (mandatory - always run `/dependency-scan`):
+  Run `/dependency-scan` with the full list of affected routes, components, types/utilities, and DB tables. Every file listed under "Mandatory additions" must be in the file list before the STOP gate.
+
+- **Path A - Spec-first**: generate `docs/specs/[block-name].md` using this structure:
+
+  ```markdown
+  # Spec - [block-name]
+  **Date**: [date]  **Sweep**: [Tier 1 / Tier 2]  **Mode**: Spec-first
+
+  ## Goal
+  [One sentence: what changes for the user when this block ships.]
+
+  ## Acceptance Criteria
+  - WHEN [trigger], the system MUST [outcome] [measurable constraint]
+  - WHEN [trigger], the system MUST [outcome]
+  - IF [precondition], THEN [behavior]
+  (3–5 criteria. EARS format: WHEN/IF/WHILE + MUST/SHALL.)
+
+  ## Scope
+  **In scope** (confirmed by dependency scan): [file or component list]
+  **Out of scope** (explicit): [what is NOT being done]
+
+  ## Definition of Done
+  - [ ] All acceptance criteria verified manually
+  - [ ] Tests cover the criteria above
+  - [ ] Phase 6 checklist signed off
+  ```
+
+  Present the spec. Do not proceed to Phase 2 until the spec is explicitly approved.
+
+- **Path B - Scope-confirm**: output feature summary + complete file list verified by dependency scan. Present for confirmation.
+
+***** STOP - Path A: spec review. Path B: requirements summary. Wait for explicit confirmation before Phase 2. *****
+
+## Phase 1.5 - Design review *(blocks touching >5 files or introducing new patterns)*
+
+- Present data flow, data structures, main trade-offs.
+- State discarded alternatives and rationale.
+- Skip for simple blocks (≤3 files, no shared types, no migration, no new patterns).
+- **All clarification questions arising during design review must use the `AskUserQuestion` tool** - no inline open questions.
+
+***** STOP - wait for design confirmation before writing code. *****
+
+## Phase 2 - Implementation
+
+- Update `docs/requirements.md` with the approved plan before writing any code.
+- Follow all coding conventions in `CLAUDE.md`.
+- **After every new migration**: apply to remote DB immediately + verify + log in your project's migrations log (e.g. `docs/migrations-log.md`) if one is tracked.
+- **Security checklist** (before intermediate commit): for every new/modified API route: (1) auth check before any operation, (2) input validated, (3) no sensitive data exposed in response, (4) access control not bypassed. For every new DB table: (5) row-level access control enabled (database-level RLS or application-level guards).
+- Run `/simplify` on changed files after writing (skip for trivial 1-file changes).
+
+## Phase 3 - Build + tests
+
+- Run type check: `[TYPE_CHECK_COMMAND]` - must be clean.
+- Run build: `[BUILD_COMMAND]` - must succeed.
+- Run tests: `[TEST_COMMAND]` - all must pass.
+- Output: summary line only (e.g. `✓ 42/42`). Do NOT paste full output.
+- **Intermediate commit** after green: `git add … && git commit -m "feat(scope): description"`
+
+## Phase 3b - API integration tests *(if block creates or modifies API routes)*
+
+- Write core tests covering:
+  - Happy path: expected status code + key fields in response body
+  - Auth: no token → 401
+  - Authz: unauthorized role → 403
+  - Validation: invalid payload or missing required field → 400
+  - Business rules: application constraint violation → correct error code
+  - DB state: after write, verify expected record with a privileged client
+- [TEST_CLEANUP_PATTERN]
+- Run `[TEST_COMMAND] [API_TESTS_PATH]` - all green before proceeding.
+
+## Phase 4 - UAT / E2E tests *(conditional - read before skipping)*
+
+**This phase activates only when both conditions hold**:
+1. `[E2E_COMMAND]` is set in CLAUDE.md Key Commands (not `# not configured`)
+2. At the Phase 1 scope gate, the user confirmed critical UI flows and defined the UAT scenarios
+
+If either condition is false: **skip this phase and state so explicitly** - do not proceed silently.
+
+- Implement exactly the numbered UAT scenarios defined by the user at the Phase 1 scope gate. Do not add, remove, or reinterpret scenarios.
+- Use `data-*` attribute selectors - never CSS color classes or positional selectors.
+- Each scenario becomes one test: scenario title as test name, steps as the test body.
+- Run: `[E2E_COMMAND]`
+- Output: summary line only (`✓ N/N`). On failure: list the failing scenario by name.
+
+## Phase 5b - Test data setup *(before smoke test)*
+
+- Identify the test account(s) from the role scope of the block.
+- Insert representative test records covering all relevant states.
+- Goal: the test account has realistic data for every UI state that must be visible during smoke.
+
+## Phase 5c - Staging deploy + smoke test
+
+- Start the dev server if needed: `[DEV_COMMAND]`. Declare the endpoint before proceeding.
+- Merge to staging: `git checkout staging && git merge feature/block-name --no-ff && git push origin staging`
+- Wait for deploy. Open staging URL and verify the main flow in 3–5 steps using a test account.
+- For blocks with UI changes: verify in both light and dark mode.
+- Output: "smoke test OK" or describe the problem and fix before proceeding.
+- Fix issues on `feature/` branch, re-merge if needed.
+
+## Phase 5d - Block-scoped quality audit *(blocks with UI or API changes)*
+
+**Track A - UI audit** *(if block adds/modifies UI routes or components - web applications only; skip for CLI, backend-only, or native projects)*
+- Run `/ui-audit` scoped to the block's new/modified routes only (token compliance, component adoption, empty states).
+- Run `/accessibility-audit` scoped to the block's new/modified routes (WCAG 2.2, contrast, static a11y patterns).
+- Run `/visual-audit` scoped to the block's new/modified pages (typography, spacing, hierarchy, colour, density, dark-mode, micro-polish).
+- Run `/ux-audit` scoped to the block's user flows (task completion, feedback clarity, cognitive load).
+- Run `/responsive-audit` only if the block modifies routes used by non-admin roles.
+- **Execution order**: `/ui-audit` is static - launch it concurrently with the first browser-based skill. Then: `/accessibility-audit` → `/visual-audit` → `/ux-audit` → `/responsive-audit` sequentially (they share the browser session).
+
+**Track B - API/DB + compliance audit** *(if block creates/modifies API routes, applies migrations, or handles PII - static analysis, no dev server needed)*
+- Run `/security-audit` if the block creates or modifies any API route.
+- Run `/api-design` if the block adds new API routes. Both are static - run them concurrently.
+- Run `/api-contract-audit` if the block modifies OpenAPI spec or API routes - checks contract drift, breaking changes, Richardson Maturity.
+- Run `/migration-audit` if the block applies migrations - static analysis of migration files.
+- Run `/skill-db` if the block changes the schema or adds new tables - live verification of schema state, access control policies, and query patterns.
+- Run `/compliance-audit` if the block touches PII fields, user-data endpoints, consent flow, or third-party SDK integration - GDPR profile (v1.14); SOC 2 / HIPAA scaffolded for v1.15+.
+
+**Track C - Test + doc + infra audit** *(runs for every block after Phase 3 is green - static analysis, no dev server needed)*
+- Run `/test-audit` - static analysis of coverage (auto-detects lcov / Istanbul / Cobertura / go / tarpaulin / xcresult), pyramid shape (unit/integration/e2e ratio), anti-patterns (`.only` leaks, skipped tests, empty bodies, no-assertion tests, hardcoded sleeps).
+- Run `/doc-audit` - static doc-drift check (relative-link resolution, code-block syntax, CDK placeholder residuals, slash-command name match, skill-count consistency, ADR freshness). Stack-aware for Next.js / Django / Swift.
+- Run `/infra-audit` - static infra-security check across GitHub Actions, Dockerfile, Kubernetes manifests, Terraform, GitLab CI. Each layer runs only if its markers are detected. Stack-agnostic.
+- Output: one-paragraph summary per skill. Critical findings (`.only` committed, 0% coverage on a file changed in this block, CDK placeholder in README, pwn-request in workflow, secret logging in CI, privileged K8s container, IAM wildcard action, hardcoded secret in Terraform) block Phase 6.
+
+**Severity handling - all tracks**:
+- **Critical**: fix before Phase 6. Do not proceed with open Critical issues.
+- **Major**: flag in Phase 6 checklist with planned resolution sprint.
+- **Minor**: append to `docs/refactoring-backlog.md` - assign ID prefix (`PERF-`, `API-`, `DB-`, `MIG-`, `SEC-`, `A11Y-`, `DEV-`, `UX-`, `TEST-`).
+- Output per skill: one-paragraph summary only.
+
+## Phase 6 - Outcome checklist ⏸ STOP
+
+Present this checklist with actual results:
+
+```
+## Block checklist - [Block Name]
+
+### Build & Test
+- [ ] Type check: 0 errors
+- [ ] Build: success
+- [ ] Tests: N/N passed
+- [ ] API tests: N/N passed (if Phase 3b executed)
+
+### Implemented features
+- [ ] [feature 1]: [outcome]
+
+### Manual verification steps
+1. [step]
+
+### Files created / modified
+- path/to/file - description
+```
+
+***** STOP - do not declare complete, do not update docs, until explicit confirmation. *****
+
+## Phase 8 - Block closure
+
+Only after explicit confirmation:
+1. **Delete session file**: remove `.claude/session/block-[name].md`.
+   - Proceed only if the user's confirmation unambiguously closes the block.
+   - If the confirmation is ambiguous (partial approval, open questions): ask explicitly before deleting.
+   - Never delete the session file speculatively.
+1b. **Delete first-session guide** (if it exists): remove `.claude/FIRST_SESSION.md`. This file is a one-time onboarding guide - it is no longer needed after the first block completes.
+2. Update `docs/implementation-checklist.md`: mark ✅, add Log row.
+3. Update `CLAUDE.md` only if block introduces non-obvious patterns or changes conventions.
+4. Update `docs/requirements.md` if spec changed during implementation.
+5. If Mode A was used: move `docs/specs/[block-name].md` → `docs/specs/archive/[block-name].md` and mark as `Status: IMPLEMENTED`.
+6. **Lessons capture**: review corrections received during this block. Add any non-obvious pattern rule to `tasks/lessons.md` (rule + why it exists). Do not wait for the next block.
+7. Update `MEMORY.md` (project root) only if new lessons emerged not already documented.
+7. **Canonical doc updates** (conditional - only update docs that exist in the project):
+   - If `docs/sitemap.md` exists and the block added/removed routes: update it now.
+   - If `docs/db-map.md` exists and the block changed the schema: update it now.
+   - If `docs/prd/prd.md` exists: update it to reflect this block's outcomes.
+   - If test counts changed in this block (integration, unit, E2E): update every place the totals appear - README shields.io badges, inline counts in README Testing section, and CLAUDE.md mentions. Stale counts signal an unmaintained project.
+8. **Commit sequence**:
+   - **Commit 1** (already done in Phase 3): source files only.
+   - **Commit 2 - docs**: `docs/` changes + `README.md` if updated.
+   - **Commit 3 - context** (only if updated): `CLAUDE.md` and/or `MEMORY.md` - never mixed with code or docs.
+9. Promote to production: `git checkout main && git merge staging --no-ff && git push origin main`
+
+## Phase 8.5 - Context review + compact
+
+**C1–C3** (grep-only - run in main session):
+Execute checks C1 through C3 from `.claude/rules/context-review.md` using Grep/Glob tools. These are mechanical pattern matches - no judgment needed. Apply any fix before proceeding to C4.
+
+**C4–C12** (judgment-required - run in main session):
+Execute checks C4 through C12 from `.claude/rules/context-review.md` in order.
+Apply any fix before moving to the next check.
+**Complete only when all checks pass.**
+
+**Mandatory closing message** (before `/compact`):
+
+```
+**Block complete ✅ - [Block name]**
+- Implemented: [one-line summary]
+- Tests: type check ✅ · build ✅ · tests N/N ✅ [+ any other phases]
+- Next: [next block name] OR "No next block defined"
+```
+
+This message is **non-negotiable** - never skip it, even if the block was small or the session is long.
+
+Then run `/compact` to free the session context.
+
+---
+
+## Cross-cutting rules
+
+- **Never commit to `main` or `staging` directly.**
+- **STOP gates are hard stops** - not suggestions. Never proceed to the next phase without explicit confirmation.
+- **Execution keywords**: `Execute` · `Proceed` · `Confirmed` · `Go ahead` - these are the only phrases that authorize autonomous action after a STOP gate.
+- **Exception - active Phase 2**: once a plan is confirmed and an execution keyword was given, proceed autonomously through implementation without re-confirming each file edit. The confirmation covers the approved plan, not each step.
+- **Green before commit**: type check + tests must pass before every commit.
+- **Conventional commits**: `feat(scope):`, `fix(scope):`, `docs:`, `chore:` - imperative, under 72 chars.
+- **No unrequested changes**: implement only what was approved in Phase 1.
+- **Dependency scan is mandatory**: always run `/dependency-scan` in Phase 1. Never produce a file list without first running the full scan.
+- **Context hygiene**: if context window reaches ~50% during Phase 2, run `/compact [keep: current implementation state and open TODOs]` before continuing.
+- **Secret hygiene**: never commit `.env*` files, tokens, or credentials.
+- **Read-only ops are always free**: `Read`, `Grep`, `Glob`, `git status/log/diff` may run without prior confirmation - no STOP gate needed for these.

--- a/docs/reviews/2026-04-26-quick/bundle/roadmap-status.md
+++ b/docs/reviews/2026-04-26-quick/bundle/roadmap-status.md
@@ -1,0 +1,149 @@
+# Roadmap Status — Q1-Q4 2026
+
+Single source of truth for development status of roadmap items.
+Updated at block start (start date) and block closure (end date, PR).
+**Prioritization**: ICE framework (Impact × Confidence × Ease, scored 2026-04-17).
+
+**GitHub Project**: claude-dev-kit Roadmap (project #1)
+**Milestones**: Q1 (#1), Q2 (#2), Q3 (#3), Q4 (#4)
+
+## Strategic frame
+
+**Target segments**: solo devs (Tier S) -> small teams (Tier M) -> enterprise (Tier L)
+**Distribution**: open-source CLI (MIT) + paid SaaS layer
+**Defensible moat**: (1) mechanical enforcement (STOP hooks, test gating), (2) stack-aware depth (11 stacks x 4 tiers), (3) cross-project governance (analytics, compliance, historical data)
+**Positioning**: Claude Code only - maximum depth, no multi-tool dilution
+
+---
+
+## Q1 — Foundation and de-risking (closed)
+
+| # | Issue | Title | Status | Start | End | PR |
+|---|---|---|---|---|---|---|
+| 1 | — | Template engine refactor (skill-registry.js) | Done | 2026-03-28 | 2026-04-02 | #46 |
+| 2 | #55 | Skill scaffolder CLI (`cdk new skill`) | Done | 2026-04-12 | 2026-04-12 | #73 |
+| 3 | #56 | Anthropic drift tracker (GitHub Action) | Done | 2026-04-12 | 2026-04-12 | #74 |
+| 4 | #62 | Agent-to-skill conversion | Done | 2026-04-12 | 2026-04-12 | #75 |
+| 5a | #58 | New skill: /test-audit | Done | 2026-04-13 | 2026-04-13 | #79 |
+| 5b | #59 | New skill: /migration-audit | Done | 2026-04-13 | 2026-04-13 | #76 |
+| 5c | #60 | New skill: /accessibility-audit | Done | 2026-04-13 | 2026-04-13 | #77, #78 |
+| 6 | — | Tier L freeze policy | Done | 2026-04-08 | 2026-04-10 | #44 |
+| 7 | — | Pipeline v2: body purity + reference files (17 skills) | Done | 2026-04-14 | 2026-04-17 | #87 |
+| 8 | — | New skill: /skill-review (quality review pipeline) | Done | 2026-04-14 | 2026-04-17 | #87 |
+
+## Q2 — Correctness, documentation, skill breadth
+
+| # | Issue | Title | ICE | Status | Start | End | PR |
+|---|---|---|---|---|---|---|---|
+| 1 | — | `add skill` / `add rule` commands | — | Done | 2026-04-05 | 2026-04-08 | #46 |
+| 2 | #90 | Anthropic spec compliance: `allowed-tools` syntax fix + progressive disclosure (>500 lines) | 441 | Done | 2026-04-24 | 2026-04-24 | v1.11.0 |
+| 3 | #57 | Public documentation site (VitePress) | 432 | Open | — | — | — |
+| 4 | #61 | New skill: /doc-audit (Q1 spillover) | 320 | Done | 2026-04-24 | 2026-04-24 | #112 |
+| 5 | #91 | `doctor` expansion: cross-file scaffold validation (skill↔CLAUDE.md↔settings.json) | 294 | Done | 2026-04-24 | 2026-04-24 | v1.12.0 |
+| 6 | — | CONTRIBUTING.md overhaul | 256 | Done | 2026-04-02 | 2026-04-25 | #46 + #114 |
+| 7 | #66 | New skills: /compliance-audit, /api-contract-audit, /infra-audit | 245 | Done | 2026-04-25 | 2026-04-25 | #113 |
+| 8 | — | External review prompt template: update to v1.10.0 + parameterize | 162 | Open | — | — | — |
+
+## Q3 — Community, DX, team primitives
+
+| # | Issue | Title | ICE | Status | Start | End | PR |
+|---|---|---|---|---|---|---|---|
+| 1 | #92 | Expand to 20+ skills total | 210 | Done | — | 2026-04-25 | reached via v1.13.0 + v1.14.0 |
+| 2 | #93 | `upgrade --anthropic` auto-upgrade command | 210 | Open | — | — | — |
+| 3 | #94 | `team-settings.json` (org-wide skill and model restrictions) | 175 | Open | — | — | — |
+| 4 | — | MCP ecosystem reassessment | 168 | Open | — | — | — |
+| 5 | #64 | `cdk sync` command | 120 | Open | — | — | — |
+| 6 | #97 | Enterprise skills: /dependency-audit, /debt-triage, /privacy-audit | 112 | Open | — | — | — |
+| 7 | #95 | VS Code extension (rule/skill management, doctor integration) | 105 | Open | — | — | — |
+| 8 | #96 | Deep stack specialization for 3 priority stacks | 105 | Open | — | — | — |
+| 9 | #65 | First Contribution campaign | 90 | Open | — | — | — |
+
+## Q4 — Ecosystem and SaaS exploration
+
+| # | Issue | Title | ICE | Status | Start | End | PR |
+|---|---|---|---|---|---|---|---|
+| 1 | #67 | Opt-in CLI telemetry | 100 | Open | — | — | — |
+| 2 | #99 | Public skill registry on docs site | 96 | Open | — | — | — |
+| 3 | — | Case study program (5+ anonymized case studies) | 84 | Open | — | — | — |
+| 4 | — | Formal Anthropic partnership pitch | 60 | Open | — | — | — |
+| 5 | #98 | `cdk sync` automation via GitHub Action | 60 | Open | — | — | — |
+| 6 | #63 | SaaS MVP: web wizard + dashboard | 54 | Open | — | — | — |
+
+## Backlog — Unscheduled (dependency-blocked or demand-unvalidated)
+
+| # | Title | ICE | Blocker |
+|---|---|---|---|
+| 1 | Skill analytics dashboard (usage, pass/fail, time-to-remediate) | 54 | Needs user base + data pipeline |
+| 2 | GitHub MCP for pipeline merge/push (#68) | 48 | MCP ecosystem immature |
+| 3 | SSO integration (GitHub/GitLab OAuth for teams) | 45 | Depends on SaaS MVP |
+| 4 | Compliance reporting with profiles (SOC 2, HIPAA, GDPR) | 32 | No enterprise customers to validate profiles |
+| 5 | Custom STOP gate configuration via SaaS UI | 20 | Depends on SaaS MVP |
+| 6 | SaaS general availability (billing, hardened, documented) | 18 | Depends on SaaS MVP |
+
+---
+
+## Skill expansion plan
+
+Priority-ranked by ICE score. Original 3-model consensus (GPT-4.1, Gemini 2.5 Pro, Mistral Large) used for skill selection; ICE used for sequencing.
+
+| Rank | Skill | Target Q | Status |
+|---|---|---|---|
+| 1 | /test-audit | Q1 | Done (PR #79) |
+| 2 | /migration-audit | Q1 | Done (PR #76) |
+| 3 | /accessibility-audit | Q1 | Done (PR #77) |
+| 4 | /doc-audit | Q2 | Done (PR #112) |
+| 5 | /compliance-audit | Q2 | Done (PR #113, GDPR active) |
+| 6 | /api-contract-audit | Q2 | Done (PR #113) |
+| 7 | /infra-audit | Q2 | Done (PR #113) |
+| 8 | /dependency-audit | Q3 | Open (#97) |
+| 9 | /debt-triage | Q3 | Open (#97) |
+| 10 | /privacy-audit | Q3 | Open (#97) |
+
+---
+
+## Source files for open items
+
+Reference material preserved for when roadmap items are worked on.
+
+| File | Covers roadmap item |
+|---|---|
+| `docs/reviews/anthropic-spec-deviations.md` | Q2 #2 — `allowed-tools` syntax (§2.4), file >500 lines (§2.5), spec reference table (§1) |
+| `docs/reviews/scaffold-verification-prompt.md` | Q2 #5 — 5-section checklist (A-E) for post-scaffold validation |
+| `docs/reviews/external-review-prompt-v1.9.md` | Q2 #8 — 7-question template, needs version number update |
+
+---
+
+## ICE scoring reference
+
+Scored 2026-04-17. Formula: Impact (1-10) × Confidence (1-10) × Ease (1-10).
+
+| Item | I | C | E | ICE |
+|---|---|---|---|---|
+| Anthropic spec compliance | 7 | 9 | 7 | 441 |
+| Public docs site (VitePress) | 9 | 8 | 6 | 432 |
+| /doc-audit | 5 | 8 | 8 | 320 |
+| Doctor expansion | 6 | 7 | 7 | 294 |
+| CONTRIBUTING.md overhaul | 4 | 8 | 8 | 256 |
+| New skills Q2 (compliance, api-contract, infra) | 7 | 7 | 5 | 245 |
+| Expand to 20+ skills | 6 | 7 | 5 | 210 |
+| `upgrade --anthropic` | 5 | 7 | 6 | 210 |
+| `team-settings.json` | 7 | 5 | 5 | 175 |
+| MCP ecosystem reassessment | 4 | 6 | 7 | 168 |
+| External review prompt update | 2 | 9 | 9 | 162 |
+| `cdk sync` | 6 | 4 | 5 | 120 |
+| Enterprise skills Q3 | 7 | 4 | 4 | 112 |
+| VS Code extension | 7 | 5 | 3 | 105 |
+| Deep stack specialization | 7 | 5 | 3 | 105 |
+| Opt-in CLI telemetry | 5 | 4 | 5 | 100 |
+| Public skill registry | 6 | 4 | 4 | 96 |
+| First Contribution campaign | 6 | 3 | 5 | 90 |
+| Case study program | 7 | 3 | 4 | 84 |
+| Anthropic partnership pitch | 10 | 2 | 3 | 60 |
+| `cdk sync` via GitHub Action | 5 | 3 | 4 | 60 |
+| SaaS MVP | 9 | 3 | 2 | 54 |
+| Skill analytics dashboard | 6 | 3 | 3 | 54 |
+| GitHub MCP | 4 | 3 | 4 | 48 |
+| SSO integration | 5 | 3 | 3 | 45 |
+| Compliance reporting | 8 | 2 | 2 | 32 |
+| Custom STOP gate via SaaS | 5 | 2 | 2 | 20 |
+| SaaS GA | 9 | 2 | 1 | 18 |

--- a/docs/reviews/2026-04-26-quick/bundle/security-audit-SKILL.md
+++ b/docs/reviews/2026-04-26-quick/bundle/security-audit-SKILL.md
@@ -1,0 +1,343 @@
+---
+name: security-audit
+description: Security audit: auth/authz on API routes, input validation, RLS policies, response shape review, secret exposure, HTTP headers. Native mode checks entitlements and Keychain.
+user-invocable: true
+model: sonnet
+context: fork
+argument-hint: [target:page:<route>|target:role:<role>|target:section:<section>]
+---
+
+## Configuration (adapt before first run)
+
+> Replace these placeholders:
+> - `[SITEMAP_OR_ROUTE_LIST]` - file listing all API routes with method, path, roles, and grouping - e.g. `docs/sitemap.md`, `docs/routes.md`. If not configured, the skill discovers routes by scanning the project's route handler directories. Announce the discovered routes before proceeding.
+
+**Scope**: API routes, middleware/proxy, row-level access control policies, data validation, response shapes, environment variables, database configuration, dependencies. For native stacks: secrets management, platform security (Keychain/Keystore/entitlements), input validation, signing credentials, sensitive data protection.
+**Out of scope**: SEO, robots.txt, public crawlability, OpenGraph, sitemap.xml.
+**Do NOT make code changes. Audit only.**
+**All findings go to `docs/refactoring-backlog.md`.**
+
+---
+
+## Applicability check
+
+Before any other step: read `CLAUDE.md` and check the Framework and Language fields.
+
+- **Web or API project** (Framework is NOT `N/A - native app`, OR route handler directories exist): proceed to **Step 0** - full web audit (Steps 0–5) + Step 3e if the language is non-JS.
+- **Native with API** (Framework is `N/A - native app` AND route handler directories exist): proceed to **Step 0** - full web audit (Steps 0–5) + Step 3e (native checks run in addition to web checks).
+- **Native only** (Framework is `N/A - native app` AND no route handler directories): skip Steps 0–5. Proceed directly to **Step 3e** (native-only audit). Then skip to **Step 6** for the report.
+
+Announce the execution path: `Running security-audit - mode: [WEB | WEB+NATIVE | NATIVE-ONLY]`
+
+---
+
+## Step 0 - Target resolution
+
+Parse `$ARGUMENTS` for a `target:` token.
+
+| Pattern | Meaning |
+|---|---|
+| `target:role:admin` | Focus on admin routes |
+| `target:section:export` | Focus on all export/bulk-data routes |
+| `target:section:<other>` | Read `[SITEMAP_OR_ROUTE_LIST]` - find rows matching the section keyword, resolve to API routes and related route files |
+| No argument | Full audit - all API routes |
+
+Announce: `Running security-audit - scope: [FULL | target: <resolved>]`
+Apply the target filter to the route inventory built in Step 1.
+
+---
+
+## Step 1 - Build API route inventory
+
+Also read:
+- Auth helper files (e.g. `lib/auth.ts`, `utils/auth.py`) - understand session/token helpers
+- `docs/refactoring-backlog.md` - avoid duplicates
+
+Output: complete list of API routes grouped by:
+- **Public** (no auth required)
+- **Protected** (auth required, any role)
+- **Role-specific** (grouped by functional section per `[SITEMAP_OR_ROUTE_LIST]`)
+- **Export routes** (bulk data endpoints returning CSV or XLSX)
+
+Apply target scope from Step 0 before proceeding.
+
+---
+
+## Step 2 - Auth, authorization, and injection checks (Explore agent)
+
+Launch a **single Explore subagent** (model: haiku) with the full route file list. Read `${CLAUDE_SKILL_DIR}/PATTERNS.md` for stack-specific grep patterns used across all checks.
+
+**CHECK A1 - Missing auth check at route entry**
+Pattern: route handler function body does NOT contain any auth verification call within the first 20 lines.
+Grep: for each route file, check if any auth pattern from PATTERNS.md → A1 appears within the first 20 lines of the handler function. Flag any route file where none appear.
+Note: service-role-only routes must still verify the caller's role - a privileged client alone is not an auth check.
+
+**CHECK A2 - Role check present for admin routes**
+Flag: any admin route without an explicit role assertion.
+
+**CHECK A3 - Input validation on request body, path params, and query params**
+Pattern A (body): route files handling POST/PUT/PATCH must validate the request body using a validation library before processing.
+Grep: in all write route files, check for validation patterns from PATTERNS.md → A3.
+Flag: any write route without validation on the request body.
+Flag: raw path params fed into DB queries without format validation - an invalid format causes a DB error, leaking implementation details.
+Pattern C (query params): grep all route files for user-provided query parameters whose return value is used in DB filter calls without an explicit allowlist or schema validation.
+Flag: unvalidated query params used as DB filter inputs.
+
+**CHECK A4 - Raw user input in SQL/queries**
+Pattern: template literals or string concatenation used to build database queries with user-provided values.
+Grep: string interpolation or concatenation in query construction - see PATTERNS.md → A4 for stack-specific patterns.
+Flag: any query built with string concatenation from user input. Use parameterized queries instead.
+
+**CHECK A5 - Sensitive fields in API responses**
+Pattern: API routes returning full objects that may include sensitive fields.
+Grep: routes selecting all columns (see PATTERNS.md → A5) AND returning the full result to the client without explicit field filtering.
+
+**CHECK A6 - Cron/job routes missing secret check**
+Flag: any job/cron route that does NOT verify a shared secret or API key before execution.
+
+**CHECK A7 - Export routes missing role check**
+Scope: any route file whose path contains 'export' or that returns `Content-Type: text/csv` or `application/vnd.openxmlformats`.
+Grep: files containing `text/csv|Content-Disposition.*attachment|application/vnd.openxml`.
+Flag: any export route without an explicit role assertion.
+
+**CHECK A8 - Client-exposed environment variable secret leak**
+Scope: all source files and `.env*` files.
+Pattern: environment variables with client-side prefixes (see PATTERNS.md → A8 for framework prefix list) whose names contain secret-like suffixes (`KEY`, `SECRET`, `TOKEN`, `PASSWORD`).
+Flag: any client-prefixed variable that contains a secret-like suffix. These variables are inlined into the client bundle and visible to all users.
+Note: public API URLs and non-secret anon keys are expected - exclude those.
+
+**CHECK A9 - Privileged credentials in client-side code**
+Scope: all client-side source files (see PATTERNS.md → A9 for client-side markers per framework).
+Pattern: grep for privileged credential references (see PATTERNS.md → A9 for credential patterns).
+Flag: any match. Privileged credentials bypass access control - their presence in client-side code exposes them to every user.
+
+**CHECK A10 - Public URL for private storage assets**
+Scope: all route files and utility files that handle file/document/attachment operations.
+Pattern: public URL generation (see PATTERNS.md → A10) in files that handle private assets (documents, contracts, receipts).
+Flag: any public URL call for a private asset. Private assets must use signed/temporary URLs with a TTL.
+Note: explicitly public storage (avatars, public uploads) is expected - exclude those.
+
+**CHECK A11 - Open redirect**
+Pattern: redirect calls where the URL argument derives from user-controlled input (query params, request body, path params) without an explicit allowlist check.
+Flag: any redirect where the target URL is constructed from user-controlled input.
+
+**CHECK A12 - Mass assignment**
+Scope: all route files handling POST/PUT/PATCH.
+Pattern: find where the raw request body object is passed wholesale to a DB write operation without explicit field destructuring or schema validation first.
+Flag: any route where the raw body is inserted/updated directly.
+Note: routes that validate through a schema before inserting are safe - exclude those.
+
+**CHECK A13 - Horizontal access control / IDOR**
+For each dynamic route:
+Step 1 - identify how the caller's identity is resolved (grep for auth patterns from PATTERNS.md → A1).
+Step 2 - verify that the DB query filters by the caller's identity or scope, not just by the URL parameter alone.
+Insecure pattern: filtering only by the requested ID without verifying ownership - any authenticated user can access any record by guessing IDs.
+Flag: each route where ownership/scope is not enforced server-side in the query.
+
+**CHECK A14 - State machine enforcement on transition routes**
+For each status-changing route:
+Step 1 - verify the route reads the CURRENT state from the DB before applying the transition (grep for a SELECT/read query before the UPDATE in the same handler).
+Flag: any transition route that does NOT verify current state server-side before applying the update. Skipping a required intermediate state is both a business logic violation and a potential abuse path."
+
+---
+
+## Step 3 - Response shape review (main context)
+
+For the 10 most-used API routes (identified from `[SITEMAP_OR_ROUTE_LIST]`):
+
+**R1 - Sensitive field exposure**
+Identify fields containing PII, financial data, or credentials (e.g. tax IDs, bank account numbers, password flags). Verify these are NOT returned to non-admin/non-owner callers.
+
+**R2 - Financial/restricted data exposure**
+Verify that financial records, compensation data, or other restricted entities are not exposed beyond their authorized audience.
+
+**R3 - Error message verbosity**
+Scan 5 route handlers for error handling blocks. Verify internal error messages (DB errors, stack traces) are NOT forwarded to the client response.
+Expected: generic error messages returned to client - never raw error details that may contain schema or internal state information.
+
+**R4 - Domain data scoping**
+Users can only see records scoped to their ownership or authorized scope (via ownership checks, row-level policies, or equivalent access control).
+
+**R5 - Rate limiting on high-value endpoints**
+- Any export route (bulk data)
+- Any bulk-action route
+Note: absence of rate limiting is a Medium finding for an internal app - flag it, don't treat as Critical.
+
+---
+
+## Step 3b - Database security advisors *(if available)*
+
+If your database platform provides automated security advisors (e.g. Supabase Security Advisors via MCP, AWS RDS recommendations), run them and include results:
+
+For each finding returned:
+- Error/critical level → **Critical** finding
+- Warning level → **High** finding
+- Info level → **Low** / informational
+
+Include the full list in the report output. Do not suppress any result.
+If no automated advisors are available, skip this step and note it in the report.
+
+---
+
+## Step 3c - Dependency CVE audit
+
+Run the appropriate dependency audit for the project's package manager:
+- Node.js: `npm audit --json --omit=dev` or `yarn audit --json`
+- Python: `pip-audit` or `safety check`
+- Ruby: `bundle-audit check`
+- Go: `govulncheck ./...`
+- Rust: `cargo audit`
+- Java/Kotlin: `mvn dependency-check:check` or `./gradlew dependencyCheckAnalyze`
+- .NET: `dotnet list package --vulnerable`
+- Swift: check Package.resolved for known CVEs
+
+For each finding, record:
+- Package name and affected version range
+- CVE ID (if available)
+- Brief description
+- Whether a fix is available
+
+Flag any `critical` CVE in a production dependency as a **Critical** finding.
+Flag any `high` CVE as a **High** finding.
+`moderate` and `low` → note in report but do not add to backlog unless directly exploitable in this app's context.
+
+If the audit command fails or is unavailable, note it and skip.
+
+---
+
+## Step 3d - Row-level access control completeness check
+
+Complement Step 3b (DB advisors) with a grep-based check on migration or schema files.
+
+**RLS-1 - Tables without row-level access control**
+Grep migration/schema files for table creation statements. For each table, check if row-level access control is enabled (e.g. `ENABLE ROW LEVEL SECURITY` in PostgreSQL, application-level guards in other stacks).
+Flag: any table storing user-scoped data where row-level access control is absent.
+Note: tables with only service-role access (e.g. internal log tables) may legitimately skip this - verify from context.
+
+**RLS-2 - Access control enabled but no policies**
+For each table with row-level access control enabled, verify that at least one access policy exists.
+Flag: any table with access control enabled but zero policies. This can cause silent empty results, masking bugs.
+
+**RLS-3 - Missing write-side policy checks**
+For databases with row-level policies: verify that INSERT/UPDATE policies include write-side checks (e.g. `WITH CHECK` in PostgreSQL).
+Flag: policies that control reads but not writes - this allows inserting/updating rows the user cannot see.
+
+---
+
+## Step 3e - Native application security checks
+
+**This step runs only when the project uses a native or non-web stack** (check CLAUDE.md Language field: Swift, Kotlin, Rust, Go, Python, Ruby, Java, C#). For web-only projects (Node.js/TypeScript with a web frontend), skip to Step 4.
+
+These checks supplement the API-level checks in Step 2. They audit the application's own security posture beyond its HTTP surface.
+
+### Stack-specific security checklist
+
+[SECURITY_CHECKLIST_ITEMS]
+
+### NS1 - Secrets management audit
+Grep all source files for patterns that indicate hardcoded secrets:
+- String literals containing `password`, `secret`, `token`, `key`, `api_key` (case-insensitive)
+- Base64-encoded strings longer than 40 characters in source (potential embedded credentials)
+- Configuration files committed to git that contain non-placeholder secret values
+
+Flag: each hardcoded secret. Secrets must come from environment variables, platform keychain, or a secrets manager.
+
+### NS2 - Dependency vulnerability scan
+Run the same dependency audit as Step 3c (adapt the command to the native stack's package manager).
+Flag: Critical/High CVEs as Critical/High findings. Medium/Low CVEs noted in report.
+
+### NS3 - Input validation on external boundaries
+For each entry point (CLI args, file parsing, IPC, network input, URL schemes, deep links, clipboard data):
+- Verify input is validated/sanitized before use
+- Check for path traversal in file operations (user input in file paths)
+- Check for command injection (user input passed to shell execution or subprocess)
+- Check for buffer overflow risk in languages without bounds checking
+
+Flag: each unvalidated external input.
+
+### NS4 - Platform security checks
+Execute each item from the stack-specific checklist above as a targeted grep/read check. See PATTERNS.md → NS4 for per-language grep patterns and flag conditions.
+
+Flag: each violation with severity based on exploitability.
+
+### NS5 - Sensitive data protection
+- Verify sensitive data written to disk uses platform encryption (see PATTERNS.md → NS4 for platform-specific mechanisms)
+- Check that temporary files with sensitive content are deleted after use
+- Verify no sensitive data in logs (grep for log/print statements near secret/token/password handling)
+- Check that error messages do not expose internal state or stack traces to users
+
+Flag: each unprotected sensitive data path.
+
+### NS6 - Code signing and distribution
+- No signing credentials, provisioning profiles, or keystores committed to repository (grep for `.p12`, `.mobileprovision`, `.keystore`, `.jks`, `.pem`, `.key` in tracked files)
+- No disabled code signing workarounds in build config
+- CI/CD signing credentials sourced from environment variables or secure storage, not checked-in files
+
+Flag: each signing credential in repository as Critical.
+
+---
+
+## Step 4 - HTTP security headers check
+
+**Static check**: read the server/framework configuration file (e.g. `next.config.ts`, `nginx.conf`, `helmet()` config). Verify these headers are configured:
+
+| Header | Expected | Risk if missing |
+|---|---|---|
+| `X-Frame-Options` | `DENY` or `SAMEORIGIN` | Clickjacking |
+| `X-Content-Type-Options` | `nosniff` | MIME sniffing |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` | Referrer data leakage |
+| `Content-Security-Policy` | Present (even permissive) | XSS escalation |
+| `Permissions-Policy` | camera/mic/geolocation denied | Feature abuse |
+
+**Live check** (staging): curl the staging URL and compare actual headers received vs configuration. A header present in config but absent in the response indicates a misconfiguration.
+
+Flag: any header present in config but absent in live response - this means the config is ineffective.
+
+---
+
+## Step 5 - Proxy / middleware check
+
+- API routes are not accessible without a valid session token (no CORS bypass path)
+- Auth-gated redirects (e.g. password change, onboarding) are enforced at the server/proxy level, not just client-side
+- Public route whitelists are narrow - specific paths only, not wildcard prefixes that could expose other routes
+- Each whitelisted path has a comment explaining why it is public
+- The proxy does not trust any header that could be forged by the client to bypass auth (e.g. `X-User-Role`, `X-Is-Admin`)
+
+---
+
+## Step 6 - Produce report and update backlog
+
+### Output format
+
+Generate the report using the template in `${CLAUDE_SKILL_DIR}/REPORT.md`. Apply the severity guide from the same file.
+
+### Backlog decision gate
+
+Present all findings with severity Medium or above as a numbered decision list, sorted Critical → High → Medium:
+
+```
+Found N findings at Medium or above. Which to add to backlog?
+
+[1] [CRITICAL] SEC-? - route/file - one-line description
+[2] [HIGH]     SEC-? - route/file - one-line description
+[3] [MEDIUM]   SEC-? - route/file - one-line description
+...
+
+Reply with numbers to include (e.g. "1 2 4"), "all", or "none".
+```
+
+**Wait for explicit user response before writing anything.**
+
+Then write ONLY the approved entries to `docs/refactoring-backlog.md`:
+- Assign ID: `SEC-[n]`
+- Add to priority index
+- Add full detail section with exploit scenario and recommended fix
+
+---
+
+## Execution notes
+
+- Do NOT modify any route, config, or migration file.
+- SEO, robots.txt, meta tags, sitemaps, and public indexing are explicitly OUT OF SCOPE.
+- **Server-side form actions**: if the framework supports server-side form actions (e.g. Next.js Server Actions, SvelteKit form actions, Remix actions), treat them as directly-reachable POST endpoints and audit with the same auth/authz/validation checks. Note as N/A if absent.
+- After the report, ask: "Should I implement the Critical/High fixes identified?"

--- a/docs/reviews/2026-04-26-quick/prompt.md
+++ b/docs/reviews/2026-04-26-quick/prompt.md
@@ -1,0 +1,105 @@
+---
+title: External LLM Review Prompt — claude-dev-kit
+version: 1.16.0
+last_synced: 2026-04-26
+target_release: "1.16.0"
+focus_area: "general"
+audience: GPT-4.1, Gemini 2.5 Pro, Mistral Large, Perplexity Sonar Pro, Claude (fresh-context)
+---
+
+# External LLM Review Prompt — claude-dev-kit
+
+> Sync the **version** + **last_synced** fields above when CDK ships a new release.
+> Replace `1.16.0` and `general` placeholders with the run-time values before fanning out to providers.
+> The bundle is auto-assembled by `scripts/external-review-bundle.mjs` (run via the `/external-review` skill).
+
+---
+
+You are reviewing an open-source CLI tool called **claude-dev-kit** (CDK). It scaffolds a governance layer on top of Claude Code (Anthropic's agentic coding CLI). The scaffold provides structured development pipelines, audit skills, security rules, process controls, and team-wide governance primitives.
+
+You have **no prior memory** of this project. Treat the attached bundle as the only source of truth. If a claim in the bundle isn't supported by another file in the bundle, flag it.
+
+## What CDK does
+
+- `npx mg-claude-dev-kit init` runs an interactive wizard
+- Outputs: `CLAUDE.md` (project context, ≤200 lines), `.claude/settings.json` (permissions + Stop hook), `.claude/rules/` (pipeline, security, git, output-style), `.claude/skills/` (audit slash-commands), `.claude/team-settings.json` (team-wide policy, opt-in)
+- Four tiers: Discovery (3 files, no pipeline), Fast Lane / Tier S (4-step pipeline, 1 scope-confirm), Standard / Tier M (8 phases, 2 STOP gates), Full / Tier L (11 phases, 4 STOP gates + audit cycle)
+- Stack-aware: auto-detects 11 tech stacks (Node-TS, Node-JS, Python, Go, Swift, Kotlin, Rust, .NET, Ruby, Java, generic), adapts security rules, permissions, commands, and skill checks
+- 20 audit skills with model routing: haiku for mechanical checks, sonnet for analysis, opus for visual reasoning. Skills are conditionally installed per project flags (`hasApi`, `hasDatabase`, `hasFrontend`, `hasDesignSystem`).
+- Three governance flags ship in the scaffold and are enforced mechanically: a Stop hook blocks task completion until tests pass, CODEOWNERS gates `.claude/` changes behind review, and `team-settings.json` (v1.16+) lets a team enforce `minTier`, `allowedSkills`, `blockedSkills`, `requiredSkills` across every clone.
+
+## Current state (1.16.0)
+
+- 365 unit tests, 1000 integration checks, all passing
+- 28 doctor checks (validation surface)
+- GitHub Actions CI: Node 22/24 matrix, Lint, Unit, Integration, Verify CLI, Drift tracker, CodeQL, dependency-review
+- ESLint + Prettier
+- Published on npm as `mg-claude-dev-kit`
+- Single maintainer, used on 2-3 real projects, npm adoption metric not yet validated (registry currently lags local versioning)
+- Roadmap is ICE-prioritized across Q1–Q4 2026; Q1+Q2 mostly shipped; Q3 has 3 of 9 items shipped through v1.16.0
+
+## Focus area for this run
+
+general
+
+> If `general` is `general`, treat the seven questions as full-coverage. If it names a specific dimension (e.g., `architecture`, `competitive-position`, `team-adoption`, `pricing`, `enterprise-readiness`), give that dimension extra depth and use the others as supporting context.
+
+## Attached files (auto-bundled)
+
+1. **README.md** — full product documentation
+2. **CHANGELOG.md** — last three releases (v1.14, v1.15, v1.16) so the change cadence is visible
+3. **security-audit SKILL.md (Tier M)** — example of a complex audit skill with 3-path stack-aware selector
+4. **pipeline.md (Tier M)** — example of the standard pipeline tier with two STOP gates
+5. **roadmap-status.md** — ICE-ranked roadmap snapshot (Q1–Q4 2026 + backlog)
+
+## Questions
+
+Answer each with specific, actionable feedback. No flattery — treat this as a paid code review. If you don't have enough information from the bundle to answer, say so explicitly rather than speculating.
+
+1. **Strongest aspect**: what is the single most valuable thing CDK does that other AI coding tools/frameworks don't?
+
+2. **Weakest aspect**: what is the biggest weakness or gap that would prevent adoption? Be specific — name what's missing and why it matters.
+
+3. **Competitive position**: how does this compare to Cursor rules (`.cursorrules`), Windsurf rules, Aider conventions, raw `CLAUDE.md` files, and Claude Code's native skills/permissions system? What does CDK offer beyond what a senior engineer could build in an afternoon? What does it offer beyond what a $20/month subscription to one of the competitors already provides?
+
+4. **Adoption barrier**: what would make a team of 5–10 engineers adopt this over writing their own `CLAUDE.md` + rules? What's the pitch they'd respond to? What objection would kill the deal?
+
+5. **Single highest-impact improvement**: if you could make one change to CDK over the next quarter, what would it be? Not a wish list — one specific change with the most leverage. Cite the roadmap item it maps to (or argue why it's missing from the roadmap).
+
+6. **Architecture concern**: is there anything in the design that would become a maintenance burden or create scaling problems as the tool grows? Consider: skill count growth (20 → 40 → 100), tier count, stack count, doctor check count, pipeline complexity per tier, drift between scaffolded files and template files.
+
+7. **What should be removed**: is there anything in CDK that adds complexity without proportional value? Over-engineering signals? Features the bundle suggests aren't pulling their weight?
+
+## Output format
+
+Use this exact structure:
+
+```
+## [Model name] Review — CDK 1.16.0
+Date: [ISO date]
+Focus area: general
+
+### 1. Strongest aspect
+[answer]
+
+### 2. Weakest aspect
+[answer]
+
+### 3. Competitive position
+[answer]
+
+### 4. Adoption barrier
+[answer]
+
+### 5. Single highest-impact improvement
+[answer — name the roadmap item if applicable, else propose a new item with rough ICE]
+
+### 6. Architecture concern
+[answer]
+
+### 7. What should be removed
+[answer — be specific; "nothing" is acceptable if defended]
+
+### Overall assessment
+[2-3 sentences. End with a single-line one-of: SHIP / SHIP-WITH-RESERVATIONS / DO-NOT-SHIP and a one-sentence reason.]
+```

--- a/docs/reviews/2026-04-26-quick/responses/claude-fresh.md
+++ b/docs/reviews/2026-04-26-quick/responses/claude-fresh.md
@@ -1,0 +1,67 @@
+## Claude (general-purpose, fresh context) Review — CDK 1.16.0
+Date: 2026-04-26
+Focus area: general
+
+### 1. Strongest aspect
+The Stop hook + CODEOWNERS + `team-settings.json` triad is the strongest piece, and specifically the **Stop hook**: it is a mechanically enforced contract (`npm test || decision: block`) that fires inside Claude Code itself and prevents the agent from declaring done while red. Cursor rules, `.cursorrules`, Aider conventions, and raw `CLAUDE.md` are all advisory text that the model can rationalize past. CDK turns "tests must pass" from a prompt instruction into a runtime gate. Pair that with the 28-check `doctor` validating the scaffold and the new `team-settings.json` propagating `minTier` / `allowedSkills` / `blockedSkills` across clones, and CDK is the only tool in the bundle's competitive set that ships *enforcement* rather than *suggestion*.
+
+### 2. Weakest aspect
+**Governance is enforced only when the user runs the CDK CLI.** The 1.16.0 release notes admit it directly: "Claude Code sessions can still invoke skills directly" because `Skill()` permission rules aren't in Anthropic's documented public schema. This is a credibility hole. The whole pitch is mechanical enforcement, but the headline 1.16 feature (`team-settings.json`) is bypassed by typing `/security-audit` in a session — the exact path most users take. A team adopting CDK for "team-wide governance" (README claim) gets advisory governance with extra steps. Until upstream lands or you ship a Stop-hook-style runtime check that reads `team-settings.json`, this feature is positioning ahead of capability.
+
+A secondary weakness: the bundle never quantifies **time-to-value**. There are 28 doctor checks, 20 skills, 11 stacks, 4 tiers, 8 phases at Tier M, 14 at Tier L, and a 295-line pipeline.md with two STOP gates and a Phase 8.5 context review. A 5–10 person team needs to know the cost of this in week one, and the README does not say.
+
+### 3. Competitive position
+Versus `.cursorrules` / Windsurf / Aider conventions / raw `CLAUDE.md`: these are single-file prompt augmentations. CDK is structurally different — multi-file scaffold, conditional skill installation per project flags, stack-specific variants, doctor validation, CLI lifecycle (`init`/`upgrade`/`add`/`doctor`). A senior engineer cannot replicate this in an afternoon. They can replicate a `CLAUDE.md` and a Stop hook in an afternoon — that is roughly Tier 0 — but they cannot replicate `/security-audit` SKILL.md (15 numbered checks A1–A14, native NS1–NS6, framework-aware grep patterns externalized to PATTERNS.md) without a week of work, and they cannot maintain it against Anthropic spec drift without the drift tracker.
+
+Versus Claude Code's native skills/permissions: CDK is a **content layer** on top, not a competitor. It is meaningful only because the native layer is bare. The risk is exactly the gap exposed in #2: as Anthropic ships native team policy, native skill permissions, and native `Skill()` permission rules, CDK's CLI-side enforcement becomes redundant and CDK is reduced to "a curated skill library with a wizard." The defensible piece long-term is the **skills themselves** (security-audit, infra-audit, compliance-audit) and the **stack-aware patterns**, not the governance scaffolding.
+
+Versus a $20/month subscription: a Cursor/Windsurf user gets fast inline completion and a chat panel; CDK gets you a 4-tier development *process*. These solve different problems. CDK competes with "team standards docs + a senior reviewer," not with Cursor.
+
+### 4. Adoption barrier
+**The pitch a 5–10 engineer team would respond to**: "Your AI-generated PRs are inconsistent and reviewers can't tell whether tests actually ran. CDK ships a Stop hook that blocks task completion until tests pass, plus 20 audit skills that run before merge. One `npx mg-claude-dev-kit init`. CODEOWNERS gate `.claude/` so the rules can't be silently weakened."
+
+**The objection that kills the deal**:
+1. *"Why a separate tool? We already have ESLint, our CI, and a `CLAUDE.md`."* The Tier M pipeline.md is 295 lines with two STOP gates, a Phase 8.5 context review, three audit tracks, and a "non-negotiable closing message." That is a lot of *new* process in a project that already has process. The wizard needs a clear "what does this replace?" answer, plus an ROI claim grounded in something concrete (e.g., "reduced AI-generated regressions by X% in 3 pilot projects"). The README only states "used on 2-3 real projects, npm adoption metric not yet validated."
+2. *"Single maintainer, npm package name confusion (`mg-` prefix), no SOC 2 / no enterprise reference."* For Tier L / enterprise the bundle is ahead of itself.
+3. *"How do I know skills won't drift from Anthropic's spec next month?"* The drift tracker exists but isn't surfaced to the user as a guarantee.
+
+### 5. Single highest-impact improvement
+**Close the team-settings enforcement gap by shipping a Stop-hook-equivalent runtime check.** Specifically: write a SessionStart hook (or PreToolUse hook on the Skill tool) that reads `.claude/team-settings.json` and refuses a session/skill invocation that violates `minTier` / `blockedSkills` / `allowedSkills`. This converts the headline 1.16 feature from "advisory at the CLI" to "mechanical at runtime" — which is the entire CDK pitch.
+
+This does **not** map to a current roadmap item. The closest is Q3 #3 (`team-settings.json`, ICE 175), which is marked Open in `roadmap-status.md` but Done in CHANGELOG 1.16.0 — a status drift between the two files I'd flag separately. The 1.16.0 release note explicitly defers native enforcement to "v1.17+" without an issue number.
+
+**Propose a new roadmap item**: "team-settings.json runtime enforcement via Claude Code hooks." Rough ICE: I=8 (rescues the credibility of the entire 1.16 release and the team-adoption pitch), C=6 (depends on hook capabilities, but PreToolUse hooks are documented and SessionStart is already used for the weekly arch-audit reminder, so the mechanism is proven within CDK), E=5 (one hook, JSON read, exit code; harder part is the test matrix). ICE ≈ **240** — would slot above the current Q3 #3 (175) and just below Q2 #2 (245).
+
+Why this beats the alternatives:
+- VitePress site (Q2 #3, ICE 432) is documentation. It does not move adoption if the product has a credibility gap.
+- `cdk sync` (Q3 #5, ICE 120) is a nice-to-have for multi-repo orgs and CDK has zero of those publicly validated.
+- Q3 #6 enterprise skills are content addition into a tool whose enforcement story is incomplete.
+
+### 6. Architecture concern
+Three real maintenance burdens visible in the bundle:
+
+1. **Combinatorial template explosion: 11 stacks × 4 tiers × 20+ skills × hasApi/hasDb/hasFrontend/hasDesignSystem flags.** The CHANGELOG flags the symptom: the v1.15 `--anthropic` registry intentionally ships *one file* because anything that goes through `interpolate()` or section stripping needs a "transformation-aware compare" that doesn't exist yet. As skill count grows 20→40→100, the count of (template × stack × tier × flag) combinations grows multiplicatively and the absence of transformation-aware diff means upgrade either drifts silently or floods users with `REVIEW_REQUIRED`. This is the architectural debt to watch.
+
+2. **Pipeline complexity per tier.** Tier M's pipeline.md is 295 lines with 11 phases (0, 1, 1.5, 2, 3, 3b, 4, 5b, 5c, 5d, 6, 8, 8.5 — note: numbered 0 through 8.5 with multiple sub-phases, no Phase 7), three audit Tracks A/B/C inside Phase 5d, a "non-negotiable closing message," conditional Phase 4 activation, and a detailed Phase 8 commit sequence. Tier L is 14 phases. This is the kind of artifact that grows by accretion every release. Suggest a **phase budget** ceiling per tier and force consolidation before adding.
+
+3. **Doctor check inflation.** 28 checks today, +1 per release on the trajectory shown (26→27 in 1.15, 27→28 in 1.16). Without a tier or severity grouping at the user output level, doctor becomes a "wall of warnings" and users learn to ignore it. The `--report` JSON change in 1.16 helps CI but not interactive users.
+
+Less concerning but worth naming: the 295-line tier-M pipeline file lives alongside Tier L and Discovery variants. Drift between scaffolded files (in user projects) and template files (upstream) is the structural risk that the `--anthropic` flag is trying to address — keep watching this.
+
+### 7. What should be removed
+**Trim, not delete:**
+
+- **The "Phase 8.5 - Context review + compact" section in tier-M pipeline.md.** C1–C12 (twelve checks, mix of grep-only and judgment) is too much process at the *end* of every block. This is the kind of section a team will silently drop in week two. Either fold C1–C3 into Phase 6 outcome checklist as machine-checkable items and delete C4–C12, or split context-review into its own optional skill invoked when triggered.
+
+- **The "non-negotiable closing message" template** ("Block complete ✅ - [Block name]..."). Anthropic's house style for output is leaner than this and the CDK tool was supposed to *enforce* mechanical things, not require ceremonial ones. If you want a closing artifact, derive it from session state instead of asking the human to fill in a template that the agent could autogenerate.
+
+- **Tier 0 "Discovery" might not pull its weight as a tier.** Per the README, "Discovery" is "Stop hook only" — i.e., one file. If a user is in pure exploration, the cost of a wizard run for one Stop hook is high. Consider collapsing Tier 0 to a single `npx mg-claude-dev-kit add hook stop` shortcut and reserving "tier" terminology for S/M/L.
+
+- **`/skill-review` shipping in user scaffolds.** Looking at the README table, `/skill-review` is described as a "Quality review pipeline for skill portfolios" — that is a tool for CDK maintainers, not for end-user projects scaffolding their own work. If users aren't authoring skill portfolios, this skill is dead weight in their `.claude/skills/`. Confirm intended audience and either gate it behind `--include-meta-skills` or move it to a maintainer-only path.
+
+- **Tier S vs Tier M distinction at the pipeline level might be too thin** to justify two separate template trees long-term. "4 steps with 1 scope-confirm" vs "8 phases with 2 STOP gates" — the gap is mostly about audit track invocation. Worth measuring: do real users on Tier S ever advance to M, or do they rewrite from scratch? If the latter, S is a leaky pre-tier and M is the real entry point.
+
+### Overall assessment
+CDK has a real, defensible insight (mechanical enforcement of test-passing inside the agent) and an unusually substantive skill library, but the bundle reveals a credibility gap between the marketing ("team-wide governance") and the implementation ("CLI-only enforcement, native rules tracked for v1.17+"). The architecture risks (template combinatorics, pipeline accretion, doctor inflation) are early-stage but real, and the single-maintainer + 2–3 real users data point should keep ambitions calibrated. The 1.16 release ships in a usable state and breaks no existing scaffolds, but the headline feature underdelivers on its own pitch.
+
+SHIP-WITH-RESERVATIONS — release stands, but the team-settings runtime-enforcement gap is the next thing to close, ahead of any docs site or new skill.

--- a/docs/reviews/2026-04-26-quick/synthesis.md
+++ b/docs/reviews/2026-04-26-quick/synthesis.md
@@ -1,0 +1,35 @@
+# CDK 1.16.0 — External Review Synthesis
+Date: 2026-04-26
+Mode: quick
+Focus: general
+Reviewers: Claude (general-purpose, fresh context)
+
+> Note: quick mode runs a single fresh-context Claude review. This synthesis is summary, not cross-LLM convergence. For cross-LLM coverage at milestone gates, run `/external-review --mode=full`.
+
+## Headline
+
+The reviewer ships the release as **SHIP-WITH-RESERVATIONS**. The release stands; the credibility gap of the v1.16 headline feature is what to close next.
+
+## Convergence (single reviewer, so each point is one-source)
+
+- **Strongest piece is the Stop hook + CODEOWNERS + team-settings.json triad.** Mechanical enforcement of "tests pass before done" is what differentiates CDK from Cursor rules / Aider conventions / raw CLAUDE.md.
+- **Headline 1.16 feature has a credibility gap.** `team-settings.json` enforces only at CLI invocation; Claude Code session can still type `/security-audit` directly and bypass `blockedSkills`. Release notes name this; reviewer judges it underdelivers on the team-governance pitch.
+- **Architecture debt to watch**: template combinatorics (stacks × tiers × skills × flags), pipeline complexity inflation (Tier M is 11 phases / 295 lines, Tier L is 14), doctor check inflation (+1/release: 26 → 27 → 28).
+- **Status drift**: `roadmap-status.md` marks Q3 #3 as Open while CHANGELOG 1.16.0 marks it Done. Same for Q3 #2 (`upgrade --anthropic`, marked Open in roadmap, Done in CHANGELOG 1.15). Roadmap not synced after recent merges.
+
+## Action items (prioritized)
+
+1. **Fix roadmap-status.md status drift for Q3 #2 and Q3 #3** — both marked Open but shipped in 1.15.0 and 1.16.0 respectively. Trivial fix; affects every external review run.
+2. **Propose new roadmap item: team-settings.json runtime enforcement via Claude Code hooks** — PreToolUse hook on `Skill` tool that reads `.claude/team-settings.json` and refuses skill invocation that violates `blockedSkills` / `allowedSkills`. Closes the v1.16 credibility gap. Reviewer-proposed ICE: 240 (I=8, C=6, E=5). Slot above current Q3 #3 row, just below Q2 #2.
+3. **Trim Phase 8.5 "Context review + compact" in tier-M pipeline.md** — C1–C12 is too much end-of-block process; fold C1–C3 into Phase 6 outcome checklist, drop C4–C12 or extract to optional skill.
+4. **Decide on `/skill-review` audience** — currently shipped in user scaffolds, but reviewer reads it as maintainer-only. Either gate behind `--include-meta-skills`, move to maintainer path, or document its end-user use case.
+5. **Quantify time-to-value in README** — "20 skills, 28 checks, 11 stacks, 4 tiers" is process surface. Add a one-line "what does week one cost a 5-person team" so the wizard's choice between tiers has concrete weight.
+6. **Drop the "non-negotiable closing message" template** — ceremonial output; agent can derive a closing artifact from session state instead of requiring fill-ins.
+
+## Divergence (single reviewer, so blanket attribution)
+
+- **Claude (fresh)**: positions CDK's long-term defensible piece as "the skills themselves and the stack-aware patterns" rather than the governance scaffolding, on the assumption that Anthropic native primitives will subsume CLI-side governance. Implication for product strategy: invest in skill content depth (audit accuracy, stack patterns) ahead of governance breadth.
+
+## Overall verdict
+
+SHIP-WITH-RESERVATIONS. v1.16 is usable and breaks nothing. Action items above (in order) close the credibility gap and reduce the architecture debt curve.

--- a/docs/reviews/external-review-prompt.md
+++ b/docs/reviews/external-review-prompt.md
@@ -1,0 +1,105 @@
+---
+title: External LLM Review Prompt — claude-dev-kit
+version: 1.16.0
+last_synced: 2026-04-26
+target_release: "{VERSION}"
+focus_area: "{FOCUS_AREA}"
+audience: GPT-4.1, Gemini 2.5 Pro, Mistral Large, Perplexity Sonar Pro, Claude (fresh-context)
+---
+
+# External LLM Review Prompt — claude-dev-kit
+
+> Sync the **version** + **last_synced** fields above when CDK ships a new release.
+> Replace `{VERSION}` and `{FOCUS_AREA}` placeholders with the run-time values before fanning out to providers.
+> The bundle is auto-assembled by `scripts/external-review-bundle.mjs` (run via the `/external-review` skill).
+
+---
+
+You are reviewing an open-source CLI tool called **claude-dev-kit** (CDK). It scaffolds a governance layer on top of Claude Code (Anthropic's agentic coding CLI). The scaffold provides structured development pipelines, audit skills, security rules, process controls, and team-wide governance primitives.
+
+You have **no prior memory** of this project. Treat the attached bundle as the only source of truth. If a claim in the bundle isn't supported by another file in the bundle, flag it.
+
+## What CDK does
+
+- `npx mg-claude-dev-kit init` runs an interactive wizard
+- Outputs: `CLAUDE.md` (project context, ≤200 lines), `.claude/settings.json` (permissions + Stop hook), `.claude/rules/` (pipeline, security, git, output-style), `.claude/skills/` (audit slash-commands), `.claude/team-settings.json` (team-wide policy, opt-in)
+- Four tiers: Discovery (3 files, no pipeline), Fast Lane / Tier S (4-step pipeline, 1 scope-confirm), Standard / Tier M (8 phases, 2 STOP gates), Full / Tier L (11 phases, 4 STOP gates + audit cycle)
+- Stack-aware: auto-detects 11 tech stacks (Node-TS, Node-JS, Python, Go, Swift, Kotlin, Rust, .NET, Ruby, Java, generic), adapts security rules, permissions, commands, and skill checks
+- 20 audit skills with model routing: haiku for mechanical checks, sonnet for analysis, opus for visual reasoning. Skills are conditionally installed per project flags (`hasApi`, `hasDatabase`, `hasFrontend`, `hasDesignSystem`).
+- Three governance flags ship in the scaffold and are enforced mechanically: a Stop hook blocks task completion until tests pass, CODEOWNERS gates `.claude/` changes behind review, and `team-settings.json` (v1.16+) lets a team enforce `minTier`, `allowedSkills`, `blockedSkills`, `requiredSkills` across every clone.
+
+## Current state ({VERSION})
+
+- 365 unit tests, 1000 integration checks, all passing
+- 28 doctor checks (validation surface)
+- GitHub Actions CI: Node 22/24 matrix, Lint, Unit, Integration, Verify CLI, Drift tracker, CodeQL, dependency-review
+- ESLint + Prettier
+- Published on npm as `mg-claude-dev-kit`
+- Single maintainer, used on 2-3 real projects, npm adoption metric not yet validated (registry currently lags local versioning)
+- Roadmap is ICE-prioritized across Q1–Q4 2026; Q1+Q2 mostly shipped; Q3 has 3 of 9 items shipped through v1.16.0
+
+## Focus area for this run
+
+{FOCUS_AREA}
+
+> If `{FOCUS_AREA}` is `general`, treat the seven questions as full-coverage. If it names a specific dimension (e.g., `architecture`, `competitive-position`, `team-adoption`, `pricing`, `enterprise-readiness`), give that dimension extra depth and use the others as supporting context.
+
+## Attached files (auto-bundled)
+
+1. **README.md** — full product documentation
+2. **CHANGELOG.md** — last three releases (v1.14, v1.15, v1.16) so the change cadence is visible
+3. **security-audit SKILL.md (Tier M)** — example of a complex audit skill with 3-path stack-aware selector
+4. **pipeline.md (Tier M)** — example of the standard pipeline tier with two STOP gates
+5. **roadmap-status.md** — ICE-ranked roadmap snapshot (Q1–Q4 2026 + backlog)
+
+## Questions
+
+Answer each with specific, actionable feedback. No flattery — treat this as a paid code review. If you don't have enough information from the bundle to answer, say so explicitly rather than speculating.
+
+1. **Strongest aspect**: what is the single most valuable thing CDK does that other AI coding tools/frameworks don't?
+
+2. **Weakest aspect**: what is the biggest weakness or gap that would prevent adoption? Be specific — name what's missing and why it matters.
+
+3. **Competitive position**: how does this compare to Cursor rules (`.cursorrules`), Windsurf rules, Aider conventions, raw `CLAUDE.md` files, and Claude Code's native skills/permissions system? What does CDK offer beyond what a senior engineer could build in an afternoon? What does it offer beyond what a $20/month subscription to one of the competitors already provides?
+
+4. **Adoption barrier**: what would make a team of 5–10 engineers adopt this over writing their own `CLAUDE.md` + rules? What's the pitch they'd respond to? What objection would kill the deal?
+
+5. **Single highest-impact improvement**: if you could make one change to CDK over the next quarter, what would it be? Not a wish list — one specific change with the most leverage. Cite the roadmap item it maps to (or argue why it's missing from the roadmap).
+
+6. **Architecture concern**: is there anything in the design that would become a maintenance burden or create scaling problems as the tool grows? Consider: skill count growth (20 → 40 → 100), tier count, stack count, doctor check count, pipeline complexity per tier, drift between scaffolded files and template files.
+
+7. **What should be removed**: is there anything in CDK that adds complexity without proportional value? Over-engineering signals? Features the bundle suggests aren't pulling their weight?
+
+## Output format
+
+Use this exact structure:
+
+```
+## [Model name] Review — CDK {VERSION}
+Date: [ISO date]
+Focus area: {FOCUS_AREA}
+
+### 1. Strongest aspect
+[answer]
+
+### 2. Weakest aspect
+[answer]
+
+### 3. Competitive position
+[answer]
+
+### 4. Adoption barrier
+[answer]
+
+### 5. Single highest-impact improvement
+[answer — name the roadmap item if applicable, else propose a new item with rough ICE]
+
+### 6. Architecture concern
+[answer]
+
+### 7. What should be removed
+[answer — be specific; "nothing" is acceptable if defended]
+
+### Overall assessment
+[2-3 sentences. End with a single-line one-of: SHIP / SHIP-WITH-RESERVATIONS / DO-NOT-SHIP and a one-sentence reason.]
+```

--- a/scripts/external-review-bundle.mjs
+++ b/scripts/external-review-bundle.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+/**
+ * Auto-assembles a reproducible bundle of CDK files for external LLM review.
+ *
+ * Output bundle (default):
+ *   - README.md
+ *   - CHANGELOG.md (last 3 release entries)
+ *   - packages/cli/templates/tier-m/.claude/skills/security-audit/SKILL.md
+ *   - packages/cli/templates/tier-m/.claude/rules/pipeline.md
+ *   - .claude/initiatives/roadmap-status.md
+ *
+ * Usage:
+ *   node scripts/external-review-bundle.mjs --out docs/reviews/2026-04-26-quick/bundle/
+ *
+ * Each file lands at <out>/<basename> with the original name preserved.
+ * CHANGELOG is sliced to the last 3 entries to keep the bundle compact and
+ * avoid models budgeting their attention on early-release noise.
+ *
+ * Exit codes:
+ *   0  bundle assembled
+ *   1  one or more sources missing
+ *   2  bad arguments
+ */
+
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { resolve, dirname, basename, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+
+const SOURCES = [
+  { src: 'README.md', dest: 'README.md', transform: null },
+  { src: 'CHANGELOG.md', dest: 'CHANGELOG.md', transform: lastThreeReleases },
+  {
+    src: 'packages/cli/templates/tier-m/.claude/skills/security-audit/SKILL.md',
+    dest: 'security-audit-SKILL.md',
+    transform: null,
+  },
+  {
+    src: 'packages/cli/templates/tier-m/.claude/rules/pipeline.md',
+    dest: 'pipeline-tier-m.md',
+    transform: null,
+  },
+  {
+    src: '.claude/initiatives/roadmap-status.md',
+    dest: 'roadmap-status.md',
+    transform: null,
+  },
+];
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--out') args.out = argv[++i];
+    else if (a === '--help' || a === '-h') args.help = true;
+    else throw new Error(`Unknown arg: ${a}`);
+  }
+  return args;
+}
+
+function lastThreeReleases(content) {
+  const lines = content.split('\n');
+  const releaseHeaders = [];
+  lines.forEach((line, i) => {
+    if (/^## \[\d+\.\d+\.\d+\]/.test(line)) releaseHeaders.push(i);
+  });
+  if (releaseHeaders.length === 0) return content;
+  const startLine = releaseHeaders[0];
+  const endLine =
+    releaseHeaders.length >= 4 ? releaseHeaders[3] : lines.length;
+  const head = lines.slice(0, startLine);
+  const slice = lines.slice(startLine, endLine);
+  return [
+    ...head,
+    '> Bundle note: trimmed to the last three releases for review compactness.',
+    '',
+    ...slice,
+  ].join('\n');
+}
+
+async function main() {
+  let args;
+  try {
+    args = parseArgs(process.argv);
+  } catch (err) {
+    console.error(`Argument error: ${err.message}`);
+    process.exit(2);
+  }
+
+  if (args.help || !args.out) {
+    console.log(
+      'Usage: node scripts/external-review-bundle.mjs --out <dir>',
+    );
+    process.exit(args.help ? 0 : 2);
+  }
+
+  const outDir = resolve(args.out);
+  await mkdir(outDir, { recursive: true });
+
+  const missing = [];
+  for (const entry of SOURCES) {
+    const srcPath = resolve(REPO_ROOT, entry.src);
+    if (!existsSync(srcPath)) {
+      missing.push(entry.src);
+      continue;
+    }
+    const raw = await readFile(srcPath, 'utf8');
+    const content = entry.transform ? entry.transform(raw) : raw;
+    const destPath = join(outDir, entry.dest);
+    await writeFile(destPath, content);
+    const lines = content.split('\n').length;
+    console.log(`  ✓ ${entry.dest} (${lines} lines)`);
+  }
+
+  if (missing.length > 0) {
+    console.error(`\nMissing sources:\n${missing.map((m) => `  - ${m}`).join('\n')}`);
+    process.exit(1);
+  }
+
+  console.log(`\nBundle assembled at ${args.out}`);
+  console.log(`Files: ${SOURCES.length}`);
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err.message);
+  process.exit(1);
+});

--- a/scripts/external-review.mjs
+++ b/scripts/external-review.mjs
@@ -1,0 +1,303 @@
+#!/usr/bin/env node
+/**
+ * External LLM review runner.
+ *
+ * Reads a prompt + a directory of context files, fans out to every provider
+ * whose API key is present in .env, and writes each response to an output
+ * directory. Designed for reproducible cross-model review of CDK templates
+ * (agnosticity audit Fase 3, post-cleanup validation Fase 7, future release
+ * reviews).
+ *
+ * Usage:
+ *   node scripts/external-review.mjs \
+ *     --prompt docs/reviews/<name>/prompt.md \
+ *     --bundle docs/reviews/<name>/bundle/ \
+ *     --out    docs/reviews/<name>/responses/ \
+ *     [--only openai,mistral]          # restrict to a subset of providers
+ *     [--suffix chunk-a]               # append to output filenames (chunking)
+ *
+ * Providers are toggled by the presence of their *_API_KEY env var:
+ *   OPENAI_API_KEY      → gpt-4.1
+ *   GEMINI_API_KEY      → gemini-2.5-pro
+ *   MISTRAL_API_KEY     → mistral-large-latest
+ *   PERPLEXITY_API_KEY  → sonar-pro
+ *
+ * Override a model id per provider with e.g. OPENAI_MODEL=gpt-5.
+ *
+ * Exit codes:
+ *   0  all providers returned a response
+ *   1  at least one provider failed (response files for failures contain the error)
+ *   2  configuration error (missing files, no providers, bad arguments)
+ */
+
+import { readFile, writeFile, mkdir, readdir, stat } from 'node:fs/promises';
+import { join, basename, resolve } from 'node:path';
+import { existsSync } from 'node:fs';
+
+// ---- arg parsing -----------------------------------------------------------
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 2; i < argv.length; i += 2) {
+    const key = argv[i]?.replace(/^--/, '');
+    const val = argv[i + 1];
+    if (!key || val === undefined) exit(2, `bad argument near: ${argv[i]}`);
+    args[key] = val;
+  }
+  for (const required of ['prompt', 'bundle', 'out']) {
+    if (!args[required]) exit(2, `missing required --${required}`);
+  }
+  args.only = args.only ? args.only.split(',').map((s) => s.trim()).filter(Boolean) : null;
+  args.suffix = args.suffix || '';
+  return args;
+}
+
+function exit(code, msg) {
+  if (msg) process.stderr.write(`external-review: ${msg}\n`);
+  process.exit(code);
+}
+
+// ---- .env loader (no dependency) -------------------------------------------
+
+async function loadEnv(cwd) {
+  const envPath = join(cwd, '.env');
+  if (!existsSync(envPath)) return;
+  const raw = await readFile(envPath, 'utf8');
+  for (const line of raw.split('\n')) {
+    const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*?)\s*$/);
+    if (!m) continue;
+    const [, key, rawVal] = m;
+    if (process.env[key]) continue; // do not override existing
+    const val = rawVal.replace(/^["']|["']$/g, '');
+    process.env[key] = val;
+  }
+}
+
+// ---- bundle assembly -------------------------------------------------------
+
+async function collectBundle(dir) {
+  const entries = [];
+  async function walk(current) {
+    const items = await readdir(current, { withFileTypes: true });
+    for (const it of items.sort((a, b) => a.name.localeCompare(b.name))) {
+      const p = join(current, it.name);
+      if (it.isDirectory()) await walk(p);
+      else if (it.isFile() && it.name.endsWith('.md')) {
+        const content = await readFile(p, 'utf8');
+        entries.push({ path: p, content });
+      }
+    }
+  }
+  await walk(dir);
+  return entries;
+}
+
+function renderBundle(entries, bundleRoot) {
+  // Files contain their own triple-backtick code fences, so wrapping them in
+  // another fence would break parsing. Use explicit plain-text delimiters.
+  const lines = ['# Context bundle', ''];
+  lines.push(`Files included: ${entries.length}`, '');
+  for (const e of entries) {
+    const rel = e.path.startsWith(bundleRoot) ? e.path.slice(bundleRoot.length).replace(/^\/+/, '') : e.path;
+    lines.push(`===== FILE-START: ${rel} =====`);
+    lines.push(e.content.trimEnd());
+    lines.push(`===== FILE-END: ${rel} =====`);
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+// ---- providers -------------------------------------------------------------
+
+const PROVIDERS = [
+  {
+    name: 'openai',
+    envKey: 'OPENAI_API_KEY',
+    modelEnv: 'OPENAI_MODEL',
+    defaultModel: 'gpt-4.1',
+    call: async ({ apiKey, model, system, user }) => {
+      const res = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', authorization: `Bearer ${apiKey}` },
+        body: JSON.stringify({
+          model,
+          messages: [
+            { role: 'system', content: system },
+            { role: 'user', content: user },
+          ],
+          temperature: 0.2,
+        }),
+      });
+      if (!res.ok) throw new Error(`openai ${res.status}: ${await res.text()}`);
+      const j = await res.json();
+      return j.choices?.[0]?.message?.content ?? '';
+    },
+  },
+  {
+    name: 'gemini',
+    envKey: 'GEMINI_API_KEY',
+    modelEnv: 'GEMINI_MODEL',
+    defaultModel: 'gemini-2.5-pro',
+    call: async ({ apiKey, model, system, user }) => {
+      const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`;
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          systemInstruction: { role: 'system', parts: [{ text: system }] },
+          contents: [{ role: 'user', parts: [{ text: user }] }],
+          generationConfig: { temperature: 0.2 },
+        }),
+      });
+      if (!res.ok) throw new Error(`gemini ${res.status}: ${await res.text()}`);
+      const j = await res.json();
+      return j.candidates?.[0]?.content?.parts?.map((p) => p.text).join('\n') ?? '';
+    },
+  },
+  {
+    name: 'mistral',
+    envKey: 'MISTRAL_API_KEY',
+    modelEnv: 'MISTRAL_MODEL',
+    defaultModel: 'mistral-large-latest',
+    call: async ({ apiKey, model, system, user }) => {
+      const res = await fetch('https://api.mistral.ai/v1/chat/completions', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', authorization: `Bearer ${apiKey}` },
+        body: JSON.stringify({
+          model,
+          messages: [
+            { role: 'system', content: system },
+            { role: 'user', content: user },
+          ],
+          temperature: 0.2,
+        }),
+      });
+      if (!res.ok) throw new Error(`mistral ${res.status}: ${await res.text()}`);
+      const j = await res.json();
+      return j.choices?.[0]?.message?.content ?? '';
+    },
+  },
+  {
+    name: 'perplexity',
+    envKey: 'PERPLEXITY_API_KEY',
+    modelEnv: 'PERPLEXITY_MODEL',
+    defaultModel: 'sonar-pro',
+    call: async ({ apiKey, model, system, user }) => {
+      const res = await fetch('https://api.perplexity.ai/chat/completions', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', authorization: `Bearer ${apiKey}` },
+        body: JSON.stringify({
+          model,
+          messages: [
+            { role: 'system', content: system },
+            { role: 'user', content: user },
+          ],
+          temperature: 0.2,
+        }),
+      });
+      if (!res.ok) throw new Error(`perplexity ${res.status}: ${await res.text()}`);
+      const j = await res.json();
+      return j.choices?.[0]?.message?.content ?? '';
+    },
+  },
+];
+
+// ---- main ------------------------------------------------------------------
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const cwd = process.cwd();
+  await loadEnv(cwd);
+
+  const promptPath = resolve(cwd, args.prompt);
+  const bundleDir = resolve(cwd, args.bundle);
+  const outDir = resolve(cwd, args.out);
+
+  if (!existsSync(promptPath)) exit(2, `prompt not found: ${promptPath}`);
+  if (!existsSync(bundleDir) || !(await stat(bundleDir)).isDirectory())
+    exit(2, `bundle dir not found: ${bundleDir}`);
+
+  const system = await readFile(promptPath, 'utf8');
+  const bundle = await collectBundle(bundleDir);
+  if (bundle.length === 0) exit(2, `bundle is empty: ${bundleDir}`);
+  const userBlob = renderBundle(bundle, bundleDir);
+
+  await mkdir(outDir, { recursive: true });
+
+  // Preflight: classify provider availability before fanning out.
+  let active = PROVIDERS.filter((p) => process.env[p.envKey]);
+  const missing = PROVIDERS.filter((p) => !process.env[p.envKey]);
+  if (args.only) {
+    const unknown = args.only.filter((n) => !PROVIDERS.some((p) => p.name === n));
+    if (unknown.length) exit(2, `unknown provider(s) in --only: ${unknown.join(',')}`);
+    active = active.filter((p) => args.only.includes(p.name));
+  }
+  if (active.length === 0) exit(2, 'no provider API keys found in env (after --only filter)');
+
+  process.stdout.write(`Bundle: ${bundle.length} files, ${userBlob.length} chars\n`);
+  process.stdout.write(
+    `Preflight: ${active.length}/${PROVIDERS.length} provider(s) available\n`,
+  );
+  process.stdout.write(`  active: ${active.map((p) => p.name).join(', ')}\n`);
+  if (missing.length > 0 && !args.only) {
+    process.stdout.write(
+      `  missing: ${missing
+        .map((p) => `${p.name} (set ${p.envKey})`)
+        .join(', ')}\n`,
+    );
+  }
+  if (active.length < PROVIDERS.length && !args.only) {
+    process.stdout.write(
+      'Warning: cross-LLM diversity is reduced; consider adding the missing keys for the next run.\n',
+    );
+  }
+  process.stdout.write('\n');
+
+  const started = Date.now();
+  const results = await Promise.allSettled(
+    active.map(async (p) => {
+      const model = process.env[p.modelEnv] || p.defaultModel;
+      const t0 = Date.now();
+      process.stdout.write(`[${p.name}] calling ${model}...\n`);
+      try {
+        const content = await p.call({
+          apiKey: process.env[p.envKey],
+          model,
+          system,
+          user: userBlob,
+        });
+        const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
+        const outPath = join(outDir, `${p.name}${args.suffix ? '.' + args.suffix : ''}.md`);
+        await writeFile(
+          outPath,
+          `# ${p.name} (${model}) — ${new Date().toISOString()}\n\nElapsed: ${elapsed}s\n\n---\n\n${content}\n`,
+          'utf8'
+        );
+        process.stdout.write(`[${p.name}] OK in ${elapsed}s → ${outPath}\n`);
+        return { name: p.name, ok: true, outPath };
+      } catch (err) {
+        const outPath = join(outDir, `${p.name}${args.suffix ? '.' + args.suffix : ''}.error.md`);
+        await writeFile(
+          outPath,
+          `# ${p.name} (${model}) — ERROR — ${new Date().toISOString()}\n\n\`\`\`\n${err?.stack || err?.message || String(err)}\n\`\`\`\n`,
+          'utf8'
+        );
+        process.stdout.write(`[${p.name}] FAIL → ${outPath}\n`);
+        return { name: p.name, ok: false, outPath };
+      }
+    })
+  );
+
+  const totalElapsed = ((Date.now() - started) / 1000).toFixed(1);
+  process.stdout.write(`\nTotal elapsed: ${totalElapsed}s\n`);
+  const failed = results.filter((r) => r.status !== 'fulfilled' || !r.value.ok);
+  if (failed.length > 0) {
+    process.stdout.write(`Failed: ${failed.length}/${results.length}\n`);
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  process.stderr.write(`external-review: unhandled: ${err?.stack || err}\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Q2 #8 ships as a scope expansion: not just an updated prompt, but a full `/external-review` skill with two modes for different review cadences.

`/external-review --mode=quick` (default) spawns a single Claude general-purpose subagent with no project memory and an auto-bundled snapshot. Cost ~$0.10, ~60 seconds. Use on every release.

`/external-review --mode=full` fans the same bundle out to GPT-4.1, Gemini 2.5 Pro, Mistral Large, and Perplexity Sonar Pro for cross-LLM coverage. Cost ~$0.50-2, ~5 minutes. Use at milestone gates.

Two-mode rationale: cross-LLM diversity catches two distinct blind-spot classes — memory-isolation fresh-eyes (replaceable cheaply by an in-family Claude subagent) and architectural diversity from different model families (irreplaceable). Quick covers the first on every release; full adds the second at milestones. Running full weekly is wasteful redundancy.

This is maintainer-only tooling. The skill lives in `.claude/skills/external-review/` (gitignore-excepted), the prompt and scripts live in `docs/reviews/` and `scripts/` respectively. Nothing ships in user scaffolds, no version bump, no breaking change.

## Smoke test artifact

The first run (`docs/reviews/2026-04-26-quick/`) is included as the v1.16.0 baseline review. It surfaced four real items:
- `roadmap-status.md` Q3 #2 and Q3 #3 still marked Open while shipped in v1.15 / v1.16 (status drift).
- `team-settings.json` enforcement is CLI-only — credibility gap with the v1.16 marketing pitch. Reviewer proposes a new roadmap item (PreToolUse hook, ICE 240) above the current Q3 #3.
- Phase 8.5 "Context review + compact" in tier-M pipeline.md (C1-C12) is too much end-of-block process; trim recommendation.
- `/skill-review` shipping in user scaffolds may be maintainer-only by intent; audience needs confirmation.

These are filed as future work, not addressed in this PR.

## Changes

- `chore(context)`: refine .gitignore to allow committing maintainer artifacts (prompt + skill + scripts + dated review subdirs)
- `feat(scripts)`: add `scripts/external-review.mjs` (cross-LLM fan-out, previously local-only) and `scripts/external-review-bundle.mjs` (auto-curated bundle assembler), plus preflight provider-availability check
- `feat(external-review)`: add `.claude/skills/external-review/SKILL.md` and the v1.16.0 baseline review run

## Test plan

- [x] Bundle script smoke-test: `node scripts/external-review-bundle.mjs --out /tmp/test` assembles 5 files
- [x] Quick mode end-to-end: spawned general-purpose subagent on the bundle, produced substantive review with SHIP-WITH-RESERVATIONS verdict
- [ ] Full mode (deferred): requires API keys; will run at the next milestone gate

No CI test changes (this is docs/scripts/maintainer-skill only). Existing 1000 integration / 365 unit unaffected.

Closes Q2 #8 (no GitHub issue assigned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)