### PR TITLE
fix(security): prevent prototype pollution in setDottedPath

### DIFF
--- a/packages/cli/src/context-builder/inference/review.js
+++ b/packages/cli/src/context-builder/inference/review.js
@@ -17,7 +17,18 @@
 import inquirer from 'inquirer';
 
 /**
- * Walk a dotted path on an object. Returns undefined if any step is missing.
+ * Keys that, if traversed, would let callers reach (and mutate) the
+ * prototype chain. We refuse to read or write them via dotted paths.
+ */
+const PROTO_POLLUTION_KEYS = new Set(['__proto__', 'prototype', 'constructor']);
+
+function isOwnSafeProperty(obj, key) {
+  return Object.prototype.hasOwnProperty.call(obj, key) && !PROTO_POLLUTION_KEYS.has(key);
+}
+
+/**
+ * Walk a dotted path on an object. Returns undefined if any step is
+ * missing or hits a forbidden prototype-polluting segment.
  */
 export function getDottedPath(obj, dottedPath) {
   if (!obj || !dottedPath) return undefined;
@@ -25,6 +36,8 @@ export function getDottedPath(obj, dottedPath) {
   let cur = obj;
   for (const p of parts) {
     if (cur === null || cur === undefined) return undefined;
+    if (PROTO_POLLUTION_KEYS.has(p)) return undefined;
+    if (!Object.prototype.hasOwnProperty.call(cur, p)) return undefined;
     cur = cur[p];
   }
   return cur;
@@ -32,17 +45,36 @@ export function getDottedPath(obj, dottedPath) {
 
 /**
  * Set a dotted path on an object (mutates). Creates intermediate objects.
+ * Refuses any path segment in PROTO_POLLUTION_KEYS to prevent prototype
+ * pollution attacks (CodeQL js/prototype-polluting-function).
  */
 export function setDottedPath(obj, dottedPath, value) {
   const parts = dottedPath.split('.');
+  for (const p of parts) {
+    if (PROTO_POLLUTION_KEYS.has(p)) {
+      throw new Error(`Unsafe dotted-path segment: "${p}"`);
+    }
+  }
   let cur = obj;
   for (let i = 0; i < parts.length - 1; i++) {
-    if (cur[parts[i]] === undefined || cur[parts[i]] === null) {
-      cur[parts[i]] = {};
+    const key = parts[i];
+    if (!isOwnSafeProperty(cur, key) || cur[key] === null || cur[key] === undefined) {
+      Object.defineProperty(cur, key, {
+        value: {},
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
     }
-    cur = cur[parts[i]];
+    cur = cur[key];
   }
-  cur[parts[parts.length - 1]] = value;
+  const lastKey = parts[parts.length - 1];
+  Object.defineProperty(cur, lastKey, {
+    value,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
 }
 
 /**

--- a/packages/cli/test/unit/context-builder/review.test.js
+++ b/packages/cli/test/unit/context-builder/review.test.js
@@ -26,6 +26,41 @@ describe('getDottedPath / setDottedPath', () => {
     setDottedPath(obj, 'a.b.c', 'hello');
     assert.deepEqual(obj, { a: { b: { c: 'hello' } } });
   });
+
+  // ── Prototype-pollution guard (CodeQL js/prototype-polluting-function) ──
+
+  it('setDottedPath refuses __proto__ segment (throws)', () => {
+    assert.throws(() => setDottedPath({}, '__proto__.polluted', 1), /Unsafe dotted-path/);
+  });
+
+  it('setDottedPath refuses prototype segment (throws)', () => {
+    assert.throws(() => setDottedPath({}, 'a.prototype.polluted', 1), /Unsafe dotted-path/);
+  });
+
+  it('setDottedPath refuses constructor segment (throws)', () => {
+    assert.throws(() => setDottedPath({}, 'constructor.polluted', 1), /Unsafe dotted-path/);
+  });
+
+  it('setDottedPath does not pollute Object.prototype', () => {
+    const obj = {};
+    try {
+      setDottedPath(obj, '__proto__.evil', 'pwned');
+    } catch {
+      // expected throw
+    }
+    assert.equal({}.evil, undefined, 'Object.prototype.evil should not be set');
+  });
+
+  it('getDottedPath ignores __proto__ segments', () => {
+    assert.equal(getDottedPath({}, '__proto__.toString'), undefined);
+  });
+
+  it('getDottedPath returns undefined for inherited properties (own-only)', () => {
+    class Foo {}
+    Foo.prototype.x = 'inherited';
+    const f = new Foo();
+    assert.equal(getDottedPath(f, 'x'), undefined);
+  });
 });
 
 describe('mergeLlmIntoDraft', () => {


### PR DESCRIPTION
## Summary

Closes the CodeQL Medium warning `js/prototype-polluting-function` flagged on PR #157 (now merged into `main` as commit 8876c66).

`setDottedPath` and `getDottedPath` in `packages/cli/src/context-builder/inference/review.js` walked dotted paths without guarding against `__proto__`, `prototype`, or `constructor` segments. A crafted dotted path could therefore reach and mutate `Object.prototype` via the review pipeline.

## Changes

- `setDottedPath` rejects any segment in `{__proto__, prototype, constructor}` with a thrown `Error("Unsafe dotted-path segment: …")`.
- `setDottedPath` writes intermediate and final keys via `Object.defineProperty` (own-data property only), preventing accidental assignment through inherited setters.
- `getDottedPath` returns `undefined` for forbidden segments and for inherited (non-own) properties.
- `PROTO_POLLUTION_KEYS` set introduced as the single source of truth, used by both setter and getter.

## Test coverage

6 new tests in `test/unit/context-builder/review.test.js`:

- `setDottedPath` throws on `__proto__`, `prototype`, and `constructor` segments
- After a refused write, `Object.prototype` is unchanged
- `getDottedPath` returns `undefined` for `__proto__` segments
- `getDottedPath` returns `undefined` for inherited (prototype-chain) properties

## Test plan

- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] `npm run test:unit` — 505/505 pass (was 499 on `main`; +6 from new security tests)
- [ ] CI integration suite

## Notes

The dotted paths consumed by `setDottedPath` in normal operation are restricted by `VALID_DOTTED_PATHS` (schema.js) when they originate from `inference.confidence` keys or `pending_decisions[].field`, so this is a defense-in-depth fix rather than a closed remote-exploit path. Still worth fixing — `setDottedPath` is now safe to reuse for callers that take less-validated input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)