### PR TITLE
feat: v1.22.0 — /skill-dev v2 hotspot priority (churn × debt)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,29 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.22.0] — 2026-04-28
+
+### Added
+
+- **`/skill-dev` Step 3b — Hotspot priority (churn × debt)**: new step computes a remediation priority matrix by intersecting per-file debt count (from Step 2 D1–D10 + Step 3 J1–J5 matches) with code churn from `git log --since="6.months.ago" --numstat`. Ranks files into 4 quadrants (Q1 hot mess / Q2 stable rot / Q3 flaky frontier / Q4 cold corner) and renders a top-10 hotspot table in the audit report. Origin: 2026-04-28 cross-LLM verdict on Issue #97 sub-track 2 (`/debt-triage` was closed; the differentiating churn-axis prioritization was folded here per all three reviewers' convergent recommendation).
+- **Hotspot priority report section**: between "Findings requiring action" and "Backlog decision gate". Top-10 rows max, sorted Q1 first by debt_count desc, then Q2/Q3/Q4. Skips with explicit "Hotspot table skipped: insufficient signal" wording on non-Git projects or projects with < 5 files showing both debt and churn.
+- **Integration scenario `scenarioSkillDevHotspot`** in `test/integration/run.js`: validates Step 3b presence, git log churn command, 4-quadrant matrix wording, report section header, and fallback wording. Tier-s + tier-m + tier-l (skill-dev minTier='s' so it ships in all three).
+
+### Changed
+
+- `/skill-dev` SKILL.md body: 330 → 368 lines (+38 lines for Step 3b + report section). Tier-s + tier-m + tier-l byte-identical.
+- Integration test count: 1114 → 1129 (+15 from `scenarioSkillDevHotspot`).
+- README skill table: `/skill-dev` row now mentions Step 3b hotspot priority.
+
+### Notes
+
+- v1.22.0 is intentionally minimal in scope. The cross-LLM verdict on 2026-04-28 said the differentiation between `/debt-triage` and `/skill-dev` was the churn-axis prioritization — nothing else. This release adds exactly that, no more. `/debt-triage` stays closed.
+- The 6-month churn window is hard-coded for v1.22. A configurable window via `CLAUDE.md` comment is documented in the skill body as a future iteration; the maintainer's bias is to ship the simple version first and add configurability only if a real project surfaces a need.
+- Hotspot priority does NOT gate the backlog. Every finding above Low severity still goes through Step 4's debt-density escalation + regression-risk downgrade unchanged. The hotspot section re-orders backlog work by leverage; it does not add or remove findings.
+- This release closes the work item created by the 2026-04-28 cross-LLM verdict. Issue #97 sub-track 3 (`/privacy-audit`) remains deferred per the criteria pinned in that comment.
+
+---
+
 ## [1.21.0] — 2026-04-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Node.js >= 22](https://img.shields.io/badge/node-%3E%3D22-brightgreen.svg)](https://nodejs.org)
 [![CI](https://github.com/marcoguillermaz/claude-dev-kit/actions/workflows/ci.yml/badge.svg)](https://github.com/marcoguillermaz/claude-dev-kit/actions/workflows/ci.yml)
-[![1114 integration checks](https://img.shields.io/badge/integration-1114%20checks-blue.svg)](#testing)
+[![1129 integration checks](https://img.shields.io/badge/integration-1129%20checks-blue.svg)](#testing)
 
 > Scaffold for legible, reviewable AI-assisted development.
 > Claude generates. Your team decides.
@@ -58,7 +58,7 @@ Executable multi-step programs that run inside Claude Code. Not prompt instructi
 | `/arch-audit`          | S M L | Governance files vs Anthropic docs. Auto-fixes deprecations.                                                                            |
 | `/security-audit`      | S M L | Auth, input validation, RLS, CVE scan. 3-path: WEB / NATIVE / HYBRID. **MCP-aware (v1.20+)**: Step 3c queries `mcp-nvd` server for live CVE data with local audit fallback. |
 | `/perf-audit`          | S M L | Bundle size, serial awaits, query efficiency. 8-stack patterns.                                                                         |
-| `/skill-dev`           | S M L | Coupling, duplication, dead code, debt-density.                                                                                         |
+| `/skill-dev`           | S M L | Coupling, duplication, dead code, debt-density. **Step 3b (v1.22+)**: hotspot priority via churn × debt — top-10 ranked by 4-quadrant matrix using `git log --since="6.months.ago"`.                                                                                         |
 | `/simplify`            | S M L | Early returns, nesting, dead code. Applies changes directly.                                                                            |
 | `/commit`              | S M L | Conventional Commits - auto-detects type, scope, description.                                                                           |
 | `/api-design`          | M L   | URL naming, HTTP verbs, response envelope, pagination.                                                                                  |
@@ -200,7 +200,7 @@ The server resolves the project root from `$CDK_PROJECT_ROOT` if set, otherwise 
 ## Testing
 
 ```bash
-node packages/cli/test/integration/run.js    # 1114 integration checks
+node packages/cli/test/integration/run.js    # 1129 integration checks
 node --test packages/cli/test/unit/*.test.js   # 373 unit tests
 ```
 
@@ -231,9 +231,9 @@ Covers: file structure per tier, Stop hook presence, pipeline gate counts, place
 
 See [GitHub Milestones](https://github.com/marcoguillermaz/claude-dev-kit/milestones) for the 12-month plan.
 
-**Current**: v1.21.0 ships **`team-settings.json` runtime enforcement** (smoke-test review proposal, ICE ~240). The new `.claude/hooks/team-settings-enforcement.mjs` script — wired as a `PreToolUse` hook on the `Skill` matcher — refuses skill invocations that violate `blockedSkills` or `allowedSkills` at runtime, before the skill body executes. This closes the credibility gap flagged on v1.16: previously `team-settings.json` enforcement was CLI-only (a Claude Code session could bypass it by typing `/skill-name` directly); now it's mechanical at the agent runtime. The hook fails-open on any error (malformed input, missing files, parse errors) so a misconfigured project never loses access to all skills — worst case is the v1.16-1.20 status quo. Doctor gains a new check `team-settings-runtime-hook` (warn-level, skips when team-settings.json is absent). Integration: 1114 checks (+14 from `scenarioRuntimeEnforcementHook`). v1.20.0 (MCP-aware audit skills) shipped 2026-04-27; the 2026-04-28 cross-LLM re-score on Q3 #6 sub-tracks 2-3 closed `/debt-triage` (fold the churn-axis prioritization into `/skill-dev` v2) and deferred `/privacy-audit` with explicit re-eval criteria.
+**Current**: v1.22.0 ships the **`/skill-dev` v2 hotspot enhancement** — the differentiating piece of the closed `/debt-triage` sub-track (Issue #97 sub-track 2), folded into `/skill-dev` per the 2026-04-28 cross-LLM verdict. New Step 3b "Hotspot priority (churn × debt)" intersects per-file debt count with `git log --since="6.months.ago" --numstat` churn data, ranks files into a 4-quadrant matrix (Q1 hot mess / Q2 stable rot / Q3 flaky frontier / Q4 cold corner), and renders a top-10 hotspot table in the audit report. The hotspot section does NOT change which findings get added to the backlog (Step 4 still applies the same severity rules) — it re-orders backlog work by leverage. Stack-agnostic; gracefully skips on non-Git projects or projects with insufficient signal. Integration: 1129 checks (+15 from `scenarioSkillDevHotspot`). The v1.21.0 PreToolUse runtime enforcement remains in place; v1.20.0 MCP-aware audit skills (`/security-audit` + `/dependency-audit`) remain pinned to `mcp-nvd` and `package-registry-mcp`.
 
-**Next**: `/skill-dev` v2 enhancement (churn × debt prioritization output, low-priority backlog), `/arch-audit` MCP-aware once the upstream Anthropic spec MCP server lands. Q2 #3 VitePress docs site (ICE 432) stays on hold.
+**Next**: `/arch-audit` MCP-aware once the upstream Anthropic spec MCP server lands. `/privacy-audit` re-eval (Issue #97 sub-track 3) when AST tracing matures or demand signal materializes. Q2 #3 VitePress docs site (ICE 432) stays on hold.
 
 ---
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mg-claude-dev-kit",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "description": "Scaffold for legible, reviewable AI-assisted development",
   "type": "module",
   "bin": {

--- a/packages/cli/templates/tier-l/.claude/skills/skill-dev/SKILL.md
+++ b/packages/cli/templates/tier-l/.claude/skills/skill-dev/SKILL.md
@@ -225,6 +225,36 @@ Read the shared types file (e.g. `lib/types.ts`, `types/`, or equivalent). Flag:
 
 ---
 
+## Step 3b - Hotspot priority (churn × debt)
+
+Skip this step if the project is not a Git repository. Otherwise compute a remediation priority matrix that intersects per-file debt count with code churn — the file the team has touched the most and that also has the most findings is what to fix first.
+
+**Churn signal**:
+```bash
+git log --since="6.months.ago" --numstat --pretty=tformat: -- <project source paths> 2>/dev/null \
+  | awk '$3 != "" && $3 !~ /^node_modules/ && $3 !~ /^vendor/ && $3 !~ /^dist/ && $3 !~ /^build/ {print $3}' \
+  | sort | uniq -c | sort -rn | head -50
+```
+
+For each unique file in the union of (Step 2 D1–D10 matches, Step 3 J1–J5 matches), record:
+- `debt_count` — number of distinct findings across D1–D10 and J1–J5 that point at this file
+- `churn` — number of commits touching this file in the last 6 months (from the command above; cap to recent activity, not whole history)
+
+**Priority matrix**:
+
+| Quadrant | debt_count | churn | Priority |
+|---|---|---|---|
+| Q1 — Hot mess | ≥ 3 | top 25% of churn | **P1 — fix first** (read often, high debt) |
+| Q2 — Stable rot | ≥ 3 | bottom 50% of churn | P2 — schedule (low traffic, but real debt) |
+| Q3 — Flaky frontier | 1–2 | top 25% of churn | P2 — watch (read often, low debt today, may grow) |
+| Q4 — Cold corner | 1–2 | bottom 50% of churn | P3 — backlog only (low traffic + low debt) |
+
+The point is to **rank backlog work by leverage**, not to add findings. Files in Q1 are the same files Step 2/3 already flagged — Step 3b only re-orders them.
+
+**Configuration**: the 6-month window is the universal default. For very young projects (< 6 months of history), the window collapses to "all available history" automatically (`git log --since` simply returns everything if the repository is younger). For long-lived monorepos where 6 months is too noisy, set a `# skill-dev: hotspot_window=N.months.ago` comment in the project's `CLAUDE.md` (consumed by future iterations of this skill — for v1.22 the window is hard-coded).
+
+The hotspot table goes in the report between "Findings requiring action" and "Backlog decision gate". It does not gate the backlog: every finding above Low severity still goes through Step 4 unchanged.
+
 ## Step 4 - Wait for Step 2 agent, then produce combined report
 
 **Wait for the Step 2 Explore agent to complete before proceeding.**
@@ -274,6 +304,14 @@ For remaining findings, apply severity modifiers in this exact order:
 ### Findings requiring action ([N] total)
 [Sorted Critical → High → Medium → Low]
 [file:line - check# - final-severity - issue - suggested fix for each]
+
+### Hotspot priority (churn × debt) — top 10
+| File | debt_count | churn (6mo) | Quadrant | Priority |
+|---|---|---|---|---|
+| path/to/file.ts | N | N | Q1 / Q2 / Q3 / Q4 | P1 / P2 / P3 |
+[10 rows max, sorted: Q1 first by debt_count desc, then Q2, then Q3, then Q4]
+
+If the project is not a Git repository or has < 5 files with both debt and churn, omit this table and note "Hotspot table skipped: insufficient signal."
 ```
 
 ### Backlog decision gate

--- a/packages/cli/templates/tier-m/.claude/skills/skill-dev/SKILL.md
+++ b/packages/cli/templates/tier-m/.claude/skills/skill-dev/SKILL.md
@@ -225,6 +225,36 @@ Read the shared types file (e.g. `lib/types.ts`, `types/`, or equivalent). Flag:
 
 ---
 
+## Step 3b - Hotspot priority (churn × debt)
+
+Skip this step if the project is not a Git repository. Otherwise compute a remediation priority matrix that intersects per-file debt count with code churn — the file the team has touched the most and that also has the most findings is what to fix first.
+
+**Churn signal**:
+```bash
+git log --since="6.months.ago" --numstat --pretty=tformat: -- <project source paths> 2>/dev/null \
+  | awk '$3 != "" && $3 !~ /^node_modules/ && $3 !~ /^vendor/ && $3 !~ /^dist/ && $3 !~ /^build/ {print $3}' \
+  | sort | uniq -c | sort -rn | head -50
+```
+
+For each unique file in the union of (Step 2 D1–D10 matches, Step 3 J1–J5 matches), record:
+- `debt_count` — number of distinct findings across D1–D10 and J1–J5 that point at this file
+- `churn` — number of commits touching this file in the last 6 months (from the command above; cap to recent activity, not whole history)
+
+**Priority matrix**:
+
+| Quadrant | debt_count | churn | Priority |
+|---|---|---|---|
+| Q1 — Hot mess | ≥ 3 | top 25% of churn | **P1 — fix first** (read often, high debt) |
+| Q2 — Stable rot | ≥ 3 | bottom 50% of churn | P2 — schedule (low traffic, but real debt) |
+| Q3 — Flaky frontier | 1–2 | top 25% of churn | P2 — watch (read often, low debt today, may grow) |
+| Q4 — Cold corner | 1–2 | bottom 50% of churn | P3 — backlog only (low traffic + low debt) |
+
+The point is to **rank backlog work by leverage**, not to add findings. Files in Q1 are the same files Step 2/3 already flagged — Step 3b only re-orders them.
+
+**Configuration**: the 6-month window is the universal default. For very young projects (< 6 months of history), the window collapses to "all available history" automatically (`git log --since` simply returns everything if the repository is younger). For long-lived monorepos where 6 months is too noisy, set a `# skill-dev: hotspot_window=N.months.ago` comment in the project's `CLAUDE.md` (consumed by future iterations of this skill — for v1.22 the window is hard-coded).
+
+The hotspot table goes in the report between "Findings requiring action" and "Backlog decision gate". It does not gate the backlog: every finding above Low severity still goes through Step 4 unchanged.
+
 ## Step 4 - Wait for Step 2 agent, then produce combined report
 
 **Wait for the Step 2 Explore agent to complete before proceeding.**
@@ -274,6 +304,14 @@ For remaining findings, apply severity modifiers in this exact order:
 ### Findings requiring action ([N] total)
 [Sorted Critical → High → Medium → Low]
 [file:line - check# - final-severity - issue - suggested fix for each]
+
+### Hotspot priority (churn × debt) — top 10
+| File | debt_count | churn (6mo) | Quadrant | Priority |
+|---|---|---|---|---|
+| path/to/file.ts | N | N | Q1 / Q2 / Q3 / Q4 | P1 / P2 / P3 |
+[10 rows max, sorted: Q1 first by debt_count desc, then Q2, then Q3, then Q4]
+
+If the project is not a Git repository or has < 5 files with both debt and churn, omit this table and note "Hotspot table skipped: insufficient signal."
 ```
 
 ### Backlog decision gate

--- a/packages/cli/templates/tier-s/.claude/skills/skill-dev/SKILL.md
+++ b/packages/cli/templates/tier-s/.claude/skills/skill-dev/SKILL.md
@@ -6,6 +6,11 @@ model: sonnet
 context: fork
 ---
 
+## Configuration (adapt before first run)
+
+> Replace these placeholders:
+> - `[LINT_COMMAND]` - project's lint command - e.g. `eslint .`, `ruff check`, `cargo clippy`, `go vet ./...`, `swiftlint lint`, `rubocop`, `dotnet format --verify-no-changes`. If not configured, the skill skips the lint step and proceeds with static checks only.
+
 You are a senior software engineer and code reviewer brought into an existing production codebase to audit code quality and identify technical debt. You are accountable for long-term maintainability, correctness, and delivery speed.
 
 **Operating mode for this skill**: Audit only - no code changes. Anchor every finding to concrete file paths and code evidence. Do not inflate severity. Distinguish facts from inferences.
@@ -36,12 +41,12 @@ Skip entirely:
 - CHECK J3 - Client/server boundary placement (SSR component frameworks only - e.g. Next.js, Nuxt)
 
 Run with adaptation:
-- CHECK D1 - Adapt from component imports to module/app imports (e.g. Django apps importing across app boundaries, Rails engines importing across boundaries)
-- CHECK D4 - Adapt "dead exports" to the language's public API surface (see language note in D4)
-- CHECK D8 - Use the language-specific suppression patterns (e.g. `# type: ignore` for Python, `@SuppressWarnings` for Java)
+- CHECK D1 - Adapt from component imports to module/app imports for the project's framework
+- CHECK D4 - Adapt "dead exports" to the language's public API surface (see PATTERNS.md → D4)
+- CHECK D8 - Use the language-specific suppression patterns (see PATTERNS.md → D8)
 
 Run as-is (stack-agnostic):
-- CHECK D3 (N+1 - adapt to your ORM: Django ORM, ActiveRecord, Eloquent, SQLAlchemy), D5, D6, D7, D10
+- CHECK D3 (N+1 - adapt to the project's ORM, see PATTERNS.md → D3), D5, D6, D7, D10
 - CHECK J1 (over-large modules), J2 (data clumps), J4 (utility consolidation - adapt directory name), J5 (typed languages only)
 
 Run additionally (language-specific - CHECK DL1).
@@ -52,7 +57,7 @@ Skip entirely:
 - CHECK D1 - Cross-module import patterns (web frameworks only)
 - CHECK D2 - Duplicated inline color/status maps (component framework only)
 - CHECK D3 - ORM/client N+1 fetch patterns (ORM-specific - run if your project uses an ORM)
-- CHECK D8 - Type safety suppressions (run DL1 language-specific checks instead)
+- CHECK D8 - Type safety suppressions - Pattern A (directive suppressions) is covered by DL1. For typed native languages (Swift, Kotlin, Rust, Go, .NET): still run Pattern C (floating promises/unhandled async) if applicable.
 - CHECK D9 - Lifecycle/side-effect antipatterns (UI frameworks only)
 - CHECK J3 - Client/server boundary placement (SSR frameworks only)
 
@@ -66,15 +71,7 @@ Run as-is (stack-agnostic):
 
 Run additionally (language-specific - CHECK DL1).
 
-**Language-specific checks (DL1)** - run for server-rendered web and native/backend stacks:
-- **Swift**: force unwrap (`!`) audit - flag each `!` on optionals outside guard/if-let; SwiftLint patterns; retain cycle risk in closures (missing `[weak self]`)
-- **Kotlin**: null safety violations (`!!` operator); detekt patterns; coroutine scope leaks (GlobalScope usage)
-- **Rust**: clippy warnings (`cargo clippy -- -W clippy::all`); unnecessary `.clone()` calls; overly complex lifetime annotations; `unwrap()` in library/production code
-- **Go**: `go vet` patterns; errcheck (unchecked error returns); staticcheck findings; naked goroutines (no context cancellation)
-- **Python**: type hint coverage on public functions; ruff/pylint patterns; bare `except:` clauses; mutable default arguments
-- **Ruby**: rubocop patterns; method length > 25 lines; missing frozen_string_literal comment
-- **Java**: spotbugs patterns; unchecked casts; empty catch blocks swallowing checked exceptions; raw types usage
-- **dotnet**: nullable reference type warnings; IDisposable not disposed; async void methods (except event handlers)
+**Language-specific checks (DL1)** - run for server-rendered web and native/backend stacks. See PATTERNS.md → DL1 for per-language grep patterns, lint commands, and flag conditions.
 
 **Lint command**: `[LINT_COMMAND]` - run before the audit if available. Include lint output summary in the report.
 
@@ -103,7 +100,7 @@ Apply the target filter to the file list in Step 1.
 ## Step 1 - Read structural guides
 
 Read in order:
-1. `docs/refactoring-backlog.md` - read in full. Use it for two purposes:
+1. `docs/refactoring-backlog.md` - read in full if it exists. If the file does not exist, skip deduplication and debt-density checks (treat as empty backlog). Use it for two purposes:
    - **Deduplication**: do not re-report a finding already present (including resolved ✅ entries - resolved entries confirm a fix was applied, not that the pattern cannot recur elsewhere).
    - **Debt density context**: for each module/file in the target list, count how many existing open entries it has. A module with 3+ open entries is a **high-debt zone** - new findings there carry elevated priority regardless of check category, because accumulated debt signals systemic fragility, not isolated issues.
 
@@ -115,9 +112,9 @@ Output: (a) structured file list, (b) high-debt zone map (module → open entry 
 
 **Launch immediately with `run_in_background: true`, then proceed to Step 3 without waiting.**
 
-Pass the full file list from Step 1 to a Haiku Explore agent, along with the exact text below - from "Run all 10 checks below" through the end of CHECK D10 - copied verbatim as the agent prompt. Do not summarize or paraphrase the check instructions.
+Pass the full file list from Step 1 to a Haiku Explore agent. **Before copying the prompt below**: remove any checks marked "Skip entirely" in the Applicability section for the detected stack category. Only include checks that are "Run as-is" or "Run with adaptation" for this project. Do not send skipped checks to the subagent.
 
-"Run all 10 checks below on ONLY the files provided. For each check: state total match count, list every match as `file:line - excerpt`, and state PASS or FAIL.
+"Read `${CLAUDE_SKILL_DIR}/PATTERNS.md` for stack-specific grep patterns. Run the checks below on ONLY the files provided. For each check: state total match count, list every match as `file:line - excerpt`, and state PASS or FAIL.
 
 **CHECK D1 - Cross-module direct imports (coupling)**
 Pattern: modules importing directly from other feature modules instead of going through a shared layer (e.g. `features/admin/` importing from `features/billing/`).
@@ -130,7 +127,7 @@ Flag: any file with this pattern NOT already importing from a shared status-badg
 Expected: all status-to-style maps centralised in a single utility.
 
 **CHECK D3 - N+1 fetch patterns in components and API routes**
-Pattern A: any database query call (e.g. `.find(`, `.select(`, `.query(`, `.execute(`, `.from(`) inside a `.map(`, `for (`, `forEach(`, or `for...of` loop.
+Pattern A: any database query call inside a `.map(`, `for (`, `forEach(`, or `for...of` loop. See PATTERNS.md → D3 for DB client method patterns per ORM.
 Grep for your project's DB client method pattern - then check if it appears inside an iteration block.
 Flag ALL matches - any database query inside a loop is a potential N+1.
 Pattern B: sequential `await` calls to the DB client inside a loop body.
@@ -138,12 +135,7 @@ Flag: each match with file:line.
 
 **CHECK D4 - Dead public API surface (sampled: 5 largest files)**
 *This is a sampled check - not exhaustive. Mark all findings as `(sampled)`. A full dead-export audit requires a dedicated tool such as `knip`.*
-Pattern: publicly accessible symbols that are never referenced elsewhere. Adapt to the language:
-- **TypeScript/JavaScript**: `export (function|const|type|interface)` that are never imported elsewhere.
-- **Python**: public functions/classes (no `_` prefix) in modules that are never imported by other modules.
-- **Swift**: `public` or `open` declarations that are never referenced outside their defining module.
-- **Go**: exported identifiers (capitalized names) that are never referenced outside their package.
-- **Other languages**: adapt to the language's public API mechanism.
+Pattern: publicly accessible symbols that are never referenced elsewhere. See PATTERNS.md → D4 for per-language public symbol patterns.
 For the 5 largest source files by line count: grep each public symbol across all other files.
 Flag: symbols with 0 consumers outside their own file.
 
@@ -163,18 +155,12 @@ Grep: `\bTODO\b|\bFIXME\b|\bHACK\b|\bXXX\b` across all files in scope.
 Flag: each match with context.
 
 **CHECK D8 - Type safety suppressions** *(typed languages only - skip for dynamically typed languages)*
-Pattern A - Directive suppressions (TypeScript):
-Grep: `@ts-ignore|@ts-expect-error|@ts-nocheck` across all files.
-`@ts-ignore` is highest severity. `@ts-expect-error` is acceptable only with a description comment.
-For other typed languages: grep for equivalent escape hatches (e.g. `# type: ignore` in Python, `@SuppressWarnings` in Java/Kotlin, `unsafe` blocks in Rust, `// nolint` in Go).
-Pattern B - Explicit `any` / untyped (TypeScript):
-Grep: `:\s*any\b|as\s+any\b|<any>|Promise<any>` in non-test source files.
-Exclude: generated type files, vendor types, and any explicit exemptions in CLAUDE.md Known Patterns.
-Flag: each remaining usage.
-Pattern C - Floating promises (unhandled async in event handlers or UI code):
-Grep for async calls (DB queries, route navigation, API calls) that appear as bare statements without `await`, `void`, `return`, or error handling. These are silent fire-and-forget calls.
+See PATTERNS.md → D8 for per-language suppression patterns, untyped escape hatches, and floating promise detection.
+Pattern A - Directive suppressions: grep for the language's type safety suppression directives. Highest severity for blanket suppressions (file-level or undescribed).
+Pattern B - Untyped escape hatches (TypeScript): grep for explicit `any` usage in non-test source files. Exclude generated type files, vendor types, and explicit exemptions in CLAUDE.md Known Patterns.
+Pattern C - Floating promises: grep for async calls that appear as bare statements without `await`, `void`, `return`, or error handling. These are silent fire-and-forget calls.
 
-**CHECK D9 - Lifecycle/side-effect antipatterns** *(React: useEffect, Vue: onMounted/watch, Svelte: onMount/$, Angular: ngOnInit - skip for non-UI projects)*
+**CHECK D9 - Lifecycle/side-effect antipatterns** *(UI frameworks only - see PATTERNS.md → D9 for framework-specific hooks. Skip for non-UI projects.)*
 Pattern A - Derived state stored in state + updated via lifecycle hook:
 Flag components where a side-effect hook's only purpose is to sync derived state - the value is computable during render/init.
 Pattern B - Event handler logic inside lifecycle hooks:
@@ -183,12 +169,12 @@ Pattern C - Missing cleanup or dependency tracking:
 Flag side-effect hooks with no dependency specification (runs on every render) or missing cleanup for subscriptions/timers.
 Expected: 0 matches for A and C. B requires judgment.
 
-**CHECK D10 - Empty catch blocks and console.log in production**
+**CHECK D10 - Empty catch blocks and debug output in production**
 Pattern A - Empty or near-empty catch blocks:
-Grep: `catch\s*\([^)]*\)\s*\{\s*\}|catch\s*\([^)]*\)\s*\{\s*\/\/|catch\s*\([^)]*\)\s*\{\s*console\.log`
-Flag: catch blocks that swallow errors silently or log them without recovery or user feedback.
+Grep for catch blocks that swallow errors silently or log them without recovery or user feedback.
+Flag: catch blocks with empty bodies, comment-only bodies, or log-only bodies without error recovery.
 Pattern B - Debug output in production:
-Grep for debug/logging statements (`console.log`, `print()`, `println!`, `fmt.Println`, `puts`, `System.out.println` - adapt to your language) in source directories (excluding test files).
+Grep for debug/logging statements in source directories (excluding test files). See PATTERNS.md → D10 for per-language debug output patterns.
 Debug-level logging in catch blocks is acceptable only if also returning an error response."
 
 ---
@@ -239,6 +225,36 @@ Read the shared types file (e.g. `lib/types.ts`, `types/`, or equivalent). Flag:
 
 ---
 
+## Step 3b - Hotspot priority (churn × debt)
+
+Skip this step if the project is not a Git repository. Otherwise compute a remediation priority matrix that intersects per-file debt count with code churn — the file the team has touched the most and that also has the most findings is what to fix first.
+
+**Churn signal**:
+```bash
+git log --since="6.months.ago" --numstat --pretty=tformat: -- <project source paths> 2>/dev/null \
+  | awk '$3 != "" && $3 !~ /^node_modules/ && $3 !~ /^vendor/ && $3 !~ /^dist/ && $3 !~ /^build/ {print $3}' \
+  | sort | uniq -c | sort -rn | head -50
+```
+
+For each unique file in the union of (Step 2 D1–D10 matches, Step 3 J1–J5 matches), record:
+- `debt_count` — number of distinct findings across D1–D10 and J1–J5 that point at this file
+- `churn` — number of commits touching this file in the last 6 months (from the command above; cap to recent activity, not whole history)
+
+**Priority matrix**:
+
+| Quadrant | debt_count | churn | Priority |
+|---|---|---|---|
+| Q1 — Hot mess | ≥ 3 | top 25% of churn | **P1 — fix first** (read often, high debt) |
+| Q2 — Stable rot | ≥ 3 | bottom 50% of churn | P2 — schedule (low traffic, but real debt) |
+| Q3 — Flaky frontier | 1–2 | top 25% of churn | P2 — watch (read often, low debt today, may grow) |
+| Q4 — Cold corner | 1–2 | bottom 50% of churn | P3 — backlog only (low traffic + low debt) |
+
+The point is to **rank backlog work by leverage**, not to add findings. Files in Q1 are the same files Step 2/3 already flagged — Step 3b only re-orders them.
+
+**Configuration**: the 6-month window is the universal default. For very young projects (< 6 months of history), the window collapses to "all available history" automatically (`git log --since` simply returns everything if the repository is younger). For long-lived monorepos where 6 months is too noisy, set a `# skill-dev: hotspot_window=N.months.ago` comment in the project's `CLAUDE.md` (consumed by future iterations of this skill — for v1.22 the window is hard-coded).
+
+The hotspot table goes in the report between "Findings requiring action" and "Backlog decision gate". It does not gate the backlog: every finding above Low severity still goes through Step 4 unchanged.
+
 ## Step 4 - Wait for Step 2 agent, then produce combined report
 
 **Wait for the Step 2 Explore agent to complete before proceeding.**
@@ -288,6 +304,14 @@ For remaining findings, apply severity modifiers in this exact order:
 ### Findings requiring action ([N] total)
 [Sorted Critical → High → Medium → Low]
 [file:line - check# - final-severity - issue - suggested fix for each]
+
+### Hotspot priority (churn × debt) — top 10
+| File | debt_count | churn (6mo) | Quadrant | Priority |
+|---|---|---|---|---|
+| path/to/file.ts | N | N | Q1 / Q2 / Q3 / Q4 | P1 / P2 / P3 |
+[10 rows max, sorted: Q1 first by debt_count desc, then Q2, then Q3, then Q4]
+
+If the project is not a Git repository or has < 5 files with both debt and churn, omit this table and note "Hotspot table skipped: insufficient signal."
 ```
 
 ### Backlog decision gate
@@ -331,9 +355,9 @@ Each entry **must** include a `Regression risk` field:
 
 ### Severity guide
 
-- **Critical**: type-safety suppression on a security/data path (TS: `@ts-ignore`, Python: `# type: ignore`, Go: `// nolint`); N+1 in a hot path (list page, dashboard, frequently-called API); floating promise or fire-and-forget async on an auth or data-write handler; force unwrap on external input (Swift: `!`, Kotlin: `!!`)
-- **High**: untyped escape hatch in shared utilities (TS: `any`, Python: bare `except:` on DB path, Kotlin: `GlobalScope.launch`); dead public symbol in shared lib; empty catch on DB write; unhandled error on async data-write path
-- **Medium**: over-large module >300 lines with 4+ responsibilities (J1); magic business-rule numbers (D6); debug output in production - `console.log` (JS), `print()` (Swift/Python), `fmt.Println` (Go) (D10); data clumps >3 always-grouped parameters (J2)
+- **Critical**: type-safety suppression on a security/data path (see PATTERNS.md → D8 for per-language directives); N+1 in a hot path (list page, dashboard, frequently-called API); floating promise or fire-and-forget async on an auth or data-write handler; force unwrap on external input (see PATTERNS.md → DL1)
+- **High**: untyped escape hatch in shared utilities; dead public symbol in shared lib; empty catch on DB write; unhandled error on async data-write path
+- **Medium**: over-large module >300 lines with 4+ responsibilities (J1); magic business-rule numbers (D6); debug output in production (see PATTERNS.md → D10); data clumps >3 always-grouped parameters (J2)
 - **Low**: TODO comments; minor coupling; consolidation opportunities; magic enum strings already covered by type definitions; D4 sampled dead public symbols
 
 ---

--- a/packages/cli/test/integration/run.js
+++ b/packages/cli/test/integration/run.js
@@ -2826,6 +2826,56 @@ async function scenarioInfraAuditPresent() {
   }
 }
 
+async function scenarioSkillDevHotspot() {
+  section('skill-dev v2 hotspot priority (churn × debt) — content assertions (v1.22.0)');
+
+  for (const tier of ['s', 'm', 'l']) {
+    const config = { ...BASE, tier, isDiscovery: false };
+    const dir = await scaffold(`skill-dev-hotspot-tier-${tier}`, tier, config);
+    const skillPath = path.join(dir, '.claude/skills/skill-dev/SKILL.md');
+    if (!fs.existsSync(skillPath)) {
+      fail(`Tier ${tier}: skill-dev SKILL.md missing`);
+      continue;
+    }
+    const body = fs.readFileSync(skillPath, 'utf8');
+
+    if (/## Step 3b - Hotspot priority/.test(body)) {
+      pass(`Tier ${tier}: skill-dev declares Step 3b — Hotspot priority`);
+    } else {
+      fail(`Tier ${tier}: skill-dev missing Step 3b`);
+    }
+
+    if (/git log --since="6\.months\.ago" --numstat/.test(body)) {
+      pass(`Tier ${tier}: skill-dev Step 3b uses git log churn signal`);
+    } else {
+      fail(`Tier ${tier}: skill-dev Step 3b missing git log churn command`);
+    }
+
+    if (
+      /Q1 — Hot mess/.test(body) &&
+      /Q2 — Stable rot/.test(body) &&
+      /Q3 — Flaky frontier/.test(body) &&
+      /Q4 — Cold corner/.test(body)
+    ) {
+      pass(`Tier ${tier}: skill-dev Step 3b documents 4-quadrant priority matrix`);
+    } else {
+      fail(`Tier ${tier}: skill-dev Step 3b missing one or more priority quadrants`);
+    }
+
+    if (/### Hotspot priority \(churn × debt\) — top 10/.test(body)) {
+      pass(`Tier ${tier}: skill-dev report includes Hotspot priority section`);
+    } else {
+      fail(`Tier ${tier}: skill-dev report missing Hotspot priority section`);
+    }
+
+    if (/Hotspot table skipped: insufficient signal/.test(body)) {
+      pass(`Tier ${tier}: skill-dev documents fallback when not a Git repo / low signal`);
+    } else {
+      fail(`Tier ${tier}: skill-dev missing Hotspot fallback wording`);
+    }
+  }
+}
+
 async function scenarioRuntimeEnforcementHook() {
   section('team-settings runtime enforcement hook (v1.21.0)');
 
@@ -3938,6 +3988,7 @@ async function main() {
   await scenarioPrReviewPresent();
   await scenarioMcpAwareSkillsV120();
   await scenarioRuntimeEnforcementHook();
+  await scenarioSkillDevHotspot();
   await scenarioUpgradeAnthropic();
   await scenarioTeamSettings();
   await scenarioMCPServer();


### PR DESCRIPTION
## Summary

v1.22.0 folds the differentiating piece of the closed `/debt-triage` sub-track (Issue #97 sub-track 2) into the existing `/skill-dev` skill, per the 2026-04-28 cross-LLM verdict. Single-skill enhancement, single SKILL.md edit, content-level only.

## What changes

`/skill-dev` gets a new **Step 3b — Hotspot priority (churn × debt)** between the existing structural judgment checks (Step 3) and the combined report (Step 4):

- Computes `git log --since="6.months.ago" --numstat` per affected file.
- Intersects per-file debt count (from D1–D10 + J1–J5 matches) with churn data.
- Ranks files into a 4-quadrant matrix: **Q1 hot mess** (high debt + high churn → P1), **Q2 stable rot** (high debt + low churn → P2), **Q3 flaky frontier** (low debt + high churn → P2 watch), **Q4 cold corner** (low debt + low churn → P3 backlog).
- Renders a top-10 hotspot table in the audit report between "Findings requiring action" and "Backlog decision gate".
- Stack-agnostic. Skips with explicit "Hotspot table skipped: insufficient signal" wording on non-Git projects or projects with < 5 files showing both debt and churn.

The hotspot section does NOT change which findings get added to the backlog. Step 4's existing severity rules (debt-density escalation, regression-risk downgrade) still apply unchanged. The new section re-orders backlog work by leverage; it adds no findings.

## Why this implementation, not a new skill

The 2026-04-28 cross-LLM re-score on Issue #97 sub-tracks 2 + 3 returned a split verdict on `/debt-triage` (1 GO / 1 DEFER / 1 NO-GO, average ICE 148 — just below threshold). All three reviewers identified the unique value as the churn-axis prioritization, not the debt detection. Resolution: fold the differentiating piece into `/skill-dev` v2 as a non-breaking enhancement — single skill instead of two with significant overlap. This release closes that work item.

`/privacy-audit` (sub-track 3) remains deferred per the criteria pinned in the 2026-04-28 #97 comment.

## Changes

- `chore(scaffold)`: `/skill-dev` SKILL.md tier-s + tier-m + tier-l byte-identical. 330 → 368 lines (+38 for Step 3b body + report section).
- `test(skill-dev)`: `scenarioSkillDevHotspot` content assertions (Step 3b presence, git log churn command, 4-quadrant matrix wording, report section header, fallback wording). 15 new checks across all three tiers.
- `chore(release)`: 1.21.0 → 1.22.0; CHANGELOG entry; README skill table + Current/Next paragraph.

## Test plan

- [x] `npm test` — 1129 integration checks (1114 → +15 from `scenarioSkillDevHotspot`)
- [x] `npm run test:unit` — 373 tests (no new unit tests; enhancement is content-level)
- [x] `npm run lint` + `npx prettier --check` — both clean
- [ ] CI mirror of the above
- [ ] Manual: scaffold a tier-m project, run `/skill-dev` against a real Git repo, verify the hotspot table renders with sensible Q1-Q4 distribution

## Reference

- Decision memo: `docs/reviews/2026-04-28-debt-privacy-rescore/synthesis.md`
- Issue #97 (sub-track 2 close + #97 comment from 2026-04-28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)