### PR TITLE
chore(context): gitignore .envrc to prevent token exposure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Local environment (never commit — contains resolved tokens)
+.envrc
+
 # Dependencies
 node_modules/
 .venv/


### PR DESCRIPTION
## Summary

- Adds `.envrc` to `.gitignore` with an explanatory comment
- `.envrc` contains `GH_TOKEN` resolved at shell load time via direnv — committing it would expose the token in version history

## Context

`.envrc` is loaded by direnv and injects `GH_TOKEN=<resolved-token>` into the shell environment for the `marcoguillermaz` account. It was already listed in CONTRIBUTING.md as a local-only file, but was not protected by `.gitignore`, leaving it one accidental `git add .` away from exposure.

## Test plan

- [ ] Confirm `.envrc` does not appear in `git status` after this PR merges
- [ ] `git check-ignore -v .envrc` returns `.gitignore:1:.envrc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)