### PR TITLE
docs: MCP prominence + R3 mandatory docs governance + npm keywords

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,11 +13,19 @@
 ## Checklist
 
 - [ ] Tested locally with `node packages/cli/src/index.js init` and/or `doctor`
-- [ ] `README.md` updated if behavior changed
-- [ ] `docs/operational-guide.md` updated if behavior changed
-- [ ] `CHANGELOG.md` updated under `[Unreleased]`
 - [ ] No placeholder syntax broken (`[PLACEHOLDER_NAME]` always uppercase with underscores)
 - [ ] Tier boundaries respected (no Tier L features in Tier M templates)
+
+### Documentation (mandatory for any user-facing change)
+
+A user-facing change is anything that adds, removes, or alters a CLI command, scaffolded file, skill, doctor check, MCP tool, schema, or public API surface. If this PR touches any of those, every applicable item below must be checked. If the PR is purely internal (refactor, test, CI, internal tooling), tick the last item to acknowledge no docs change was warranted.
+
+- [ ] `README.md` updated — opening tagline / "What it does" / Architecture diagram / CLI Commands / dedicated section, as relevant
+- [ ] `docs/operational-guide.md` updated with the corresponding subsection
+- [ ] `CHANGELOG.md` entry under `[Unreleased]` (or the new version block if this PR is the release)
+- [ ] PR title and body name the user-visible feature, not just the implementation detail
+- [ ] If a release: humanized GitHub Release notes drafted (R2 governance)
+- [ ] No user-facing change in this PR — internal/refactor/test/CI only
 
 ## Related issue
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,6 +133,8 @@ These conventions are mandatory for every PR. We follow them ourselves on every 
 
 **Mid-feature budget checkpoints.** When writing a `SKILL.md` body, run `wc -l` after roughly half the steps. If the body is trending over 400 lines with material left to write, extract stack-specific or layer-specific content into a sibling file before the budget runs out.
 
+**R3 — Documentation update is mandatory for any user-facing change.** A user-facing change is anything that adds, removes, or alters a CLI command, scaffolded file, skill, doctor check, MCP tool, schema, or public API surface. The PR cannot land until the relevant docs are touched: `README.md` where the surface is described (opening tagline, "What it does", Architecture, CLI Commands, dedicated section), `docs/operational-guide.md` for the operational subsection, and `CHANGELOG.md` with an entry under `[Unreleased]` or the release block. The `.github/PULL_REQUEST_TEMPLATE.md` checklist enforces this at PR-open time. Buried documentation is treated as a credibility regression — the smoke-test review on v1.16.0 caught exactly this drift, where a headline feature was technically present but invisible from the README.
+
 ---
 
 ## 6. Adding a new skill

--- a/README.md
+++ b/README.md
@@ -8,10 +8,13 @@
 
 > Scaffold for legible, reviewable AI-assisted development.
 > Claude generates. Your team decides.
+> MCP-native — read CDK governance state from Claude Desktop, ChatGPT, Cursor, VS Code.
 
 Claude Code is a powerful CLI that reads, writes, and reasons about your entire codebase. Without shared process, it makes autonomous decisions that are hard to track and harder to review.
 
 **claude-dev-kit** scaffolds a structured, reviewable development process on top of Claude Code. It enforces one non-negotiable rule mechanically: Claude cannot declare a task complete until your tests pass. Everything else scales with your needs.
+
+Since v1.17.0, CDK ships an MCP server alongside the CLI. Any MCP-aware client can read your project's doctor report, team-settings policy, last arch-audit, and skill inventory without anyone running the CDK CLI. See [MCP server](#mcp-server).
 
 ---
 
@@ -79,6 +82,10 @@ Skills are conditionally installed based on your project: `hasApi`, `hasDatabase
 
 Node.js/TS, Node.js/JS, Python, Go, Swift, Kotlin, Rust, .NET, Ruby, Java - plus generic fallback. Security rules, permissions, and CLAUDE.md fields adapt automatically.
 
+### MCP server (v1.17.0+)
+
+The `mg-claude-dev-kit` package ships an MCP server (`claude-dev-kit-mcp` binary) alongside the CLI, version-locked, single `npm install -g`. Any MCP-aware client (Claude Desktop, ChatGPT desktop, Cursor, VS Code, Copilot Studio) can query CDK governance state without the CDK CLI running. Five read-only tools cover doctor report, team-settings, last arch-audit, skill inventory, and package metadata. Full reference in the [MCP server](#mcp-server) section below.
+
 ### Incremental adoption
 
 Install individual components without a full scaffold:
@@ -100,13 +107,15 @@ your-project/
 ├── CLAUDE.md                    # Project context (<200 lines)
 ├── .claude/
 │   ├── settings.json            # Permissions + Stop hook (mechanical enforcement)
+│   ├── team-settings.json       # Team policy: minTier / allowed / blocked / required (v1.16+)
 │   ├── rules/
 │   │   ├── pipeline.md          # Development workflow (tier-appropriate)
 │   │   ├── security.md          # Stack-aware: web / apple / android / systems
 │   │   ├── git.md               # Commit format, branch rules
 │   │   └── output-style.md      # Communication rules
 │   ├── skills/                  # Audit skills (conditional per project)
-│   └── session/                 # Session recovery (gitignored)
+│   ├── session/                 # Session recovery (gitignored)
+│   └── .mcp.json                # Wire claude-dev-kit-mcp into MCP-aware clients (v1.17+)
 ├── docs/                        # Requirements, specs, backlog (M/L)
 ├── .github/                     # PR template, CODEOWNERS
 └── .pre-commit-config.yaml      # Secret scanning

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,6 +35,9 @@
   "keywords": [
     "claude",
     "claude-code",
+    "mcp",
+    "mcp-server",
+    "modelcontextprotocol",
     "ai",
     "developer-tools",
     "scaffold",

--- a/packages/cli/templates/common/PULL_REQUEST_TEMPLATE.md
+++ b/packages/cli/templates/common/PULL_REQUEST_TEMPLATE.md
@@ -34,6 +34,15 @@
 - [ ] New tests written for new behaviour (if applicable)
 - [ ] Smoke tested on staging
 
+## Documentation
+
+User-facing changes (CLI flags, public API, schemas, migrations, configuration) must be reflected in the corresponding project docs before merge. Internal-only changes (refactor, test, CI) tick the last item.
+
+- [ ] README updated where the user-facing surface is described
+- [ ] Inline docstrings or operational docs updated for new public APIs / schemas / commands
+- [ ] CHANGELOG entry under `[Unreleased]` or the relevant version block
+- [ ] No user-facing change — internal/refactor/test/CI only
+
 ## Breaking Changes
 
 - [ ] No breaking changes


### PR DESCRIPTION
## Summary

Three connected docs changes triggered by the realization that v1.17.0's headline feature (MCP server) was buried at section 6 of the README. The smoke-test review on v1.16.0 had flagged the same pattern (headline feature underdelivered in surface visibility); this PR closes that gap structurally so it can't recur.

### 1. README — MCP elevated from buried section 6 to headline

- Tagline now mentions "MCP-native — read CDK governance state from Claude Desktop, ChatGPT, Cursor, VS Code"
- Opening paragraph says "Since v1.17.0, CDK ships an MCP server alongside the CLI" with link to the dedicated section
- "What it does" section gets a new "MCP server (v1.17.0+)" subsection describing the value prop
- Architecture diagram now shows `team-settings.json` (v1.16+) and `.mcp.json` (v1.17+)
- Existing dedicated MCP section unchanged (already comprehensive)

### 2. R3 governance rule — documentation update is mandatory for any user-facing change

Added to `CONTRIBUTING.md` section 5 alongside R1 (`/commit`) and R2 (`/humanize`):

> A user-facing change is anything that adds, removes, or alters a CLI command, scaffolded file, skill, doctor check, MCP tool, schema, or public API surface. The PR cannot land until the relevant docs are touched.

The `.github/PULL_REQUEST_TEMPLATE.md` checklist enforces this at PR-open time with a dedicated "Documentation (mandatory for any user-facing change)" section. Internal-only changes (refactor, test, CI) tick the explicit "no user-facing change" item to acknowledge the bypass is conscious.

The scaffolded `packages/cli/templates/common/PULL_REQUEST_TEMPLATE.md` (used by user projects) gets a generic equivalent — symmetry with the CDK self-template, applicable to any project's docs.

### 3. npm package keywords for MCP discoverability

Added `mcp`, `mcp-server`, `modelcontextprotocol` to `packages/cli/package.json` keywords. Third-party MCP registries (Glama, mcp.so) auto-index npm by these keywords; without them, the v1.17.0 server is invisible to passive discovery.

## Public listing memo

Local maintainer memo at `.claude/initiatives/2026-04-26-mcp-public-listing.md` (gitignored) captures the action plan for the three priority channels (Official MCP Registry, Glama, Smithery) with exact submission commands. Three submissions are user-action items requiring credentials I can't run automatically — the memo is the action plan, the user executes.

## Changes

- `docs(readme)`: MCP prominence in tagline, opening paragraph, "What it does" subsection, Architecture diagram
- `docs(contributing)`: R3 mandatory-docs rule
- `docs(template)`: PR template gets dedicated Documentation section (root + scaffolded)
- `chore(deps)`: npm keywords for MCP discovery

## Test plan

- [x] `npm test` — 1009 integration checks pass (no scaffolded golden-file impact)
- [x] `npm run lint` — clean
- [x] `npx prettier --check` — clean
- [ ] CI mirror of the above
- [ ] Manual: rendered README Markdown shows MCP in the headline and TOC
- [ ] Manual: open a fresh PR after merge — verify the new template appears with the Documentation section

No version bump (docs-only PR per established pattern from #114, #117).

🤖 Generated with [Claude Code](https://claude.com/claude-code)