### PR TITLE
fix(scaffold): add placeholder behavior meta-rule to all 3 pipeline tiers (#134)

### DIFF
--- a/packages/cli/templates/tier-l/.claude/rules/pipeline.md
+++ b/packages/cli/templates/tier-l/.claude/rules/pipeline.md
@@ -17,7 +17,7 @@ Branch prefix `feature/` activates the full pipeline automatically.
 
 ## Placeholder behavior
 
-When a placeholder like `[TYPE_CHECK_COMMAND]`, `[BUILD_COMMAND]`, `[TEST_COMMAND]`, `[E2E_COMMAND]`, or `[DEV_COMMAND]` is `# not configured` (or absent from `CLAUDE.md`):
+When a placeholder like `[TYPE_CHECK_COMMAND]`, `[BUILD_COMMAND]`, `[TEST_COMMAND]`, `[E2E_COMMAND]`, or `[DEV_COMMAND]` has no configured value in `CLAUDE.md` (absent or left as a comment placeholder):
 - Emit a visible step: `[SKIP] No <command-name> configured for this stack — verify manually if applicable.`
 - Do NOT proceed as if the command succeeded.
 - Do NOT mark the gate green.

--- a/packages/cli/templates/tier-l/.claude/rules/pipeline.md
+++ b/packages/cli/templates/tier-l/.claude/rules/pipeline.md
@@ -15,6 +15,17 @@ Branch prefix `feature/` activates the full pipeline automatically.
 
 ---
 
+## Placeholder behavior
+
+When a placeholder like `[TYPE_CHECK_COMMAND]`, `[BUILD_COMMAND]`, `[TEST_COMMAND]`, `[E2E_COMMAND]`, or `[DEV_COMMAND]` is `# not configured` (or absent from `CLAUDE.md`):
+- Emit a visible step: `[SKIP] No <command-name> configured for this stack — verify manually if applicable.`
+- Do NOT proceed as if the command succeeded.
+- Do NOT mark the gate green.
+
+A skip is a legitimate outcome. Silent degradation is not.
+
+---
+
 ## Phase 0 - Session orientation
 
 **FIRST**: check for `CONTEXT_IMPORT.md` in the project root. If it exists and contains `Status: PENDING_DISCOVERY`, run the Discovery Workflow inside that file **before any other work**. Do not proceed until discovery is marked `COMPLETE`.

--- a/packages/cli/templates/tier-l/.claude/rules/pipeline.md
+++ b/packages/cli/templates/tier-l/.claude/rules/pipeline.md
@@ -17,7 +17,7 @@ Branch prefix `feature/` activates the full pipeline automatically.
 
 ## Placeholder behavior
 
-When a placeholder like `[TYPE_CHECK_COMMAND]`, `[BUILD_COMMAND]`, `[TEST_COMMAND]`, `[E2E_COMMAND]`, or `[DEV_COMMAND]` has no configured value in `CLAUDE.md` (absent or left as a comment placeholder):
+When a command placeholder in `CLAUDE.md` (type-check, build, test, E2E, or dev-server command) has no configured value (absent or left as a comment placeholder):
 - Emit a visible step: `[SKIP] No <command-name> configured for this stack — verify manually if applicable.`
 - Do NOT proceed as if the command succeeded.
 - Do NOT mark the gate green.

--- a/packages/cli/templates/tier-m/.claude/rules/pipeline.md
+++ b/packages/cli/templates/tier-m/.claude/rules/pipeline.md
@@ -17,7 +17,7 @@ Branch prefix `feature/` activates this pipeline automatically.
 
 ## Placeholder behavior
 
-When a placeholder like `[TYPE_CHECK_COMMAND]`, `[BUILD_COMMAND]`, `[TEST_COMMAND]`, `[E2E_COMMAND]`, or `[DEV_COMMAND]` has no configured value in `CLAUDE.md` (absent or left as a comment placeholder):
+When a command placeholder in `CLAUDE.md` (type-check, build, test, E2E, or dev-server command) has no configured value (absent or left as a comment placeholder):
 - Emit a visible step: `[SKIP] No <command-name> configured for this stack — verify manually if applicable.`
 - Do NOT proceed as if the command succeeded.
 - Do NOT mark the gate green.

--- a/packages/cli/templates/tier-m/.claude/rules/pipeline.md
+++ b/packages/cli/templates/tier-m/.claude/rules/pipeline.md
@@ -15,6 +15,17 @@ Branch prefix `feature/` activates this pipeline automatically.
 
 ---
 
+## Placeholder behavior
+
+When a placeholder like `[TYPE_CHECK_COMMAND]`, `[BUILD_COMMAND]`, `[TEST_COMMAND]`, `[E2E_COMMAND]`, or `[DEV_COMMAND]` is `# not configured` (or absent from `CLAUDE.md`):
+- Emit a visible step: `[SKIP] No <command-name> configured for this stack — verify manually if applicable.`
+- Do NOT proceed as if the command succeeded.
+- Do NOT mark the gate green.
+
+A skip is a legitimate outcome. Silent degradation is not.
+
+---
+
 ## Phase 0 - Session orientation
 
 - **FIRST**: check for `CONTEXT_IMPORT.md` in the project root. If it exists and contains `Status: PENDING_DISCOVERY`, run the Discovery Workflow inside that file **before any other work**. Do not proceed to Phase 1 until discovery is marked `COMPLETE`.

--- a/packages/cli/templates/tier-m/.claude/rules/pipeline.md
+++ b/packages/cli/templates/tier-m/.claude/rules/pipeline.md
@@ -17,7 +17,7 @@ Branch prefix `feature/` activates this pipeline automatically.
 
 ## Placeholder behavior
 
-When a placeholder like `[TYPE_CHECK_COMMAND]`, `[BUILD_COMMAND]`, `[TEST_COMMAND]`, `[E2E_COMMAND]`, or `[DEV_COMMAND]` is `# not configured` (or absent from `CLAUDE.md`):
+When a placeholder like `[TYPE_CHECK_COMMAND]`, `[BUILD_COMMAND]`, `[TEST_COMMAND]`, `[E2E_COMMAND]`, or `[DEV_COMMAND]` has no configured value in `CLAUDE.md` (absent or left as a comment placeholder):
 - Emit a visible step: `[SKIP] No <command-name> configured for this stack — verify manually if applicable.`
 - Do NOT proceed as if the command succeeded.
 - Do NOT mark the gate green.

--- a/packages/cli/templates/tier-s/.claude/rules/pipeline.md
+++ b/packages/cli/templates/tier-s/.claude/rules/pipeline.md
@@ -7,7 +7,7 @@ Branch prefix `fix/` activates this pipeline automatically.
 
 ## Placeholder behavior
 
-When a placeholder like `[TYPE_CHECK_COMMAND]`, `[BUILD_COMMAND]`, `[TEST_COMMAND]`, `[E2E_COMMAND]`, or `[DEV_COMMAND]` is `# not configured` (or absent from `CLAUDE.md`):
+When a placeholder like `[TYPE_CHECK_COMMAND]`, `[BUILD_COMMAND]`, `[TEST_COMMAND]`, `[E2E_COMMAND]`, or `[DEV_COMMAND]` has no configured value in `CLAUDE.md` (absent or left as a comment placeholder):
 - Emit a visible step: `[SKIP] No <command-name> configured for this stack — verify manually if applicable.`
 - Do NOT proceed as if the command succeeded.
 - Do NOT mark the gate green.

--- a/packages/cli/templates/tier-s/.claude/rules/pipeline.md
+++ b/packages/cli/templates/tier-s/.claude/rules/pipeline.md
@@ -5,6 +5,17 @@ Branch prefix `fix/` activates this pipeline automatically.
 
 ---
 
+## Placeholder behavior
+
+When a placeholder like `[TYPE_CHECK_COMMAND]`, `[BUILD_COMMAND]`, `[TEST_COMMAND]`, `[E2E_COMMAND]`, or `[DEV_COMMAND]` is `# not configured` (or absent from `CLAUDE.md`):
+- Emit a visible step: `[SKIP] No <command-name> configured for this stack — verify manually if applicable.`
+- Do NOT proceed as if the command succeeded.
+- Do NOT mark the gate green.
+
+A skip is a legitimate outcome. Silent degradation is not.
+
+---
+
 ## FL-0 - Branch check + session file
 
 - **Session file**: check `.claude/session/` for existing `fix-*.md` files.

--- a/packages/cli/templates/tier-s/.claude/rules/pipeline.md
+++ b/packages/cli/templates/tier-s/.claude/rules/pipeline.md
@@ -7,7 +7,7 @@ Branch prefix `fix/` activates this pipeline automatically.
 
 ## Placeholder behavior
 
-When a placeholder like `[TYPE_CHECK_COMMAND]`, `[BUILD_COMMAND]`, `[TEST_COMMAND]`, `[E2E_COMMAND]`, or `[DEV_COMMAND]` has no configured value in `CLAUDE.md` (absent or left as a comment placeholder):
+When a command placeholder in `CLAUDE.md` (type-check, build, test, E2E, or dev-server command) has no configured value (absent or left as a comment placeholder):
 - Emit a visible step: `[SKIP] No <command-name> configured for this stack — verify manually if applicable.`
 - Do NOT proceed as if the command succeeded.
 - Do NOT mark the gate green.


### PR DESCRIPTION
## Summary

Aggiunge la sezione `## Placeholder behavior` all'inizio di ogni `pipeline.md` (tier-S, tier-M, tier-L) — immediatamente dopo il selector-table e prima di Phase 0 / FL-0.

La sezione è **identica nei 3 tier** (cross-tier diff verificato):

\`\`\`markdown
## Placeholder behavior

When a placeholder like `[TYPE_CHECK_COMMAND]`, `[BUILD_COMMAND]`, `[TEST_COMMAND]`,
`[E2E_COMMAND]`, or `[DEV_COMMAND]` is `# not configured` (or absent from `CLAUDE.md`):
- Emit a visible step: `[SKIP] No <command-name> configured for this stack — verify manually if applicable.`
- Do NOT proceed as if the command succeeded.
- Do NOT mark the gate green.

A skip is a legitimate outcome. Silent degradation is not.
\`\`\`

## Contesto

Il placeholder silent no-op è la fonte di silent degradation più universale identificata dal cross-LLM review (4/4 LLM su `rules/pipeline.md`, fonte `docs/reviews/2026-04-29-dev-pipeline-meta/synthesis.md` § CC1 — gitignored, locale maintainer). Senza questa meta-rule:
- `[TYPE_CHECK_COMMAND]` non configurato → Claude skips silenziosamente → gate "green" senza che nessun type check sia girato
- `[TEST_COMMAND]` non configurato → stessa dinamica → utente su Go/Swift/Python non ha segnale

La meta-rule converte il failure mode da **silent degradation** (peggiore) a **explicit skip** (recuperabile).

## Caratteristiche

- Insertion point identico nei 3 tier: dopo il pipeline-selector `---`, prima del primo phase
- Zero modifica a logica o flusso esistente: prosa-only, additive
- Architecture-independent: la clausola è valida sia nel body monolitico attuale sia sotto strada E (#133), dove diventa parte del body universale che sopravvive a qualunque refactor
- 33 insertions, 0 deletions su 3 file

## Test plan

- [ ] Scaffold CDK in progetto Python — `[TYPE_CHECK_COMMAND]` non configurato → Phase 3 deve emettere `[SKIP] No TYPE_CHECK_COMMAND configured for this stack` anziché procedere silenziosamente
- [ ] Scaffold CDK in progetto Swift iOS — `[E2E_COMMAND]` non configurato → Phase 4 deve emettere skip statement
- [ ] Nessuna regressione su progetti Node/TS con tutti i placeholder configurati

## Refs

Closes #134 (shipped pipeline P1.1 — placeholder commands explicit-skip meta-rule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)