### PR TITLE
feat: v1.17.0 — CDK governance MCP server (Q3 #4a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,31 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.17.0] — 2026-04-26
+
+### Added
+
+- **CDK governance MCP server** (Q3 #4a, Issue #118, ICE 294): a local Model Context Protocol server that exposes CDK's existing JSON outputs as MCP tools. Any MCP-aware client (Claude Desktop, ChatGPT desktop, Cursor, VS Code, Copilot Studio) can now query CDK project health without the CDK CLI installed. Five read-only tools: `cdk_doctor_report`, `cdk_team_settings`, `cdk_arch_audit_status`, `cdk_skill_inventory`, `cdk_package_meta`.
+- **`claude-dev-kit-mcp` binary**: shipped in the same npm package as the existing `claude-dev-kit` CLI. Single `npm install -g`, two binaries, version-locked. Wire up via `.mcp.json` or `~/.claude/.mcp.json`:
+  ```json
+  { "mcpServers": { "cdk": { "command": "claude-dev-kit-mcp" } } }
+  ```
+- **`@modelcontextprotocol/sdk` (^1.29.0)** added as dependency. ESM-only, stdio transport, official Anthropic SDK.
+- **Integration scenario `scenarioMCPServer`** in `test/integration/run.js`: end-to-end test that spawns the MCP server as a child process, connects via the SDK client, lists tools, calls each tool, and verifies the JSON shape — both on a fully scaffolded project and on a clean scaffold (everRan=false, present=false).
+
+### Changed
+
+- npm `bin` entries: `mg-claude-dev-kit` package now ships `claude-dev-kit` and `claude-dev-kit-mcp` together. No standalone CLI version exists.
+- Integration test count: 1000 → 1009 (+9 from `scenarioMCPServer`).
+
+### Notes
+
+- This is the first release in which CDK is itself an MCP citizen. Previously, CDK *consumed* MCP via the Playwright tools wired into the visual / responsive / accessibility / UI skills. Now CDK *publishes* an MCP server too, closing the asymmetry flagged in the 2026-04-26 MCP reassessment.
+- Read-only tool surface in v1.17.0 by design. Mutating tools (`cdk_apply_skill`, `cdk_run_doctor` triggered remotely) are deferred until adoption signal supports them.
+- Q3 #4b (MCP-aware audit skills, Issue #119, ICE 210) is the natural follow-on once 4a is in production. Schedule TBD.
+
+---
+
 ## [1.16.0] — 2026-04-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Node.js >= 22](https://img.shields.io/badge/node-%3E%3D22-brightgreen.svg)](https://nodejs.org)
 [![CI](https://github.com/marcoguillermaz/claude-dev-kit/actions/workflows/ci.yml/badge.svg)](https://github.com/marcoguillermaz/claude-dev-kit/actions/workflows/ci.yml)
-[![1000 integration checks](https://img.shields.io/badge/integration-1000%20checks-blue.svg)](#testing)
+[![1009 integration checks](https://img.shields.io/badge/integration-1009%20checks-blue.svg)](#testing)
 
 > Scaffold for legible, reviewable AI-assisted development.
 > Claude generates. Your team decides.
@@ -132,7 +132,34 @@ npx mg-claude-dev-kit upgrade --anthropic --apply  # write the diff (with .bak b
 npx mg-claude-dev-kit add skill <name>        # install one skill
 npx mg-claude-dev-kit add rule <name>         # install one rule
 npx mg-claude-dev-kit new skill               # create a custom skill (wizard)
+claude-dev-kit-mcp                            # MCP server (stdio); wire from .mcp.json
 ```
+
+## MCP server
+
+`claude-dev-kit-mcp` is a Model Context Protocol server that exposes CDK governance signals to any MCP-aware client (Claude Desktop, ChatGPT desktop, Cursor, VS Code, Copilot Studio). The CLI and MCP server ship in the same npm package, version-locked.
+
+Wire it up by adding to `.mcp.json` (project-scoped) or `~/.claude/.mcp.json` (user-scoped):
+
+```json
+{
+  "mcpServers": {
+    "cdk": { "command": "claude-dev-kit-mcp" }
+  }
+}
+```
+
+Read-only tools exposed:
+
+| Tool | Returns |
+| ---- | ------- |
+| `cdk_doctor_report` | `doctor --report` JSON (28 checks) |
+| `cdk_team_settings` | parsed `.claude/team-settings.json` |
+| `cdk_arch_audit_status` | last `arch-audit` run timestamp + age |
+| `cdk_skill_inventory` | installed skills + frontmatter snapshot |
+| `cdk_package_meta` | CDK package name, version, CLI path, cwd |
+
+The server resolves the project root from `$CDK_PROJECT_ROOT` if set, otherwise from `process.cwd()`. No mutating tools in v1.17.0 by design.
 
 ---
 
@@ -161,7 +188,7 @@ npx mg-claude-dev-kit new skill               # create a custom skill (wizard)
 ## Testing
 
 ```bash
-node packages/cli/test/integration/run.js    # 1000 integration checks
+node packages/cli/test/integration/run.js    # 1009 integration checks
 node --test packages/cli/test/unit/*.test.js   # 365 unit tests
 ```
 
@@ -192,9 +219,9 @@ Covers: file structure per tier, Stop hook presence, pipeline gate counts, place
 
 See [GitHub Milestones](https://github.com/marcoguillermaz/claude-dev-kit/milestones) for the 12-month plan.
 
-**Current**: v1.16.0 ships `team-settings.json` for team-wide CLI governance (Q3 #3, Issue #94, ICE 175). Schema v1: `minTier` (s/m/l), `allowedSkills`, `blockedSkills`, `requiredSkills`. An empty or absent file means no restrictions, so existing setups keep working untouched. Enforcement covers `init` (refuses scaffolds below `minTier`), `upgrade` (refuses promotion-required scaffolds and suggests an alternative), `add skill` (refuses blocked or non-whitelisted skills, with `custom-*` bypassing the whitelist), and a new warn-level doctor check, `team-settings-compliance`. The doctor count moves from 27 to 28. Validation rejects any allowed/blocked overlap as a mutual-exclusion error. Native `Skill()` permission rules don't ship this release: Claude Code's permission grammar for skills isn't part of the documented public schema, so v1.16.0 keeps enforcement strictly CLI-side. Native rule generation is on the table for v1.17+. Integration: 1000 checks (+10 from `scenarioTeamSettings`). Unit: 365 tests (+22 from `team-settings.test.js`).
+**Current**: v1.17.0 ships the **CDK governance MCP server** (Q3 #4a, Issue #118, ICE 294). Any MCP-aware client (Claude Desktop, ChatGPT desktop, Cursor, VS Code, Copilot Studio) can now read CDK project state without the CDK CLI installed. The `mg-claude-dev-kit` npm package ships two binaries together — `claude-dev-kit` and `claude-dev-kit-mcp` — version-locked. Five read-only tools cover doctor reports, team-settings, last arch-audit run, skill inventory, and package metadata. Wire up via `.mcp.json` and CDK appears as a tool option in every MCP client your team already uses. This release is the first in which CDK is itself an MCP citizen rather than only a consumer. Integration: 1009 checks (+9 from `scenarioMCPServer`). Unit: 365 tests (unchanged — server logic covered by the integration scenario at the process boundary).
 
-**Next**: Q3 #4 `cdk sync` for cross-project rules sync (ICE 168), or Q2 #8 external review prompt template update (ICE 162). Q2 #3 VitePress docs site (ICE 432) stays on hold.
+**Next**: Q3 #4b MCP-aware audit skills (Issue #119, ICE 210), then a runtime-enforcement hook for `team-settings.json` (proposed by the 2026-04-26 external review, ICE ~240). The 2026-04-26 MCP reassessment memo records the full reasoning. Q2 #3 VitePress docs site (ICE 432) stays on hold.
 
 ---
 

--- a/docs/operational-guide.md
+++ b/docs/operational-guide.md
@@ -1256,6 +1256,30 @@ Enforcement points: `init` (refuse + explain), `upgrade` (refuse + suggest), `ad
 
 v1.16.0 keeps enforcement strictly CLI-side. Native `Skill()` permission rules in `.claude/settings.json` are not generated this release: Claude Code's permission grammar for skills is not part of the documented public schema. Native rule generation tracks for v1.17+, after upstream verification.
 
+### MCP server
+
+The `mg-claude-dev-kit` npm package ships two binaries: `claude-dev-kit` (the wizard CLI) and `claude-dev-kit-mcp` (a Model Context Protocol server). Version-locked, single install.
+
+The MCP server exposes CDK governance state to any MCP-aware client (Claude Desktop, ChatGPT desktop, Cursor, VS Code, Copilot Studio). Five read-only tools:
+
+- `cdk_doctor_report` — runs `doctor --report` and returns the JSON
+- `cdk_team_settings` — parsed `.claude/team-settings.json` contents
+- `cdk_arch_audit_status` — last arch-audit run timestamp + age in days
+- `cdk_skill_inventory` — installed skills with frontmatter snapshot
+- `cdk_package_meta` — package name, version, CLI path, project root
+
+Wire up by adding to `.mcp.json` (project-scoped) or `~/.claude/.mcp.json` (user-scoped):
+
+```json
+{
+  "mcpServers": {
+    "cdk": { "command": "claude-dev-kit-mcp" }
+  }
+}
+```
+
+The server resolves the project root from `$CDK_PROJECT_ROOT` if set, otherwise from the calling process's `cwd`. No mutating tools in v1.17.0 — adoption signal first, then read-write surface in a future minor.
+
 ### Adding team-specific rules
 
 Do not edit scaffolded rule files directly if you want upgrade compatibility. Instead:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mg-claude-dev-kit",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "Scaffold for legible, reviewable AI-assisted development",
   "type": "module",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,7 +4,8 @@
   "description": "Scaffold for legible, reviewable AI-assisted development",
   "type": "module",
   "bin": {
-    "claude-dev-kit": "src/index.js"
+    "claude-dev-kit": "src/index.js",
+    "claude-dev-kit-mcp": "src/mcp/server.js"
   },
   "files": [
     "src/",
@@ -20,6 +21,7 @@
     "format:check": "prettier --check src/ test/"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "chalk": "^5.3.0",
     "commander": "^14.0.0",
     "diff": "^9.0.0",

--- a/packages/cli/src/mcp/server.js
+++ b/packages/cli/src/mcp/server.js
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { execFileSync } from 'node:child_process';
+import { readFileSync, existsSync, readdirSync } from 'node:fs';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLI_PATH = resolve(__dirname, '..', 'index.js');
+
+function readPackageVersion() {
+  const pkg = JSON.parse(readFileSync(resolve(__dirname, '..', '..', 'package.json'), 'utf8'));
+  return pkg.version;
+}
+
+function getCwd() {
+  return process.env.CDK_PROJECT_ROOT || process.cwd();
+}
+
+function safeReadJson(path) {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch (err) {
+    return { _error: `parse failed: ${err.message}` };
+  }
+}
+
+function buildToolReply(payload) {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }],
+  };
+}
+
+function runDoctorReport(cwd) {
+  try {
+    const stdout = execFileSync('node', [CLI_PATH, 'doctor', '--report'], {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return JSON.parse(stdout);
+  } catch (err) {
+    const stdout = (err.stdout || '').toString();
+    if (stdout.trim().startsWith('{')) {
+      try {
+        return JSON.parse(stdout);
+      } catch {
+        // fall through
+      }
+    }
+    return {
+      _error: 'doctor invocation failed',
+      message: err.message,
+      stdout: stdout.slice(0, 2000),
+    };
+  }
+}
+
+function readTeamSettings(cwd) {
+  const file = join(cwd, '.claude', 'team-settings.json');
+  if (!existsSync(file)) return { present: false, settings: null };
+  const parsed = safeReadJson(file);
+  return { present: true, settings: parsed };
+}
+
+function readArchAuditStatus(cwd) {
+  const file = join(cwd, '.claude', 'session', 'last-arch-audit');
+  if (!existsSync(file)) {
+    return { everRan: false, lastRunUnix: null, lastRunIso: null };
+  }
+  try {
+    const raw = readFileSync(file, 'utf8').trim();
+    const epoch = Number.parseInt(raw, 10);
+    if (!Number.isFinite(epoch)) {
+      return {
+        everRan: true,
+        lastRunUnix: null,
+        lastRunIso: null,
+        _warning: `unparseable: ${raw.slice(0, 40)}`,
+      };
+    }
+    return {
+      everRan: true,
+      lastRunUnix: epoch,
+      lastRunIso: new Date(epoch * 1000).toISOString(),
+      ageDays: (Date.now() / 1000 - epoch) / 86400,
+    };
+  } catch (err) {
+    return { everRan: false, lastRunUnix: null, lastRunIso: null, _error: err.message };
+  }
+}
+
+function readSkillInventory(cwd) {
+  const skillsDir = join(cwd, '.claude', 'skills');
+  if (!existsSync(skillsDir)) return { skills: [], skillsDir, present: false };
+  const entries = readdirSync(skillsDir, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name);
+  const skills = [];
+  for (const name of entries) {
+    const skillFile = join(skillsDir, name, 'SKILL.md');
+    if (!existsSync(skillFile)) continue;
+    const raw = readFileSync(skillFile, 'utf8');
+    const fmMatch = raw.match(/^---\n([\s\S]*?)\n---/);
+    const frontmatter = {};
+    if (fmMatch) {
+      for (const line of fmMatch[1].split('\n')) {
+        const m = line.match(/^([a-zA-Z0-9_-]+):\s*(.*)$/);
+        if (m) frontmatter[m[1]] = m[2].trim();
+      }
+    }
+    skills.push({
+      name,
+      isCustom: name.startsWith('custom-'),
+      bodyLines: raw.split('\n').length,
+      description: frontmatter.description || null,
+      model: frontmatter.model || null,
+      userInvocable: frontmatter['user-invocable'] || null,
+      allowedTools: frontmatter['allowed-tools'] || null,
+    });
+  }
+  return { skills, skillsDir, present: true, count: skills.length };
+}
+
+function getPackageMeta() {
+  return {
+    name: 'mg-claude-dev-kit',
+    version: readPackageVersion(),
+    cliPath: CLI_PATH,
+    cwd: getCwd(),
+  };
+}
+
+export function buildServer() {
+  const server = new McpServer({
+    name: 'mg-claude-dev-kit',
+    version: readPackageVersion(),
+  });
+
+  server.registerTool(
+    'cdk_doctor_report',
+    {
+      title: 'CDK doctor report',
+      description:
+        'Runs `claude-dev-kit doctor --report` against the current project and returns the JSON compliance summary (28 checks: governance files, hooks, skill spec, security variant, drift markers).',
+      inputSchema: {},
+    },
+    async () => buildToolReply(runDoctorReport(getCwd())),
+  );
+
+  server.registerTool(
+    'cdk_team_settings',
+    {
+      title: 'CDK team-settings.json contents',
+      description:
+        'Returns the parsed `.claude/team-settings.json` for the current project. The `present` flag indicates whether the file exists; when absent, the project is unrestricted by CDK governance.',
+      inputSchema: {},
+    },
+    async () => buildToolReply(readTeamSettings(getCwd())),
+  );
+
+  server.registerTool(
+    'cdk_arch_audit_status',
+    {
+      title: 'Last arch-audit run status',
+      description:
+        'Returns the timestamp of the last `arch-audit` skill execution recorded in `.claude/session/last-arch-audit`, plus age in days. Useful to verify the weekly cadence is honoured.',
+      inputSchema: {},
+    },
+    async () => buildToolReply(readArchAuditStatus(getCwd())),
+  );
+
+  server.registerTool(
+    'cdk_skill_inventory',
+    {
+      title: 'Installed skills inventory',
+      description:
+        'Lists every skill installed in `.claude/skills/`, with frontmatter snapshot (description, model, allowed-tools, user-invocable). Custom skills are flagged separately.',
+      inputSchema: {},
+    },
+    async () => buildToolReply(readSkillInventory(getCwd())),
+  );
+
+  server.registerTool(
+    'cdk_package_meta',
+    {
+      title: 'CDK package metadata',
+      description:
+        'Returns the CDK package name, installed version, CLI path, and resolved project root. Useful for clients to verify which CDK CLI is wired up to this MCP server.',
+      inputSchema: {},
+    },
+    async () => buildToolReply(getPackageMeta()),
+  );
+
+  return server;
+}
+
+export async function startStdio() {
+  const server = buildServer();
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  startStdio().catch((err) => {
+    process.stderr.write(`mg-claude-dev-kit-mcp fatal: ${err.message}\n`);
+    process.exit(1);
+  });
+}

--- a/packages/cli/test/integration/run.js
+++ b/packages/cli/test/integration/run.js
@@ -3234,6 +3234,166 @@ async function scenarioTeamSettings() {
   }
 }
 
+async function scenarioMCPServer() {
+  section('CDK governance MCP server (v1.17.0): tool surface + read-only outputs');
+
+  const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
+  const { StdioClientTransport } = await import('@modelcontextprotocol/sdk/client/stdio.js');
+
+  const SERVER_PATH = path.resolve(__dirname, '../../src/mcp/server.js');
+
+  const config = { ...BASE, tier: 'm', isDiscovery: false };
+  const dir = await scaffold('mcp-server-tier-m', 'm', config);
+
+  // Drop a team-settings.json so cdk_team_settings has something interesting to return
+  fs.writeFileSync(
+    path.join(dir, '.claude/team-settings.json'),
+    JSON.stringify({ minTier: 'm', requiredSkills: ['arch-audit'] }, null, 2),
+  );
+
+  // Mark a recent arch-audit so cdk_arch_audit_status returns a populated payload
+  const sessionDir = path.join(dir, '.claude/session');
+  await fs.ensureDir(sessionDir);
+  const fixedEpoch = Math.floor(Date.now() / 1000) - 3 * 86400; // 3 days ago
+  fs.writeFileSync(path.join(sessionDir, 'last-arch-audit'), `${fixedEpoch}\n`);
+
+  const transport = new StdioClientTransport({
+    command: 'node',
+    args: [SERVER_PATH],
+    env: { ...process.env, CDK_PROJECT_ROOT: dir },
+    stderr: 'pipe',
+  });
+
+  const client = new Client(
+    { name: 'cdk-integration-test', version: '0.0.1' },
+    { capabilities: {} },
+  );
+
+  try {
+    await client.connect(transport);
+    pass('MCP server: connect via stdio succeeds');
+
+    const tools = await client.listTools();
+    const expected = [
+      'cdk_doctor_report',
+      'cdk_team_settings',
+      'cdk_arch_audit_status',
+      'cdk_skill_inventory',
+      'cdk_package_meta',
+    ];
+    const got = tools.tools.map((t) => t.name).sort();
+    if (JSON.stringify(got) === JSON.stringify(expected.sort())) {
+      pass(`MCP server: listTools returns ${expected.length} expected tools`);
+    } else {
+      fail(`MCP server: tool list mismatch. expected=${expected}, got=${got}`);
+    }
+
+    function parseToolReply(result) {
+      const text = result?.content?.[0]?.text;
+      if (!text) throw new Error('no content[0].text in tool result');
+      return JSON.parse(text);
+    }
+
+    const meta = parseToolReply(await client.callTool({ name: 'cdk_package_meta', arguments: {} }));
+    if (meta.name === 'mg-claude-dev-kit' && meta.cwd === dir) {
+      pass('cdk_package_meta: name + cwd correct');
+    } else {
+      fail(`cdk_package_meta: ${JSON.stringify(meta)}`);
+    }
+
+    const team = parseToolReply(
+      await client.callTool({ name: 'cdk_team_settings', arguments: {} }),
+    );
+    if (
+      team.present === true &&
+      team.settings?.minTier === 'm' &&
+      Array.isArray(team.settings?.requiredSkills)
+    ) {
+      pass('cdk_team_settings: present=true, minTier and requiredSkills parsed');
+    } else {
+      fail(`cdk_team_settings: ${JSON.stringify(team)}`);
+    }
+
+    const arch = parseToolReply(
+      await client.callTool({ name: 'cdk_arch_audit_status', arguments: {} }),
+    );
+    if (
+      arch.everRan === true &&
+      arch.lastRunUnix === fixedEpoch &&
+      typeof arch.ageDays === 'number'
+    ) {
+      pass(`cdk_arch_audit_status: lastRunUnix matches, ageDays=${arch.ageDays.toFixed(2)}`);
+    } else {
+      fail(`cdk_arch_audit_status: ${JSON.stringify(arch)}`);
+    }
+
+    const inv = parseToolReply(
+      await client.callTool({ name: 'cdk_skill_inventory', arguments: {} }),
+    );
+    if (inv.present === true && Array.isArray(inv.skills) && inv.count > 0) {
+      pass(`cdk_skill_inventory: present, count=${inv.count}`);
+    } else {
+      fail(`cdk_skill_inventory: ${JSON.stringify(inv)}`);
+    }
+
+    const doctorReport = parseToolReply(
+      await client.callTool({ name: 'cdk_doctor_report', arguments: {} }),
+    );
+    if (
+      doctorReport &&
+      typeof doctorReport.timestamp === 'string' &&
+      Array.isArray(doctorReport.checks) &&
+      doctorReport.checks.length >= 20
+    ) {
+      pass(
+        `cdk_doctor_report: ${doctorReport.checks.length} checks, summary=${JSON.stringify(doctorReport.summary)}`,
+      );
+    } else {
+      fail(`cdk_doctor_report: unexpected shape ${JSON.stringify(doctorReport).slice(0, 200)}`);
+    }
+
+    // Negative case: arch-audit absent
+    const dirNoAudit = await scaffold('mcp-server-no-audit', 'm', config);
+    const transport2 = new StdioClientTransport({
+      command: 'node',
+      args: [SERVER_PATH],
+      env: { ...process.env, CDK_PROJECT_ROOT: dirNoAudit },
+      stderr: 'pipe',
+    });
+    const client2 = new Client(
+      { name: 'cdk-integration-test-2', version: '0.0.1' },
+      { capabilities: {} },
+    );
+    await client2.connect(transport2);
+    const archEmpty = parseToolReply(
+      await client2.callTool({ name: 'cdk_arch_audit_status', arguments: {} }),
+    );
+    if (archEmpty.everRan === false && archEmpty.lastRunUnix === null) {
+      pass('cdk_arch_audit_status: clean scaffold reports everRan=false');
+    } else {
+      fail(`cdk_arch_audit_status (no run): ${JSON.stringify(archEmpty)}`);
+    }
+    const teamAbsent = parseToolReply(
+      await client2.callTool({ name: 'cdk_team_settings', arguments: {} }),
+    );
+    if (teamAbsent.present === false && teamAbsent.settings === null) {
+      pass('cdk_team_settings: absent file reports present=false');
+    } else {
+      fail(`cdk_team_settings (absent): ${JSON.stringify(teamAbsent)}`);
+    }
+    await client2.close();
+
+    await client.close();
+  } catch (err) {
+    fail(`MCP server scenario: ${err.message}`);
+    try {
+      await client.close();
+    } catch {
+      // ignore
+    }
+  }
+}
+
 // ── Main ─────────────────────────────────────────────────────────────────────
 
 async function main() {
@@ -3285,6 +3445,7 @@ async function main() {
   await scenarioComplianceAuditPresent();
   await scenarioUpgradeAnthropic();
   await scenarioTeamSettings();
+  await scenarioMCPServer();
 
   // ── Summary ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

CDK is now an MCP citizen, not just a consumer.

v1.17.0 ships `claude-dev-kit-mcp`, a Model Context Protocol server that exposes CDK's governance state to any MCP-aware client (Claude Desktop, ChatGPT desktop, Cursor, VS Code, Copilot Studio). The `mg-claude-dev-kit` npm package now ships two binaries together — `claude-dev-kit` and `claude-dev-kit-mcp` — version-locked, single `npm install -g`.

## Tool surface (read-only, v1)

| Tool | Returns |
| ---- | ------- |
| `cdk_doctor_report` | `doctor --report` JSON (28 checks) |
| `cdk_team_settings` | parsed `.claude/team-settings.json` |
| `cdk_arch_audit_status` | last `arch-audit` run timestamp + age in days |
| `cdk_skill_inventory` | installed skills + frontmatter snapshot |
| `cdk_package_meta` | name, version, CLI path, project root |

The server resolves the project root from `$CDK_PROJECT_ROOT`, otherwise from `process.cwd()`. Wire it up via `.mcp.json`:

```json
{ "mcpServers": { "cdk": { "command": "claude-dev-kit-mcp" } } }
```

## Why this matters

Highest-ICE item in the current CDK roadmap (ICE 294, scored after the 2026-04-26 MCP reassessment). It collapses three problems currently tracked separately:

1. **Distribution multiplier** — CDK reaches every MCP-aware client without requiring CLI adoption. A solo dev on Claude Desktop sees CDK signal inline.
2. **Telemetry foundation** — MCP server runtime registers invocations, giving CDK its first adoption signal without the SaaS endpoint that `cdk sync` (Q3 #5) was meant to build.
3. **Anti-commoditization** — CDK becomes an MCP citizen visible in server registries (Anthropic, awesome-mcp-servers, Cloudflare). Skip this and CDK risks marginalization as Anthropic's native primitives mature.

## Changes

- `feat(mcp)`: new `packages/cli/src/mcp/server.js` (5 tools, stdio transport, `@modelcontextprotocol/sdk` ^1.29.0). New `bin` entry `claude-dev-kit-mcp`.
- `test(mcp)`: integration scenario `scenarioMCPServer` (+9 checks). Spawns the server as a child process via the SDK client, lists tools, calls each, verifies JSON shape.
- `docs`: README CLI commands + new "MCP server" section + Current/Next paragraph rewrite. Operational guide gets an "MCP server" subsection.
- `chore(release)`: 1.16.0 → 1.17.0, CHANGELOG entry.

## Test plan

- [x] Local end-to-end smoke test: spawn server, listTools returns the expected 5, each tool returns parsed JSON of the expected shape on a scaffolded project and on a clean scaffold (everRan=false, present=false)
- [ ] CI: lint, unit (365), integration (1009), verify-cli, drift-tracker, codeql, dependency-review all green
- [ ] Manual: configure `.mcp.json` in a sample project, point Claude Desktop at it, verify `cdk_doctor_report` appears in Claude Desktop's tool surface and returns sensible output

Closes #118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)