### PR TITLE
feat: v1.21.0 — team-settings runtime enforcement hook (closes v1.16 credibility gap)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,30 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.21.0] — 2026-04-28
+
+### Added
+
+- **`team-settings.json` runtime enforcement hook** (smoke-test review proposal, ICE ~240). New `.claude/hooks/team-settings-enforcement.mjs` script wired as a `PreToolUse` hook on the `Skill` matcher in `.claude/settings.json`. Refuses skill invocations that violate `blockedSkills` or `allowedSkills` at runtime, before the skill body executes. Closes the credibility gap flagged on v1.16: previously `team-settings.json` enforcement was CLI-only (a Claude Code session could bypass it by typing `/skill-name` directly); now it's mechanical at the agent runtime.
+- **Doctor check `team-settings-runtime-hook`** (warn-level): verifies the hook script is scaffolded AND `.claude/settings.json` registers it on the Skill matcher. Skips silently when `.claude/team-settings.json` is absent (unrestricted projects don't need the hook). Doctor check count: 28 → 29.
+- **Integration scenario `scenarioRuntimeEnforcementHook`** in `test/integration/run.js`: validates hook scaffolding across tier-s/m/l, settings.json registration, behavior on no-team-settings (allow), `blockedSkills` (deny JSON), `allowedSkills` whitelist (deny + custom-* bypass), non-Skill tools (passthrough), malformed settings (fail-open), and the doctor check passing/warning paths. ~14 new assertions.
+- **Hook protocol implementation** matches the Anthropic [PreToolUse hook spec](https://code.claude.com/docs/en/hooks): reads JSON from stdin (`tool_name`, `tool_input.skill_name`), returns `hookSpecificOutput.permissionDecision = "deny"` with reason on stdout for blocked invocations, exits 0 silently to allow.
+
+### Changed
+
+- All three tier templates (`tier-s/.claude/settings.json`, `tier-m`, `tier-l`) now register the `PreToolUse` Skill matcher. Tier-l merges with the pre-existing PreToolUse Bash destructive-command guard (the previous duplicate-key issue is fixed in this release).
+- Integration test count: 1100 → 1114 (+14 from `scenarioRuntimeEnforcementHook`).
+
+### Notes
+
+- The hook is intentionally fail-open. Any error (malformed stdin, missing project root, JSON parse failure, unexpected exception) results in exit 0 with no output — i.e., skill invocation is allowed. Rationale: the hook is a value-add, not a critical path; a bug in the hook itself should never lock a user out of all skills. The doctor `team-settings-compliance` check surfaces parse errors in interactive runs.
+- Custom skills (`custom-*` prefix) bypass the `allowedSkills` whitelist (matches v1.16 CLI semantics) but NOT the `blockedSkills` denylist (governance overrides the "custom skills preserved across upgrades" convention). The hook implements both rules consistently with the CLI side.
+- The hook script is self-contained (no CDK package dependency at hook-execution time) so user projects don't need to keep `node_modules` for it. It uses only Node built-ins (`node:fs`, `node:path`).
+- Hook timeout is 5 seconds. The hook script does I/O on a small JSON file and exits — well under the budget. If the hook ever exceeds 5s, treat it as a CDK bug, not a user-config issue.
+- This release closes the architectural feedback loop opened by the 2026-04-26 smoke-test review on v1.16.
+
+---
+
 ## [1.20.0] — 2026-04-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Node.js >= 22](https://img.shields.io/badge/node-%3E%3D22-brightgreen.svg)](https://nodejs.org)
 [![CI](https://github.com/marcoguillermaz/claude-dev-kit/actions/workflows/ci.yml/badge.svg)](https://github.com/marcoguillermaz/claude-dev-kit/actions/workflows/ci.yml)
-[![1100 integration checks](https://img.shields.io/badge/integration-1100%20checks-blue.svg)](#testing)
+[![1114 integration checks](https://img.shields.io/badge/integration-1114%20checks-blue.svg)](#testing)
 
 > Scaffold for legible, reviewable AI-assisted development.
 > Claude generates. Your team decides.
@@ -200,7 +200,7 @@ The server resolves the project root from `$CDK_PROJECT_ROOT` if set, otherwise 
 ## Testing
 
 ```bash
-node packages/cli/test/integration/run.js    # 1100 integration checks
+node packages/cli/test/integration/run.js    # 1114 integration checks
 node --test packages/cli/test/unit/*.test.js   # 373 unit tests
 ```
 
@@ -231,9 +231,9 @@ Covers: file structure per tier, Stop hook presence, pipeline gate counts, place
 
 See [GitHub Milestones](https://github.com/marcoguillermaz/claude-dev-kit/milestones) for the 12-month plan.
 
-**Current**: v1.20.0 ships **MCP-aware audit skills** (Q3 #4b, Issue #119, ICE 210). `/security-audit` Step 3c now queries the [`mcp-nvd`](https://github.com/marcoeg/mcp-nvd) MCP server for live CVE data; `/dependency-audit` Step 2 queries [`package-registry-mcp`](https://github.com/Artmann/package-registry-mcp) for multi-ecosystem package metadata. Both skills fall back to their existing static logic with a clear warning when the MCP server is unreachable, so projects without MCP wiring keep working unchanged. Frontmatter declares the consumed `mcp__*` tools per Anthropic spec. Issue #119 originally bundled three skills; the third (`/arch-audit` instrumentation against Anthropic's Claude Code spec) is **deferred** because no production-grade MCP server exists for `code.claude.com/docs` as of 2026-04-27 — wrapping the existing WebFetch path in an MCP layer would have added indirection without value. Re-evaluate when Anthropic ships an official spec MCP server. Integration: 1100 checks (+15 from `scenarioMcpAwareSkillsV120`).
+**Current**: v1.21.0 ships **`team-settings.json` runtime enforcement** (smoke-test review proposal, ICE ~240). The new `.claude/hooks/team-settings-enforcement.mjs` script — wired as a `PreToolUse` hook on the `Skill` matcher — refuses skill invocations that violate `blockedSkills` or `allowedSkills` at runtime, before the skill body executes. This closes the credibility gap flagged on v1.16: previously `team-settings.json` enforcement was CLI-only (a Claude Code session could bypass it by typing `/skill-name` directly); now it's mechanical at the agent runtime. The hook fails-open on any error (malformed input, missing files, parse errors) so a misconfigured project never loses access to all skills — worst case is the v1.16-1.20 status quo. Doctor gains a new check `team-settings-runtime-hook` (warn-level, skips when team-settings.json is absent). Integration: 1114 checks (+14 from `scenarioRuntimeEnforcementHook`). v1.20.0 (MCP-aware audit skills) shipped 2026-04-27; the 2026-04-28 cross-LLM re-score on Q3 #6 sub-tracks 2-3 closed `/debt-triage` (fold the churn-axis prioritization into `/skill-dev` v2) and deferred `/privacy-audit` with explicit re-eval criteria.
 
-**Next**: Q3 #6 sub-tracks 2-3 (`/debt-triage`, `/privacy-audit`) cross-LLM re-score, then runtime-enforcement hook for `team-settings.json` (smoke-test review proposal, ICE ~240), then `/arch-audit` MCP-aware once the upstream server lands. Q2 #3 VitePress docs site (ICE 432) stays on hold.
+**Next**: `/skill-dev` v2 enhancement (churn × debt prioritization output, low-priority backlog), `/arch-audit` MCP-aware once the upstream Anthropic spec MCP server lands. Q2 #3 VitePress docs site (ICE 432) stays on hold.
 
 ---
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mg-claude-dev-kit",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "Scaffold for legible, reviewable AI-assisted development",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/doctor.js
+++ b/packages/cli/src/commands/doctor.js
@@ -621,6 +621,61 @@ const checks = [
     },
   },
   {
+    id: 'team-settings-runtime-hook',
+    label:
+      '`team-settings.json` runtime enforcement hook is wired (`.claude/hooks/team-settings-enforcement.mjs` + PreToolUse Skill matcher in settings.json)',
+    check: (cwd) => {
+      const teamSettingsPath = path.join(cwd, '.claude', 'team-settings.json');
+      if (!fs.existsSync(teamSettingsPath)) return { pass: true, skip: true };
+
+      const hookScript = path.join(cwd, '.claude', 'hooks', 'team-settings-enforcement.mjs');
+      if (!fs.existsSync(hookScript)) {
+        return {
+          pass: false,
+          warn: true,
+          info: 'team-settings.json present but `.claude/hooks/team-settings-enforcement.mjs` missing — runtime enforcement disabled (CLI-side enforcement only).',
+          fix: 'Run `claude-dev-kit upgrade` to refresh the hook script, or copy it manually from the CDK template.',
+        };
+      }
+
+      const settingsPath = path.join(cwd, '.claude', 'settings.json');
+      if (!fs.existsSync(settingsPath)) {
+        return {
+          pass: false,
+          warn: true,
+          info: 'team-settings.json + hook script present, but `.claude/settings.json` missing — hook will not fire.',
+          fix: 'Run `claude-dev-kit init` to scaffold settings.json, or restore from the CDK template.',
+        };
+      }
+
+      try {
+        const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+        const preToolUse = settings?.hooks?.PreToolUse || [];
+        const skillMatcher = preToolUse.find((entry) => entry.matcher === 'Skill');
+        const hasHook = skillMatcher?.hooks?.some(
+          (h) => typeof h.command === 'string' && /team-settings-enforcement\.mjs/.test(h.command),
+        );
+        if (!hasHook) {
+          return {
+            pass: false,
+            warn: true,
+            info: '`.claude/settings.json` does not register the team-settings PreToolUse hook for the Skill matcher.',
+            fix: 'Add a PreToolUse entry with matcher \'Skill\' that runs `node "$CLAUDE_PROJECT_DIR/.claude/hooks/team-settings-enforcement.mjs"` (timeout: 5).',
+          };
+        }
+      } catch (err) {
+        return {
+          pass: false,
+          warn: true,
+          info: `Could not parse settings.json: ${err.message}`,
+          fix: 'Fix the JSON syntax in .claude/settings.json.',
+        };
+      }
+
+      return { pass: true };
+    },
+  },
+  {
     id: 'permissions-no-duplicates',
     label: 'No duplicate entries in permissions deny list',
     check: (cwd) => {

--- a/packages/cli/templates/common/.claude/hooks/team-settings-enforcement.mjs
+++ b/packages/cli/templates/common/.claude/hooks/team-settings-enforcement.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+// team-settings runtime enforcement hook (CDK v1.21+).
+// Wired as a `PreToolUse` hook on the `Skill` matcher. Reads `.claude/team-settings.json`
+// from the project and refuses skill invocations that violate `blockedSkills` or
+// `allowedSkills`. Falls open silently on any error so a misconfigured project never
+// loses access to all skills — the worst case is the v1.16-1.20 status quo
+// (CLI-side enforcement only).
+//
+// Spec reference: https://code.claude.com/docs/en/hooks
+//   - matcher: "Skill"
+//   - input: JSON on stdin with tool_name="Skill" and tool_input.skill_name
+//   - block: exit 0 with hookSpecificOutput.permissionDecision = "deny" + reason
+//   - allow: exit 0 silently (no output)
+
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const PROJECT_DIR = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+const SETTINGS_PATH = path.join(PROJECT_DIR, '.claude', 'team-settings.json');
+
+function readStdin() {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => {
+      data += chunk;
+    });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', reject);
+  });
+}
+
+function denyReply(reason) {
+  return {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'deny',
+      permissionDecisionReason: reason,
+    },
+  };
+}
+
+function extractSkillName(payload) {
+  const ti = payload?.tool_input;
+  if (!ti) return null;
+  return ti.skill_name || ti.skill || ti.name || null;
+}
+
+async function main() {
+  const stdin = await readStdin();
+  if (!stdin || !stdin.trim()) {
+    process.exit(0); // empty input → allow
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(stdin);
+  } catch {
+    process.exit(0); // malformed input → fail-open
+  }
+
+  if (payload.tool_name !== 'Skill') {
+    process.exit(0); // not a skill invocation → don't interfere
+  }
+
+  const skillName = extractSkillName(payload);
+  if (!skillName) {
+    process.exit(0); // can't determine skill name → fail-open
+  }
+
+  if (!existsSync(SETTINGS_PATH)) {
+    process.exit(0); // no team-settings.json → unrestricted (v1.16+ semantics)
+  }
+
+  let settings;
+  try {
+    settings = JSON.parse(readFileSync(SETTINGS_PATH, 'utf8'));
+  } catch {
+    // malformed settings → fail-open. The CDK doctor check on team-settings-compliance
+    // will surface the parse error in interactive runs.
+    process.exit(0);
+  }
+
+  // blockedSkills: hard deny (custom-* is NOT exempt; matches v1.16 CLI semantics).
+  if (Array.isArray(settings.blockedSkills) && settings.blockedSkills.includes(skillName)) {
+    process.stdout.write(
+      JSON.stringify(
+        denyReply(
+          `Skill "${skillName}" is blocked by .claude/team-settings.json (blockedSkills). Edit the file or use a different skill.`,
+        ),
+      ),
+    );
+    process.exit(0);
+  }
+
+  // allowedSkills: whitelist deny (custom-* IS exempt; matches v1.16 CLI semantics).
+  if (Array.isArray(settings.allowedSkills) && settings.allowedSkills.length > 0) {
+    if (!skillName.startsWith('custom-') && !settings.allowedSkills.includes(skillName)) {
+      process.stdout.write(
+        JSON.stringify(
+          denyReply(
+            `Skill "${skillName}" is not in the allowedSkills list of .claude/team-settings.json. Allowed: ${settings.allowedSkills.join(', ')}. Custom skills (custom-*) bypass this check.`,
+          ),
+        ),
+      );
+      process.exit(0);
+    }
+  }
+
+  // Default: allow.
+  process.exit(0);
+}
+
+main().catch((err) => {
+  // Any unexpected error → fail-open. Never block the user because the hook itself failed.
+  process.stderr.write(`team-settings hook error (failing open): ${err.message}\n`);
+  process.exit(0);
+});

--- a/packages/cli/templates/tier-l/.claude/settings.json
+++ b/packages/cli/templates/tier-l/.claude/settings.json
@@ -52,6 +52,16 @@
     ],
     "PreToolUse": [
       {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/team-settings-enforcement.mjs\"",
+            "timeout": 5
+          }
+        ]
+      },
+      {
         "matcher": "Bash",
         "hooks": [
           {

--- a/packages/cli/templates/tier-m/.claude/settings.json
+++ b/packages/cli/templates/tier-m/.claude/settings.json
@@ -18,6 +18,18 @@
     ]
   },
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/team-settings-enforcement.mjs\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/packages/cli/templates/tier-s/.claude/settings.json
+++ b/packages/cli/templates/tier-s/.claude/settings.json
@@ -21,6 +21,18 @@
     ]
   },
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/team-settings-enforcement.mjs\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/packages/cli/test/integration/run.js
+++ b/packages/cli/test/integration/run.js
@@ -2826,6 +2826,224 @@ async function scenarioInfraAuditPresent() {
   }
 }
 
+async function scenarioRuntimeEnforcementHook() {
+  section('team-settings runtime enforcement hook (v1.21.0)');
+
+  const HOOK_PATH = path.resolve(
+    __dirname,
+    '../../templates/common/.claude/hooks/team-settings-enforcement.mjs',
+  );
+
+  function invokeHook(cwd, payload) {
+    try {
+      const out = execFileSync('node', [HOOK_PATH], {
+        cwd,
+        encoding: 'utf8',
+        input: JSON.stringify(payload),
+        env: { ...process.env, CLAUDE_PROJECT_DIR: cwd },
+      });
+      return { code: 0, out };
+    } catch (e) {
+      return { code: e.status || 1, out: (e.stdout || '').toString() };
+    }
+  }
+
+  for (const tier of ['s', 'm', 'l']) {
+    const config = { ...BASE, tier, isDiscovery: false };
+    const dir = await scaffold(`runtime-enforcement-tier-${tier}`, tier, config);
+
+    const hookFile = path.join(dir, '.claude/hooks/team-settings-enforcement.mjs');
+    if (fs.existsSync(hookFile)) {
+      pass(`Tier ${tier}: hook script scaffolded at .claude/hooks/team-settings-enforcement.mjs`);
+    } else {
+      fail(`Tier ${tier}: hook script missing`);
+      continue;
+    }
+
+    const settings = JSON.parse(fs.readFileSync(path.join(dir, '.claude/settings.json'), 'utf8'));
+    const preToolUse = settings?.hooks?.PreToolUse || [];
+    const skillMatcher = preToolUse.find((e) => e.matcher === 'Skill');
+    if (skillMatcher?.hooks?.some((h) => /team-settings-enforcement\.mjs/.test(h.command || ''))) {
+      pass(`Tier ${tier}: settings.json registers PreToolUse Skill matcher with hook command`);
+    } else {
+      fail(`Tier ${tier}: settings.json does not register the runtime enforcement hook`);
+    }
+  }
+
+  // Behavior tests against the hook script directly.
+  const dir = await scaffold('runtime-enforcement-behavior', 'm', {
+    ...BASE,
+    tier: 'm',
+    isDiscovery: false,
+  });
+
+  // No team-settings.json → allow (exit 0, no output)
+  {
+    const r = invokeHook(dir, {
+      tool_name: 'Skill',
+      tool_input: { skill_name: 'security-audit' },
+    });
+    if (r.code === 0 && r.out.trim() === '') {
+      pass('No team-settings.json: hook allows silently');
+    } else {
+      fail(`No team-settings.json: hook returned code=${r.code} out=${r.out.slice(0, 100)}`);
+    }
+  }
+
+  // blockedSkills hits → deny JSON
+  fs.writeFileSync(
+    path.join(dir, '.claude/team-settings.json'),
+    JSON.stringify({ blockedSkills: ['security-audit'] }, null, 2),
+  );
+  {
+    const r = invokeHook(dir, {
+      tool_name: 'Skill',
+      tool_input: { skill_name: 'security-audit' },
+    });
+    let parsed = null;
+    try {
+      parsed = JSON.parse(r.out);
+    } catch {
+      // ignore
+    }
+    if (
+      r.code === 0 &&
+      parsed?.hookSpecificOutput?.permissionDecision === 'deny' &&
+      /blocked/.test(parsed?.hookSpecificOutput?.permissionDecisionReason || '')
+    ) {
+      pass('blockedSkills: hook returns deny JSON with reason mentioning blocked');
+    } else {
+      fail(`blockedSkills: hook code=${r.code} out=${r.out.slice(0, 200)}`);
+    }
+  }
+
+  // allowedSkills whitelist refuses skill not in list (custom-* exempt)
+  fs.writeFileSync(
+    path.join(dir, '.claude/team-settings.json'),
+    JSON.stringify({ allowedSkills: ['arch-audit', 'visual-audit'] }, null, 2),
+  );
+  {
+    const r = invokeHook(dir, {
+      tool_name: 'Skill',
+      tool_input: { skill_name: 'security-audit' },
+    });
+    let parsed = null;
+    try {
+      parsed = JSON.parse(r.out);
+    } catch {
+      // ignore
+    }
+    if (
+      r.code === 0 &&
+      parsed?.hookSpecificOutput?.permissionDecision === 'deny' &&
+      /allowedSkills/.test(parsed?.hookSpecificOutput?.permissionDecisionReason || '')
+    ) {
+      pass('allowedSkills whitelist: hook denies skill not in list');
+    } else {
+      fail(`allowedSkills deny: code=${r.code} out=${r.out.slice(0, 200)}`);
+    }
+  }
+
+  // custom-* bypasses allowedSkills
+  {
+    const r = invokeHook(dir, {
+      tool_name: 'Skill',
+      tool_input: { skill_name: 'custom-experimental' },
+    });
+    if (r.code === 0 && r.out.trim() === '') {
+      pass('allowedSkills: custom-* skill bypasses whitelist');
+    } else {
+      fail(`custom-* bypass: code=${r.code} out=${r.out.slice(0, 200)}`);
+    }
+  }
+
+  // Non-Skill tool: hook does not interfere
+  {
+    const r = invokeHook(dir, {
+      tool_name: 'Bash',
+      tool_input: { command: 'ls' },
+    });
+    if (r.code === 0 && r.out.trim() === '') {
+      pass('Non-Skill tool (Bash): hook passes through silently');
+    } else {
+      fail(`Bash passthrough: code=${r.code} out=${r.out.slice(0, 200)}`);
+    }
+  }
+
+  // Malformed team-settings.json: hook fails-open (allow)
+  fs.writeFileSync(path.join(dir, '.claude/team-settings.json'), '{not json');
+  {
+    const r = invokeHook(dir, {
+      tool_name: 'Skill',
+      tool_input: { skill_name: 'security-audit' },
+    });
+    if (r.code === 0 && r.out.trim() === '') {
+      pass('Malformed team-settings.json: hook fails open (allows silently)');
+    } else {
+      fail(`Malformed settings: code=${r.code} out=${r.out.slice(0, 200)}`);
+    }
+  }
+
+  // Doctor team-settings-runtime-hook check passes when wired correctly
+  {
+    fs.writeFileSync(
+      path.join(dir, '.claude/team-settings.json'),
+      JSON.stringify({ blockedSkills: ['security-audit'] }, null, 2),
+    );
+    let out;
+    try {
+      out = execFileSync(
+        'node',
+        [path.resolve(__dirname, '../../src/index.js'), 'doctor', '--report'],
+        { cwd: dir, encoding: 'utf8' },
+      );
+    } catch (e) {
+      out = (e.stdout || '').toString();
+    }
+    let report = null;
+    try {
+      report = JSON.parse(out);
+    } catch {
+      // ignore
+    }
+    const check = report?.checks?.find((c) => c.id === 'team-settings-runtime-hook');
+    if (check && check.status === 'pass') {
+      pass(
+        'doctor team-settings-runtime-hook: pass when team-settings.json + hook + settings.json all present',
+      );
+    } else {
+      fail(`doctor team-settings-runtime-hook: ${check?.status} info=${check?.info}`);
+    }
+  }
+
+  // Doctor team-settings-runtime-hook check warns when hook is removed
+  {
+    fs.unlinkSync(path.join(dir, '.claude/hooks/team-settings-enforcement.mjs'));
+    let out;
+    try {
+      out = execFileSync(
+        'node',
+        [path.resolve(__dirname, '../../src/index.js'), 'doctor', '--report'],
+        { cwd: dir, encoding: 'utf8' },
+      );
+    } catch (e) {
+      out = (e.stdout || '').toString();
+    }
+    let report = null;
+    try {
+      report = JSON.parse(out);
+    } catch {
+      // ignore
+    }
+    const check = report?.checks?.find((c) => c.id === 'team-settings-runtime-hook');
+    if (check && check.status === 'warn' && /missing/.test(check.info || '')) {
+      pass('doctor team-settings-runtime-hook: warns when hook script is missing');
+    } else {
+      fail(`doctor warn missing: ${check?.status} info=${check?.info}`);
+    }
+  }
+}
+
 async function scenarioMcpAwareSkillsV120() {
   section('MCP-aware skill instrumentation: security-audit + dependency-audit (v1.20.0)');
 
@@ -3719,6 +3937,7 @@ async function main() {
   await scenarioDependencyAuditPresent();
   await scenarioPrReviewPresent();
   await scenarioMcpAwareSkillsV120();
+  await scenarioRuntimeEnforcementHook();
   await scenarioUpgradeAnthropic();
   await scenarioTeamSettings();
   await scenarioMCPServer();


### PR DESCRIPTION
## Summary

v1.21.0 closes the architectural feedback loop opened by the 2026-04-26 smoke-test review on v1.16.

The new `.claude/hooks/team-settings-enforcement.mjs` script — wired as a `PreToolUse` hook on the `Skill` matcher in `.claude/settings.json` — refuses skill invocations that violate `blockedSkills` or `allowedSkills` at runtime, before the skill body executes. Previously, `team-settings.json` enforcement was CLI-only: a Claude Code session could bypass it by typing `/skill-name` directly. Now it's mechanical at the agent runtime.

## Why this matters

The 2026-04-26 smoke-test review flagged this exact gap as the v1.16 release's "credibility hole":

> The whole pitch is mechanical enforcement, but the headline 1.16 feature (`team-settings.json`) is bypassed by typing `/security-audit` in a session — the exact path most users take.

That review proposed a runtime enforcement hook with ICE ~240. v1.21.0 delivers it.

## Hook design

- **Wired as `PreToolUse` with matcher `Skill`** per Anthropic spec.
- Reads JSON from stdin (`tool_name`, `tool_input.skill_name`).
- Returns `hookSpecificOutput.permissionDecision = "deny"` with reason on stdout for blocked invocations.
- Exits 0 silently to allow.
- **Fail-open on any error** (malformed input, missing files, parse errors) — the hook never locks a user out of all skills if it fails. Worst case is the v1.16-1.20 status quo (CLI-only enforcement). Doctor `team-settings-compliance` surfaces parse errors in interactive runs.
- Self-contained Node script — no CDK package dependency at hook-execution time.
- 5-second timeout; the hook does I/O on a small JSON file and exits.

## Semantics match v1.16 CLI

- `blockedSkills`: hard deny (custom-* NOT exempt).
- `allowedSkills`: whitelist deny (custom-* IS exempt by design — custom skills are not part of the team-settings whitelist scope).
- Non-Skill tool invocations: passthrough (the hook only governs Skill calls).

## Doctor coverage

New check `team-settings-runtime-hook` (warn-level). Skips silently when `.claude/team-settings.json` is absent. When present, it verifies:
1. The hook script `.claude/hooks/team-settings-enforcement.mjs` is scaffolded.
2. `.claude/settings.json` registers the hook on the `PreToolUse` Skill matcher.
3. The registered command references `team-settings-enforcement.mjs`.

Doctor check count: 28 → 29.

## Tier-l fix

While adding the PreToolUse Skill matcher, the existing tier-l template's PreToolUse Bash destructive-command guard was discovered as a duplicate `PreToolUse` JSON key (the second declaration silently overwrote the first). Both entries are now merged into a single `PreToolUse` array with two matchers (Skill + Bash), each with its own hook command.

## Changes

- `feat(scaffold)`: new hook script + PreToolUse Skill matcher in tier-s/m/l settings.json templates. Tier-l merge fix (PreToolUse duplicate-key bug).
- `feat(doctor)`: `team-settings-runtime-hook` check (warn-level, skip when team-settings.json absent).
- `test(team-settings)`: integration scenario validates scaffolding, settings registration, behavior across allow/deny/passthrough/fail-open paths, and doctor check pass/warn states.
- `chore(release)`: 1.20.0 → 1.21.0; CHANGELOG entry; README Current/Next paragraph rewrite.

## Test plan

- [x] `npm test` — 1114 integration checks (1100 → +14 from `scenarioRuntimeEnforcementHook`)
- [x] `npm run test:unit` — 373 tests (no new unit tests; hook tested end-to-end via integration)
- [x] `npm run lint` + `npx prettier --check` — both clean
- [ ] CI mirror of the above
- [ ] Manual: scaffold a tier-m project, drop a `team-settings.json` with `blockedSkills: ["security-audit"]`, open Claude Code, type `/security-audit` — verify the session shows the deny reason

## Reference

- Smoke-test review that surfaced the gap: `docs/reviews/2026-04-26-quick/synthesis.md`
- Anthropic hooks spec: https://code.claude.com/docs/en/hooks
- v1.16.0 release that introduced team-settings.json: https://github.com/marcoguillermaz/claude-dev-kit/releases/tag/v1.16.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)