### PR TITLE
chore(scaffold): P2+P3 pipeline polish — escalation language-aware, scope sweep, dependency scan

### DIFF
--- a/packages/cli/templates/tier-l/.claude/rules/pipeline.md
+++ b/packages/cli/templates/tier-l/.claude/rules/pipeline.md
@@ -70,7 +70,7 @@ Then:
   - **Data**: entities read/written? Silent data loss possible?
   - **Triggers**: activating event? Secondary triggers?
   - **Error conditions**: invalid input, missing data, concurrent edits - behavior defined?
-  - **UI states**: empty, error, loading covered?
+  - **UI/output states**: empty, error, loading covered? For CLI: exit codes, stderr output, no-results case.
   - **Integrations**: notifications, external systems affected?
   - **Reversibility**: irreversible operation? Rollback defined?
   - **Explicit exclusions**: what is NOT being done that a reader might assume?
@@ -80,7 +80,7 @@ Then:
   - **Conditions** `IF/THEN`: preconditions that change behavior? Edge cases, concurrent edits?
   - **States** `WHILE`: which entity states or user states affect behavior? All combinations covered?
   - **Optional / role-gated** `WHERE`: what is conditional on role, community, or config?
-  - All Tier 1 dimensions (roles, data, error conditions, UI states, integrations, reversibility, exclusions)
+  - All Tier 1 dimensions (roles, data, error conditions, UI/output states, integrations, reversibility, exclusions)
   - **Pre-mortem**: if this plan fails in Phase 2 due to scope ambiguity, what caused it?
 
   Also declare: **does this block include critical UI flows?** (yes/no). Determines whether Phase 4 activates.
@@ -90,7 +90,7 @@ Then:
   Compose one `AskUserQuestion` with all open items. The user - not Claude - declares when scope is complete.
 
 - **Dependency scan** (mandatory - always run `/dependency-scan`):
-  Run `/dependency-scan` with the full list of affected routes, components, types/utilities, DB tables in one prompt. It runs all 6 checks and returns exact file paths + line numbers. Do not run checks manually in the main session - an incomplete scan is an incomplete file list, which is a process error.
+  Run `/dependency-scan` with the full list of affected routes/screens/commands, components/views, types/utilities, data models/DB tables in one prompt. It runs all 6 checks and returns exact file paths + line numbers. Do not run checks manually in the main session - an incomplete scan is an incomplete file list, which is a process error.
   Every file listed under "Mandatory additions" in the report must be in the file list before the STOP gate.
 - **All clarification questions must use `AskUserQuestion` tool** - never inline.
 

--- a/packages/cli/templates/tier-m/.claude/rules/pipeline.md
+++ b/packages/cli/templates/tier-m/.claude/rules/pipeline.md
@@ -67,7 +67,7 @@ A skip is a legitimate outcome. Silent degradation is not.
   - **Data**: entities read/written? Silent data loss possible?
   - **Triggers**: what user action activates this? Secondary triggers?
   - **Error conditions**: invalid input, missing data, concurrent edits - behavior defined?
-  - **UI states**: empty, error, loading covered?
+  - **UI/output states**: empty, error, loading covered? For CLI: exit codes, stderr output, no-results case.
   - **Integrations**: emails, notifications, external systems affected?
   - **Reversibility**: any irreversible operation? Rollback defined?
   - **Explicit exclusions**: what is NOT being done that a reader might assume is included?
@@ -86,7 +86,7 @@ A skip is a legitimate outcome. Silent degradation is not.
   Compose one `AskUserQuestion` with all open items from the sweep. Do NOT proceed to the dependency scan until an execution keyword is received.
 
 - **Dependency scan** (mandatory - always run `/dependency-scan`):
-  Run `/dependency-scan` with the full list of affected routes, components, types/utilities, and DB tables. Every file listed under "Mandatory additions" must be in the file list before the STOP gate.
+  Run `/dependency-scan` with the full list of affected routes/screens/commands, components/views, types/utilities, and data models/DB tables. Every file listed under "Mandatory additions" must be in the file list before the STOP gate.
 
 - **Path A - Spec-first**: generate `docs/specs/[block-name].md` using this structure:
 

--- a/packages/cli/templates/tier-s/.claude/rules/pipeline.md
+++ b/packages/cli/templates/tier-s/.claude/rules/pipeline.md
@@ -23,7 +23,7 @@ A skip is a legitimate outcome. Silent degradation is not.
   - If none: create `.claude/session/fix-[description].md` with a one-line description and the current date.
 - Confirm current branch starts with `fix/`. If not: `git checkout -b fix/description`.
 - Never commit directly to `main` or `staging`.
-- **Escalation check**: if the fix touches a shared utility or type with >5 import consumers, stop - notify the user and escalate to Tier M (full pipeline). A fix with wide-impact shared changes is not a fast-lane operation.
+- **Escalation check**: if the fix touches a shared utility or type with >5 import consumers (or the equivalent in the project's language — Go `pkg/`, Swift shared framework, Python package imports), stop - notify the user and escalate to Tier M (full pipeline). A fix with wide-impact shared changes is not a fast-lane operation.
 
 ## FL-1 - Implement
 


### PR DESCRIPTION
## Summary

- **P2.4 — Tier S FL-0 escalation criteria language-aware**: "shared utility or type with >5 import consumers" extended with stack equivalents: Go `pkg/`, Swift shared framework, Python package imports
- **P3.1 — Scope sweep "UI states" → "UI/output states"**: applies to Tier 1 Standard Sweep in tier-m and tier-l; adds CLI-specific examples (exit codes, stderr, no-results case). Also updates the Tier 2 summary line in tier-l.
- **P3.1 — Dependency scan terminology generalized**: "routes, components, types/utilities, DB tables" → "routes/screens/commands, components/views, types/utilities, data models/DB tables" in both tier-m and tier-l, making it applicable to native (screens), CLI (commands), and non-relational stacks.

Most P2 items (P2.1 smoke test, P2.2 Track B gate, P2.3 E2E selectors, P2.5 Phase 5b test data) were already applied in prior PRs. This closes out the remaining P2 and P3 items from the 2026-04-29 dev-pipeline cross-LLM meta-review.

## Why

From the meta-review (Mistral High, Gemini Medium, 2/4 convergence on CC6):
- Escalation criteria assumed TypeScript module system — Go, Swift, and Python developers would not recognize ">5 import consumers" as applying to their projects
- "UI states" framing confused reviewers on CLI/API blocks; "no-results" and "stderr" are the CLI equivalents of empty/error states
- Dependency scan prompt listing "routes/components/DB tables" read as web-only, causing CLI and native reviewers to interpret the scan as inapplicable

## Test plan

- [x] Integration tests: `cd packages/cli && npm test` → 1129 passed, 0 failed
- [ ] Verify Tier S FL-0 has "(or equivalent in the project's language — Go `pkg/`, Swift shared framework, Python package imports)"
- [ ] Verify "UI/output states" with CLI examples in tier-m and tier-l Tier 1 sweep
- [ ] Verify dependency scan prompt includes "routes/screens/commands" and "data models/DB tables"

🤖 Generated with [Claude Code](https://claude.com/claude-code)