### PR TITLE
docs: sync README + operational-guide + CONTRIBUTING with v1.22.0 reality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **Documentation drift sync** (no behavior change). Realigned README, CONTRIBUTING and `docs/operational-guide.md` with the v1.22.0 codebase after a deep-review pass surfaced stale numbers and missing sections.
+  - Test counts updated: 1129 integration checks (was 979), 373 unit tests across 61 suites (was 332 across 50), ~118 integration scenarios (was ~40).
+  - Doctor count updated: 29 checks (was 28). The numbered list in operational-guide §13 now includes `team-settings-runtime-hook`, scaffolded back in v1.21.0 but never enumerated.
+  - Audit-skill count corrected to 24 (was 22) by adding `/dependency-scan` (Tier M+L) and `/context-review` (Tier L) to the README skill table. Both were already covered in operational-guide §11 as pipeline-integrated skills; the README simply omitted them.
+  - MCP-server tool count corrected to six (was five). `cdk_pr_review` shipped as the sixth tool but the introductory sentence was never updated.
+  - Operational-guide §10 now has dedicated entries for `/dependency-audit` and `/pr-review`, which were listed in the README skill table but missing from the per-skill detail section.
+  - Operational-guide footer bumped from "v1.10.4" to "v1.22.0".
+  - Hardcoded "1129 integration checks" badge removed from the README header to retire a recurring per-release maintenance debt; the exact count remains in §Testing.
+  - Statements about v1.16.0 and v1.17.0 in the operational-guide reframed in past tense so readers do not infer those are the current state.
+
 ---
 
 ## [1.22.0] — 2026-04-28

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,8 +40,8 @@ node packages/cli/src/index.js new skill
 **Run the test suites**:
 
 ```bash
-node packages/cli/test/integration/run.js     # 979 integration checks
-node --test packages/cli/test/unit/*.test.js  # 332 unit tests
+node packages/cli/test/integration/run.js     # 1129 integration checks
+node --test packages/cli/test/unit/*.test.js  # 373 unit tests
 ```
 
 Both must pass before you submit a PR. Add `--verbose` to the integration runner to see per-assertion output when debugging.
@@ -271,9 +271,9 @@ Pick a short uppercase prefix for findings that the skill produces. Existing pre
 
 CDK ships two test layers:
 
-**Unit tests** (`packages/cli/test/unit/*.test.js`) cover pure functions: `skill-registry`, `doctor-cross-file`, `skill-frontmatter`, individual scaffold helpers. Use `node:test`. Run via `npm run --prefix packages/cli test:unit`. Total: 332 tests across 50 suites.
+**Unit tests** (`packages/cli/test/unit/*.test.js`) cover pure functions: `skill-registry`, `doctor-cross-file`, `skill-frontmatter`, individual scaffold helpers. Use `node:test`. Run via `npm run --prefix packages/cli test:unit`. Total: 373 tests across 61 suites.
 
-**Integration tests** (`packages/cli/test/integration/run.js`) scaffold full projects to a tmp directory and assert on file structure, content, and CLI behavior. Uses a custom `pass()` / `fail()` reporter (no test framework). Total: 979 checks across ~40 scenarios. Run via `npm test --prefix packages/cli`.
+**Integration tests** (`packages/cli/test/integration/run.js`) scaffold full projects to a tmp directory and assert on file structure, content, and CLI behavior. Uses a custom `pass()` / `fail()` reporter (no test framework). Total: 1129 checks across ~118 scenarios. Run via `npm test --prefix packages/cli`.
 
 **Fixtures** for full CLI execution via `--answers` live in `packages/cli/test/integration/fixtures/`. Each fixture is a JSON file matching the wizard prompt schema. Used by `scenarioWizardCoverage`.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Node.js >= 22](https://img.shields.io/badge/node-%3E%3D22-brightgreen.svg)](https://nodejs.org)
 [![CI](https://github.com/marcoguillermaz/claude-dev-kit/actions/workflows/ci.yml/badge.svg)](https://github.com/marcoguillermaz/claude-dev-kit/actions/workflows/ci.yml)
-[![1129 integration checks](https://img.shields.io/badge/integration-1129%20checks-blue.svg)](#testing)
 
 > Scaffold for legible, reviewable AI-assisted development.
 > Claude generates. Your team decides.
@@ -49,7 +48,7 @@ After init, open Claude Code and start working. The scaffold is active immediate
 
 Start at Tier 0. Move up when you need more structure: `npx mg-claude-dev-kit upgrade --tier=m`
 
-### 22 audit skills
+### 24 audit skills
 
 Executable multi-step programs that run inside Claude Code. Not prompt instructions - structured audit workflows with model routing (haiku for mechanical checks, sonnet for analysis).
 
@@ -77,6 +76,8 @@ Executable multi-step programs that run inside Claude Code. Not prompt instructi
 | `/dependency-audit`    | M L   | Outdated package audit: Tier A (safe batch) / B (non-core major) / C (core/breaking-risk) classification, changelog summary for Tier B/C, codebase impact grep, runtime LTS status. Stack-aware (node-ts/python/swift); agnostic fallback for other stacks. Audit-only in v1; mutating apply-tier-a deferred to Q4. **MCP-aware (v1.20+)**: Step 2 queries `package-registry-mcp` for multi-ecosystem package metadata with WebFetch fallback. |
 | `/pr-review`           | M L   | Autonomous local PR review via gh CLI: spawns review subagent on the diff, classifies findings (Critical / Major / Minor) using universal + stack-specific severity criteria, posts review as PR comment for audit trail. Configurable via team-settings.json `prReviewSeverity`. Read-only. `--deep` escalates to opus for sensitive changes. Also exposed as `cdk_pr_review` MCP tool. |
 | `/skill-review`        | M L   | Quality review pipeline for skill portfolios. Spec compliance, cross-tier coherence, behavioral fixtures.                               |
+| `/dependency-scan`     | M L   | Pipeline-integrated (Phase 1): forked-context scan that returns the full file list — routes, components, shared types, DB tables — fed into the Phase 1 STOP gate. Six structurally independent checks (C1–C6) with a "Mandatory additions" section. |
+| `/context-review`      | L     | Pipeline-integrated (Phase 8.5): forked-context review that runs after block closure to recompact `CLAUDE.md` and detect context drift before the next block opens. Tier L only.                  |
 
 Skills are conditionally installed based on your project: `hasApi`, `hasDatabase`, `hasFrontend`, `hasDesignSystem`.
 
@@ -86,7 +87,7 @@ Node.js/TS, Node.js/JS, Python, Go, Swift, Kotlin, Rust, .NET, Ruby, Java - plus
 
 ### MCP server (v1.17.0+)
 
-The `mg-claude-dev-kit` package ships an MCP server (`claude-dev-kit-mcp` binary) alongside the CLI, version-locked, single `npm install -g`. Any MCP-aware client (Claude Desktop, ChatGPT desktop, Cursor, VS Code, Copilot Studio) can query CDK governance state without the CDK CLI running. Five read-only tools cover doctor report, team-settings, last arch-audit, skill inventory, and package metadata. Full reference in the [MCP server](#mcp-server) section below.
+The `mg-claude-dev-kit` package ships an MCP server (`claude-dev-kit-mcp` binary) alongside the CLI, version-locked, single `npm install -g`. Any MCP-aware client (Claude Desktop, ChatGPT desktop, Cursor, VS Code, Copilot Studio) can query CDK governance state without the CDK CLI running. Six read-only tools cover doctor report, team-settings, last arch-audit, skill inventory, package metadata, and `/pr-review` comments. Full reference in the [MCP server](#mcp-server) section below.
 
 ### Incremental adoption
 
@@ -133,7 +134,7 @@ The Stop hook in `settings.json` is the core enforcement mechanism. It blocks Cl
 npx mg-claude-dev-kit init                    # scaffold wizard
 npx mg-claude-dev-kit init --dry-run          # preview without writing
 npx mg-claude-dev-kit init --answers file.json  # skip prompts (CI/automation)
-npx mg-claude-dev-kit doctor                  # validate setup (28 checks)
+npx mg-claude-dev-kit doctor                  # validate setup (29 checks)
 npx mg-claude-dev-kit doctor --report         # JSON output for CI
 npx mg-claude-dev-kit doctor --ci             # silent, exit 1 on failure
 npx mg-claude-dev-kit upgrade                 # update template files
@@ -164,14 +165,14 @@ Read-only tools exposed:
 
 | Tool | Returns |
 | ---- | ------- |
-| `cdk_doctor_report` | `doctor --report` JSON (28 checks) |
+| `cdk_doctor_report` | `doctor --report` JSON (29 checks) |
 | `cdk_team_settings` | parsed `.claude/team-settings.json` |
 | `cdk_arch_audit_status` | last `arch-audit` run timestamp + age |
 | `cdk_skill_inventory` | installed skills + frontmatter snapshot |
 | `cdk_package_meta` | CDK package name, version, CLI path, cwd |
 | `cdk_pr_review` | reads existing `/pr-review` skill comments on a GitHub PR (verdict, severity counts). Read-only — to generate a fresh review, invoke the `/pr-review` CDK skill. |
 
-The server resolves the project root from `$CDK_PROJECT_ROOT` if set, otherwise from `process.cwd()`. No mutating tools in v1.17.0 by design.
+The server resolves the project root from `$CDK_PROJECT_ROOT` if set, otherwise from `process.cwd()`. v1.17.0 launched read-only by design; that posture is unchanged through v1.22.0.
 
 ---
 
@@ -204,7 +205,7 @@ node packages/cli/test/integration/run.js    # 1129 integration checks
 node --test packages/cli/test/unit/*.test.js   # 373 unit tests
 ```
 
-Covers: file structure per tier, Stop hook presence, pipeline gate counts, placeholder resolution, skill pruning, security variant selection, native stack adaptation, rubric scoring, cross-stack content invariants (10 stacks), golden-file assertions (Swift, Node-TS, Python), full CLI execution via `--answers` fixtures.
+Covers: file structure per tier, Stop hook presence, pipeline gate counts, placeholder resolution, skill pruning, security variant selection, native stack adaptation, rubric scoring, cross-stack content invariants (10 stacks — the named stacks excluding the `other` fallback), golden-file assertions (Swift, Node-TS, Python), full CLI execution via `--answers` fixtures.
 
 ---
 

--- a/docs/operational-guide.md
+++ b/docs/operational-guide.md
@@ -977,6 +977,20 @@ Unlike other skills, this one **applies changes directly**. Targets: early retur
 
 Conventional Commits automation. Auto-detects commit type, scope, and description from staged changes.
 
+#### /dependency-audit
+
+**File**: `.claude/skills/dependency-audit/SKILL.md` | **Tier**: M, L | **Backlog prefix**: `DEP-n`
+
+Outdated-package audit with severity classification. Three tiers: Tier A (safe batch — patch and minor bumps for non-core packages), Tier B (non-core major), Tier C (core or breaking-risk). Tier B and Tier C entries include a one-paragraph changelog summary plus a grep-based codebase impact note. Runtime LTS status is reported alongside the package report. Stack-aware (`node-ts`, `python`, `swift`); other stacks fall back to a generic outdated-listing pass.
+
+When the [`package-registry-mcp`](https://github.com/Artmann/package-registry-mcp) server is wired in `.mcp.json`, Step 2 calls `mcp__package-registry-mcp__lookup_package` for current package metadata (latest version, repository URL, maintainer, dist-tags) and uses the returned repo URL to fetch the GitHub releases changelog. Falls back to WebFetch with an explicit warning when the MCP server is unreachable. Audit-only in v1; mutating apply-tier-a is deferred.
+
+#### /pr-review
+
+**File**: `.claude/skills/pr-review/SKILL.md` | **Tier**: M, L
+
+Autonomous local pull-request review via the `gh` CLI. Spawns a review subagent on the PR diff, classifies findings as Critical / Major / Minor using universal plus stack-specific severity criteria, and posts the review as a PR comment for audit trail. Configurable through `.claude/team-settings.json` `prReviewSeverity`. Read-only — no merges, no code changes. The `--deep` flag escalates the subagent to opus for sensitive changes. The skill is also exposed as the `cdk_pr_review` MCP tool, which reads existing review comments rather than generating fresh ones.
+
 ---
 
 ## 11. Pipeline-integrated skills (Tier M / L)
@@ -1187,7 +1201,7 @@ npx mg-claude-dev-kit doctor --report  # JSON compliance output for CI pipelines
 npx mg-claude-dev-kit doctor --ci      # silent mode: exit 1 if any check fails
 ```
 
-Runs 28 checks:
+Runs 29 checks:
 
 1. Claude Code CLI is installed and reachable
 2. `CLAUDE.md` is present
@@ -1216,9 +1230,10 @@ Runs 28 checks:
 25. Stop hook has `timeout` configured and ≤ 600s (warn if missing - prevents hanging test commands)
 26. Anthropic-influenced files match the installed CDK template — `arch-audit/advanced-checks.md` in v1.15.0 (warn on drift, suggest `upgrade --anthropic`)
 27. Repo state matches `.claude/team-settings.json` — minTier ≥ scaffold tier, no blocked skills installed, all required skills present (warn-level; skips when the file is absent)
-28. No duplicate entries in `permissions.deny` list (warn if duplicates found)
+28. `team-settings.json` runtime enforcement hook is scaffolded and registered on the `Skill` matcher in `.claude/settings.json` (warn-level; skips when `team-settings.json` is absent — added in v1.21.0)
+29. No duplicate entries in `permissions.deny` list (warn if duplicates found)
 
-Checks 12-28 are skipped for Tier 0 projects.
+Checks 12-29 are skipped for Tier 0 projects.
 
 **`--report` output**: machine-readable JSON with timestamp, cwd, summary (passed/warned/failed/skipped), and per-check details. Consumed by CI systems or external audit tools.
 
@@ -1254,19 +1269,20 @@ Enforcement points: `init` (refuse + explain), `upgrade` (refuse + suggest), `ad
 
 `init-from-context` does not enforce `team-settings.json` because the target directory is greenfield; a parent `team-settings.json` doesn't propagate by design.
 
-v1.16.0 keeps enforcement strictly CLI-side. Native `Skill()` permission rules in `.claude/settings.json` are not generated this release: Claude Code's permission grammar for skills is not part of the documented public schema. Native rule generation tracks for v1.17+, after upstream verification.
+v1.16.0 introduced CLI-side enforcement only; native `Skill()` permission rules in `.claude/settings.json` were not generated at the time because Claude Code's permission grammar for skills was not part of the documented public schema. v1.21.0 closed that gap with a `PreToolUse` hook on the `Skill` matcher (`.claude/hooks/team-settings-enforcement.mjs`) that refuses skill invocations violating `blockedSkills` or `allowedSkills` at runtime — covered by doctor check #28 (`team-settings-runtime-hook`).
 
 ### MCP server
 
 The `mg-claude-dev-kit` npm package ships two binaries: `claude-dev-kit` (the wizard CLI) and `claude-dev-kit-mcp` (a Model Context Protocol server). Version-locked, single install.
 
-The MCP server exposes CDK governance state to any MCP-aware client (Claude Desktop, ChatGPT desktop, Cursor, VS Code, Copilot Studio). Five read-only tools:
+The MCP server exposes CDK governance state to any MCP-aware client (Claude Desktop, ChatGPT desktop, Cursor, VS Code, Copilot Studio). Six read-only tools:
 
 - `cdk_doctor_report` — runs `doctor --report` and returns the JSON
 - `cdk_team_settings` — parsed `.claude/team-settings.json` contents
 - `cdk_arch_audit_status` — last arch-audit run timestamp + age in days
 - `cdk_skill_inventory` — installed skills with frontmatter snapshot
 - `cdk_package_meta` — package name, version, CLI path, project root
+- `cdk_pr_review` — reads existing `/pr-review` comments on a GitHub PR (verdict + severity counts). Read-only; to generate a fresh review, invoke the `/pr-review` CDK skill.
 
 Wire up by adding to `.mcp.json` (project-scoped) or `~/.claude/.mcp.json` (user-scoped):
 
@@ -1278,7 +1294,7 @@ Wire up by adding to `.mcp.json` (project-scoped) or `~/.claude/.mcp.json` (user
 }
 ```
 
-The server resolves the project root from `$CDK_PROJECT_ROOT` if set, otherwise from the calling process's `cwd`. No mutating tools in v1.17.0 — adoption signal first, then read-write surface in a future minor.
+The server resolves the project root from `$CDK_PROJECT_ROOT` if set, otherwise from the calling process's `cwd`. v1.17.0 launched read-only by design; that posture is unchanged through v1.22.0. A read-write surface remains a future-minor decision contingent on adoption signal.
 
 ### Adding team-specific rules
 
@@ -1410,4 +1426,4 @@ Nine example fixtures are in `packages/cli/test/fixtures/wizard-answers/`. Copy 
 
 ---
 
-_Last updated: 2026-04-23 - v1.10.4_
+_Last updated: 2026-04-28 - v1.22.0_


### PR DESCRIPTION
## Summary

Documentation drift sync — no code change, no behavior change. A deep-review pass surfaced numeric and structural inconsistencies between docs and the v1.22.0 codebase. This PR realigns README, CONTRIBUTING, `docs/operational-guide.md`, and CHANGELOG.

## What changed

**Numbers fixed**

- Integration checks: 979 → 1129 (CONTRIBUTING ×2 spots)
- Unit tests: 332 → 373; suites 50 → 61 (CONTRIBUTING ×2 spots)
- Integration scenarios: ~40 → ~118 (CONTRIBUTING)
- Doctor checks: 28 → 29 (README ×2 spots, operational-guide). Added `team-settings-runtime-hook` (v1.21.0) to the numbered list in operational-guide §13.
- Audit-skill count: 22 → 24 (README). Added `/dependency-scan` and `/context-review` rows to the skill table — both already documented in operational-guide §11 but missing from the README enumeration.
- MCP-server tool count: Five → Six (README × 2 spots, operational-guide). The introductory sentence trailed the tool table that already listed `cdk_pr_review`.

**Structural additions**

- Operational-guide §10 now has dedicated entries for `/dependency-audit` and `/pr-review` (previously listed only in the README skill table).
- Operational-guide footer updated from "v1.10.4" to "v1.22.0".

**Stylistic / housekeeping**

- Removed the hardcoded `1129 integration checks` badge from the README header — it was a recurring per-release maintenance debt. The exact count is preserved in §Testing.
- Reframed historical statements about v1.16.0 and v1.17.0 in past tense so readers don't infer they describe the current state.
- Clarified that the "10 stacks" cross-stack invariants exclude the generic `other` fallback (vs the "11 tech stacks" claim earlier in the doc).

## Decisions taken

- **B1a**: chose to unify the count (24) rather than separate audit skills from pipeline-integrated skills in the README. The two pipeline-integrated entries (`/dependency-scan`, `/context-review`) appear in the same table with explicit "Pipeline-integrated" wording in the description column.
- **C1**: removed the integration-checks badge rather than dynamically generating it.
- Version stays at v1.22.0 as instructed; the entry lives under `[Unreleased]` in CHANGELOG.

## Test plan

- [x] `node packages/cli/test/integration/run.js` — 1129 passed
- [x] `node --test packages/cli/test/unit/*.test.js` — 373 / 61 suites passed
- [ ] CI — `Lint`, `Test`, `CodeQL`, `Anthropic-spec drift` all green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)