### PR TITLE
fix(scripts): pin GH_TOKEN to marcoguillermaz in gh-release.sh

### DIFF
--- a/.claude/scripts/gh-release.sh
+++ b/.claude/scripts/gh-release.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export GH_TOKEN=$(gh auth token --user marcoguillermaz)
+
+TAG="${1:?Usage: gh-release.sh <tag> <title> <notes-file>}"
+TITLE="${2:?Usage: gh-release.sh <tag> <title> <notes-file>}"
+NOTES_FILE="${3:?Usage: gh-release.sh <tag> <title> <notes-file>}"
+
+[[ -f "$NOTES_FILE" ]] || { echo "Error: notes file not found: $NOTES_FILE" >&2; exit 1; }
+
+gh release create "$TAG" --title "$TITLE" --notes-file "$NOTES_FILE"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -350,7 +350,7 @@ This section is for repo administrators handling release cycles. Contributors do
 2. **Sync local main**: `git checkout main && git pull origin main`.
 3. **Create the tag**: `git tag -a v<MAJOR>.<MINOR>.<PATCH> -m "v<MAJOR>.<MINOR>.<PATCH> - <one-line summary>"`. Push with `git push origin v<MAJOR>.<MINOR>.<PATCH>`.
 4. **Run `/humanize`** on the GitHub Release notes draft (domain `announcement`).
-5. **Create the GitHub Release**: `gh release create v<MAJOR>.<MINOR>.<PATCH> --title "..." --notes "$(cat humanized-notes.md)"`. The active `gh` account must have repo write scope (verify with `gh auth status --active`); switch to `marcoguillermaz` account if `gh auth switch --user marcoguillermaz` is needed.
+5. **Create the GitHub Release**: `.claude/scripts/gh-release.sh v<MAJOR>.<MINOR>.<PATCH> "Release title" humanized-notes.md`. The script pins `GH_TOKEN` to `marcoguillermaz` on its own; no manual account switch needed. Output is the release URL.
 6. **Comment on the closed issue** with a humanized closing note pointing to the Release URL.
 7. **Update `roadmap-status.md`** locally: roadmap row → Done with the merge date and PR number. The file is gitignored under `.claude/initiatives/` — local source of truth.
 8. **Sync the GitHub Project**: `gh project item-edit --project-id <project-id> --id <item-id> --field-id <Status-field-id> --single-select-option-id <Done-option-id>`. The current project IDs live in `.claude/initiatives/roadmap-status.md` (gitignored).
@@ -369,7 +369,7 @@ npm publish
 
 ### Auth scoping protocol
 
-The `gh` CLI account `marcoguillermaz-spec` is read-only on this repo (no `workflow` scope). Release creation requires `marcoguillermaz`. After git operations the active account often reverts — always run `gh auth switch --user marcoguillermaz` immediately before any release-affecting `gh` invocation. Inline the switch in the same Bash call to avoid the silent revert window.
+The `gh` CLI account `marcoguillermaz-spec` is read-only on this repo (no `workflow` scope). Release creation requires `marcoguillermaz`. `.claude/scripts/gh-release.sh` pins `GH_TOKEN=$(gh auth token --user marcoguillermaz)` as its first action: the correct token is injected regardless of which account is currently active. Do not call `gh auth switch` before running the script; it is not needed for release operations.
 
 ### Branch protection
 


### PR DESCRIPTION
## Summary

Replaces the fragile manual `gh auth switch` workaround with automatic token pinning in a dedicated release script.

**Problem**: `CONTRIBUTING.md` documented `gh auth switch --user marcoguillermaz` as a manual step before every `gh release create`. A session with the wrong active account silently broke release creation — no error until the command failed with a permission denied.

**Fix**:
- New `.claude/scripts/gh-release.sh`: accepts `<tag> <title> <notes-file>`, pins `GH_TOKEN=$(gh auth token --user marcoguillermaz)` as its first action, then runs `gh release create`. Token is injected regardless of which `gh` account is currently active. Output is the release URL.
- `CONTRIBUTING.md` step 5: replaces the manual `gh release create` + auth switch instruction with a reference to the script.
- `CONTRIBUTING.md` "Auth scoping protocol": updated to reflect that pinning is now automatic and `gh auth switch` must not be called manually before release operations.

## Verification

`gh auth token --user marcoguillermaz` returns a valid token on this machine. Script exits with `set -euo pipefail` — any failure (missing notes file, token error, release already exists) surfaces immediately with a non-zero exit code.

## Test plan

- [x] `gh auth token --user marcoguillermaz` returns token (verified pre-commit)
- [x] Script is executable (`chmod +x`)
- [x] `CONTRIBUTING.md` prose passed through `/humanize` (domain: generico)
- [x] No other files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)