### PR TITLE
chore(scaffold): expand Phase 4 cross-LLM prompt to full CDK matrix

### DIFF
--- a/packages/cli/templates/tier-l/.claude/skills/skill-review/REVIEW_FRAMEWORK.md
+++ b/packages/cli/templates/tier-l/.claude/skills/skill-review/REVIEW_FRAMEWORK.md
@@ -285,7 +285,9 @@ Skip Phase 4 when ALL three hold:
 
 For simple skills (commit, simplify), marginal value low. Document skip explicitly in review log.
 
-**For all other skills**: submit to 3 models (Gemini 2.5 Pro, Mistral Large, GPT-4.1) with identical prompt.
+**For all other skills**: submit to 3 models (Gemini 2.5 Pro, Mistral Large, GPT-4.1) with identical prompt:
+
+> "Would this skill produce correct, actionable results on a [Vue/Svelte/Angular/vanilla/Python FastAPI/Go CLI/Swift iOS] project?"
 
 **LLM adjudication rule (C1)**:
 - Models produce **candidate findings**, not verdicts.

--- a/packages/cli/templates/tier-m/.claude/skills/skill-review/REVIEW_FRAMEWORK.md
+++ b/packages/cli/templates/tier-m/.claude/skills/skill-review/REVIEW_FRAMEWORK.md
@@ -285,7 +285,9 @@ Skip Phase 4 when ALL three hold:
 
 For simple skills (commit, simplify), marginal value low. Document skip explicitly in review log.
 
-**For all other skills**: submit to 3 models (Gemini 2.5 Pro, Mistral Large, GPT-4.1) with identical prompt.
+**For all other skills**: submit to 3 models (Gemini 2.5 Pro, Mistral Large, GPT-4.1) with identical prompt:
+
+> "Would this skill produce correct, actionable results on a [Vue/Svelte/Angular/vanilla/Python FastAPI/Go CLI/Swift iOS] project?"
 
 **LLM adjudication rule (C1)**:
 - Models produce **candidate findings**, not verdicts.


### PR DESCRIPTION
Expands the Phase 4 cross-LLM validation prompt in `REVIEW_FRAMEWORK.md` from a frontend-only stack list to the full CDK matrix: `[Vue/Svelte/Angular/vanilla/Python FastAPI/Go CLI/Swift iOS]`.

Fixes CC1 Critical from the 2026-04-29 pipeline meta-review: the Phase 4 gate covered only the frontend cluster, leaving backend (Python/Go) and native (Swift) blind — roughly 60-70% of the declared target matrix unvalidated.

Cross-tier: identical change applied to tier-l and tier-m.

---

## Test plan
- [x] Integration tests: 1129/1129 passed
- [x] Diff: 2 files, +2 lines each, no structural changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)