### PR TITLE
chore(scaffold): explicit skip gates for Track A and security checklist (P1.2+P1.3)

### DIFF
--- a/packages/cli/templates/tier-l/.claude/rules/pipeline.md
+++ b/packages/cli/templates/tier-l/.claude/rules/pipeline.md
@@ -157,7 +157,12 @@ Then:
 - Follow all coding conventions in `CLAUDE.md`.
 - **After every new migration**: apply to remote DB immediately + verify + log in your project's migrations log (e.g. `docs/migrations-log.md`) if one is tracked.
 - **Destructive migrations** (`DROP COLUMN`, `DROP TABLE`): write rollback SQL in a comment block at the top of the migration file before applying.
-- **Security checklist** (before intermediate commit): (1) auth check before any operation, (2) input validated, (3) no sensitive data in response, (4) access control not bypassed; (5) new tables have row-level access control enabled — RLS in Postgres, equivalent feature in your DB engine, or application-level guards as fallback.
+- **Security checklist** (before intermediate commit):
+  - If block adds/modifies API routes: (1) auth check before any operation, (2) input validated, (3) no sensitive data in response, (4) access control not bypassed.
+  - If block adds/modifies DB tables: (5) row-level access control enabled — RLS in Postgres, equivalent feature in your DB engine, or application-level guards as fallback.
+  - If project is CLI: check argument sanitization, filesystem access patterns, command injection vectors.
+  - If project is native mobile: check keychain usage, data-at-rest encryption, App Transport Security (ATS).
+  - If none of the above apply to this block: state explicitly that no security checklist items are applicable and why.
 - Run `/simplify` on changed files after writing (skip for trivial 1-file changes).
 
 ## Phase 3 - Build + unit tests
@@ -212,7 +217,10 @@ If either condition is false: **skip this phase and state so explicitly** - do n
 
 ## Phase 5d - Block-scoped quality audit *(blocks with UI or API changes)*
 
-**Track A - UI audit** *(if block adds/modifies UI routes or components - web applications only; skip for CLI, backend-only, or native projects)*
+**Track A - UI audit** *(if block adds/modifies UI routes or components AND the project is a web or native UI application)*
+
+If the project is CLI-only, backend-only, or native-standalone without a UI layer: state `[SKIP] Track A — not a web or native UI project` and move to Track B.
+
 - Run `/ui-audit` scoped to the block's new/modified routes only (token compliance, component adoption, empty states).
 - Run `/accessibility-audit` scoped to the block's new/modified routes (WCAG 2.2, contrast, static a11y patterns).
 - Run `/visual-audit` scoped to the block's new/modified pages (typography, spacing, hierarchy, colour, density, dark-mode, micro-polish).

--- a/packages/cli/templates/tier-m/.claude/rules/pipeline.md
+++ b/packages/cli/templates/tier-m/.claude/rules/pipeline.md
@@ -133,7 +133,12 @@ A skip is a legitimate outcome. Silent degradation is not.
 - Update `docs/requirements.md` with the approved plan before writing any code.
 - Follow all coding conventions in `CLAUDE.md`.
 - **After every new migration**: apply to remote DB immediately + verify + log in your project's migrations log (e.g. `docs/migrations-log.md`) if one is tracked.
-- **Security checklist** (before intermediate commit): for every new/modified API route: (1) auth check before any operation, (2) input validated, (3) no sensitive data exposed in response, (4) access control not bypassed. For every new DB table: (5) row-level access control enabled — RLS in Postgres, equivalent feature in your DB engine, or application-level guards as fallback.
+- **Security checklist** (before intermediate commit):
+  - If block adds/modifies API routes: (1) auth check before any operation, (2) input validated, (3) no sensitive data exposed in response, (4) access control not bypassed.
+  - If block adds/modifies DB tables: (5) row-level access control enabled — RLS in Postgres, equivalent feature in your DB engine, or application-level guards as fallback.
+  - If project is CLI: check argument sanitization, filesystem access patterns, command injection vectors.
+  - If project is native mobile: check keychain usage, data-at-rest encryption, App Transport Security (ATS).
+  - If none of the above apply to this block: state explicitly that no security checklist items are applicable and why.
 - Run `/simplify` on changed files after writing (skip for trivial 1-file changes).
 
 ## Phase 3 - Build + tests
@@ -187,7 +192,10 @@ If either condition is false: **skip this phase and state so explicitly** - do n
 
 ## Phase 5d - Block-scoped quality audit *(blocks with UI or API changes)*
 
-**Track A - UI audit** *(if block adds/modifies UI routes or components - web applications only; skip for CLI, backend-only, or native projects)*
+**Track A - UI audit** *(if block adds/modifies UI routes or components AND the project is a web or native UI application)*
+
+If the project is CLI-only, backend-only, or native-standalone without a UI layer: state `[SKIP] Track A — not a web or native UI project` and move to Track B.
+
 - Run `/ui-audit` scoped to the block's new/modified routes only (token compliance, component adoption, empty states).
 - Run `/accessibility-audit` scoped to the block's new/modified routes (WCAG 2.2, contrast, static a11y patterns).
 - Run `/visual-audit` scoped to the block's new/modified pages (typography, spacing, hierarchy, colour, density, dark-mode, micro-polish).


### PR DESCRIPTION
## Summary

- **P1.2 — Track A UI audit gate**: gate condition changed from implicit parenthetical note to explicit dual condition `(UI changes AND web/native UI application)` with a required skip output for CLI/backend/native-standalone projects
- **P1.3 — Security checklist**: rewrote from hardcoded API+DB checks to conditional IF clauses: API routes → (1)-(4), DB tables → (5), CLI → argument sanitization/filesystem/injection, native mobile → keychain/data-at-rest/ATS. Adds explicit "none apply" output when no clause matches.
- Applies to tier-m and tier-l only (tier-s Fast Lane has no Phase 5d or security checklist)

## Why

Both issues were confirmed Critical by 4/4 reviewers in the 2026-04-29 dev-pipeline cross-LLM meta-review:

- **CC2**: Track A had no explicit skip output for non-web projects — Claude could silently pass a browser audit phase on a Go CLI or Python FastAPI project
- **CC3**: Security checklist ran "completa" on CLI/native stacks with no API or DB, giving a false sense of security without checking the relevant vectors (argument sanitization, keychain, ATS)

## Test plan

- [x] Integration tests: `cd packages/cli && npm test` → 1129 passed, 0 failed
- [ ] Verify Track A heading shows `AND the project is a web or native UI application`
- [ ] Verify Track A has explicit `[SKIP]` clause for CLI/backend/native-standalone
- [ ] Verify security checklist has IF clauses for API, DB, CLI, native mobile
- [ ] Verify both tier-m and tier-l are updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)