### PR TITLE
chore(scaffold): add placeholder skip rule to all pipeline tiers

### DIFF
--- a/packages/cli/templates/tier-l/.claude/rules/pipeline.md
+++ b/packages/cli/templates/tier-l/.claude/rules/pipeline.md
@@ -17,7 +17,7 @@ Branch prefix `feature/` activates the full pipeline automatically.
 
 ## Placeholder behavior
 
-When a placeholder like `[TYPE_CHECK_COMMAND]`, `[BUILD_COMMAND]`, `[TEST_COMMAND]`, `[E2E_COMMAND]`, or `[DEV_COMMAND]` is `# not configured` (or absent from `CLAUDE.md`):
+When a placeholder like `[TYPE_CHECK_COMMAND]`, `[BUILD_COMMAND]`, `[TEST_COMMAND]`, `[E2E_COMMAND]`, or `[DEV_COMMAND]` has no configured value in `CLAUDE.md` (absent or left as a comment placeholder):
 - Emit a visible step: `[SKIP] No <command-name> configured for this stack — verify manually if applicable.`
 - Do NOT proceed as if the command succeeded.
 - Do NOT mark the gate green.

--- a/packages/cli/templates/tier-l/.claude/rules/pipeline.md
+++ b/packages/cli/templates/tier-l/.claude/rules/pipeline.md
@@ -15,6 +15,17 @@ Branch prefix `feature/` activates the full pipeline automatically.
 
 ---
 
+## Placeholder behavior
+
+When a placeholder like `[TYPE_CHECK_COMMAND]`, `[BUILD_COMMAND]`, `[TEST_COMMAND]`, `[E2E_COMMAND]`, or `[DEV_COMMAND]` is `# not configured` (or absent from `CLAUDE.md`):
+- Emit a visible step: `[SKIP] No <command-name> configured for this stack — verify manually if applicable.`
+- Do NOT proceed as if the command succeeded.
+- Do NOT mark the gate green.
+
+A skip is a legitimate outcome. Silent degradation is not.
+
+---
+
 ## Phase 0 - Session orientation
 
 **FIRST**: check for `CONTEXT_IMPORT.md` in the project root. If it exists and contains `Status: PENDING_DISCOVERY`, run the Discovery Workflow inside that file **before any other work**. Do not proceed until discovery is marked `COMPLETE`.

--- a/packages/cli/templates/tier-l/.claude/rules/pipeline.md
+++ b/packages/cli/templates/tier-l/.claude/rules/pipeline.md
@@ -17,7 +17,7 @@ Branch prefix `feature/` activates the full pipeline automatically.
 
 ## Placeholder behavior
 
-When a placeholder like `[TYPE_CHECK_COMMAND]`, `[BUILD_COMMAND]`, `[TEST_COMMAND]`, `[E2E_COMMAND]`, or `[DEV_COMMAND]` has no configured value in `CLAUDE.md` (absent or left as a comment placeholder):
+When a command placeholder in `CLAUDE.md` (type-check, build, test, E2E, or dev-server command) has no configured value (absent or left as a comment placeholder):
 - Emit a visible step: `[SKIP] No <command-name> configured for this stack — verify manually if applicable.`
 - Do NOT proceed as if the command succeeded.
 - Do NOT mark the gate green.

--- a/packages/cli/templates/tier-m/.claude/rules/pipeline.md
+++ b/packages/cli/templates/tier-m/.claude/rules/pipeline.md
@@ -17,7 +17,7 @@ Branch prefix `feature/` activates this pipeline automatically.
 
 ## Placeholder behavior
 
-When a placeholder like `[TYPE_CHECK_COMMAND]`, `[BUILD_COMMAND]`, `[TEST_COMMAND]`, `[E2E_COMMAND]`, or `[DEV_COMMAND]` has no configured value in `CLAUDE.md` (absent or left as a comment placeholder):
+When a command placeholder in `CLAUDE.md` (type-check, build, test, E2E, or dev-server command) has no configured value (absent or left as a comment placeholder):
 - Emit a visible step: `[SKIP] No <command-name> configured for this stack — verify manually if applicable.`
 - Do NOT proceed as if the command succeeded.
 - Do NOT mark the gate green.

--- a/packages/cli/templates/tier-m/.claude/rules/pipeline.md
+++ b/packages/cli/templates/tier-m/.claude/rules/pipeline.md
@@ -15,6 +15,17 @@ Branch prefix `feature/` activates this pipeline automatically.
 
 ---
 
+## Placeholder behavior
+
+When a placeholder like `[TYPE_CHECK_COMMAND]`, `[BUILD_COMMAND]`, `[TEST_COMMAND]`, `[E2E_COMMAND]`, or `[DEV_COMMAND]` is `# not configured` (or absent from `CLAUDE.md`):
+- Emit a visible step: `[SKIP] No <command-name> configured for this stack — verify manually if applicable.`
+- Do NOT proceed as if the command succeeded.
+- Do NOT mark the gate green.
+
+A skip is a legitimate outcome. Silent degradation is not.
+
+---
+
 ## Phase 0 - Session orientation
 
 - **FIRST**: check for `CONTEXT_IMPORT.md` in the project root. If it exists and contains `Status: PENDING_DISCOVERY`, run the Discovery Workflow inside that file **before any other work**. Do not proceed to Phase 1 until discovery is marked `COMPLETE`.

--- a/packages/cli/templates/tier-m/.claude/rules/pipeline.md
+++ b/packages/cli/templates/tier-m/.claude/rules/pipeline.md
@@ -17,7 +17,7 @@ Branch prefix `feature/` activates this pipeline automatically.
 
 ## Placeholder behavior
 
-When a placeholder like `[TYPE_CHECK_COMMAND]`, `[BUILD_COMMAND]`, `[TEST_COMMAND]`, `[E2E_COMMAND]`, or `[DEV_COMMAND]` is `# not configured` (or absent from `CLAUDE.md`):
+When a placeholder like `[TYPE_CHECK_COMMAND]`, `[BUILD_COMMAND]`, `[TEST_COMMAND]`, `[E2E_COMMAND]`, or `[DEV_COMMAND]` has no configured value in `CLAUDE.md` (absent or left as a comment placeholder):
 - Emit a visible step: `[SKIP] No <command-name> configured for this stack — verify manually if applicable.`
 - Do NOT proceed as if the command succeeded.
 - Do NOT mark the gate green.

--- a/packages/cli/templates/tier-s/.claude/rules/pipeline.md
+++ b/packages/cli/templates/tier-s/.claude/rules/pipeline.md
@@ -7,7 +7,7 @@ Branch prefix `fix/` activates this pipeline automatically.
 
 ## Placeholder behavior
 
-When a placeholder like `[TYPE_CHECK_COMMAND]`, `[BUILD_COMMAND]`, `[TEST_COMMAND]`, `[E2E_COMMAND]`, or `[DEV_COMMAND]` is `# not configured` (or absent from `CLAUDE.md`):
+When a placeholder like `[TYPE_CHECK_COMMAND]`, `[BUILD_COMMAND]`, `[TEST_COMMAND]`, `[E2E_COMMAND]`, or `[DEV_COMMAND]` has no configured value in `CLAUDE.md` (absent or left as a comment placeholder):
 - Emit a visible step: `[SKIP] No <command-name> configured for this stack — verify manually if applicable.`
 - Do NOT proceed as if the command succeeded.
 - Do NOT mark the gate green.

--- a/packages/cli/templates/tier-s/.claude/rules/pipeline.md
+++ b/packages/cli/templates/tier-s/.claude/rules/pipeline.md
@@ -5,6 +5,17 @@ Branch prefix `fix/` activates this pipeline automatically.
 
 ---
 
+## Placeholder behavior
+
+When a placeholder like `[TYPE_CHECK_COMMAND]`, `[BUILD_COMMAND]`, `[TEST_COMMAND]`, `[E2E_COMMAND]`, or `[DEV_COMMAND]` is `# not configured` (or absent from `CLAUDE.md`):
+- Emit a visible step: `[SKIP] No <command-name> configured for this stack — verify manually if applicable.`
+- Do NOT proceed as if the command succeeded.
+- Do NOT mark the gate green.
+
+A skip is a legitimate outcome. Silent degradation is not.
+
+---
+
 ## FL-0 - Branch check + session file
 
 - **Session file**: check `.claude/session/` for existing `fix-*.md` files.

--- a/packages/cli/templates/tier-s/.claude/rules/pipeline.md
+++ b/packages/cli/templates/tier-s/.claude/rules/pipeline.md
@@ -7,7 +7,7 @@ Branch prefix `fix/` activates this pipeline automatically.
 
 ## Placeholder behavior
 
-When a placeholder like `[TYPE_CHECK_COMMAND]`, `[BUILD_COMMAND]`, `[TEST_COMMAND]`, `[E2E_COMMAND]`, or `[DEV_COMMAND]` has no configured value in `CLAUDE.md` (absent or left as a comment placeholder):
+When a command placeholder in `CLAUDE.md` (type-check, build, test, E2E, or dev-server command) has no configured value (absent or left as a comment placeholder):
 - Emit a visible step: `[SKIP] No <command-name> configured for this stack — verify manually if applicable.`
 - Do NOT proceed as if the command succeeded.
 - Do NOT mark the gate green.


### PR DESCRIPTION
## Summary

- Add a `## Placeholder behavior` section to pipeline.md across all three tiers (tier-l, tier-m, tier-s)
- Rule: when a `CLAUDE.md` command placeholder has no configured value, emit `[SKIP] No <command-name> configured` and do NOT mark the gate green
- Applies to type-check, build, test, E2E, and dev-server command slots

## Why

Without this rule, unconfigured placeholders could silently pass pipeline gates — the pipeline would proceed as if the command succeeded when no command was ever run. This makes fresh scaffolds fail quietly instead of visibly.

A skip is a legitimate outcome. Silent degradation is not.

## Test plan

- [x] Integration tests: 1129 passed, 0 failed (run on main before branch diverged)
- [ ] Verify `## Placeholder behavior` section present in all three tier pipeline.md files
- [ ] Verify section appears before Phase 0 / FL-0

🤖 Generated with [Claude Code](https://claude.com/claude-code)