### PR TITLE
feat(cli): v1.25.0 — validate-context as standalone CLI (v1.1 P1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.25.0] — 2026-05-14
+
+### Added
+
+- **`validate-context` sub-command** — `npx mg-claude-dev-kit validate-context [file]` runs the 16 MUST PASS + 6 inter-field checks against a hand-edited or generated `CONTEXT.md` and exits 0 on pass, 1 on any failure. Defaults to `./CONTEXT.md` when no path is given. `--json` switches output to a parseable JSON shape (`{ valid, errors, data, body }`) on stdout, regardless of pass/fail. Use case: CI gating (`npx mg-claude-dev-kit validate-context && npm run build`), pre-commit hooks on hand-edited CONTEXT.md, reproducible sanity check.
+- `packages/cli/src/commands/validate-context.js` (NEW) — exposes `buildValidationOutput()` (pure formatter) and `validateContext()` (CLI entry).
+- `packages/cli/test/unit/context-builder/validate-context-command.test.js` (NEW) — 12 tests: 5 pure-formatter cases + 7 CLI subprocess integration tests (valid / invalid / missing / `--json` / default path / `--help`).
+
+### Notes
+
+- 539/539 unit tests pass (+12 from the new CLI command).
+- The validator function itself is unchanged from v1.23.0 — this is a CLI surface, not a logic change.
+- Closes v1.1 P1 from the reopened roadmap. P2 (`--from-yaml`) and P3 (tier M/L) remain ahead.
+
+---
+
 ## [1.24.0] — 2026-05-14
 
 ### Changed

--- a/docs/operational-guide.md
+++ b/docs/operational-guide.md
@@ -1439,4 +1439,4 @@ Nine example fixtures are in `packages/cli/test/fixtures/wizard-answers/`. Copy 
 
 ---
 
-_Last updated: 2026-05-12 - v1.23.0_
+_Last updated: 2026-05-14 - v1.25.0_

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mg-claude-dev-kit",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "description": "Scaffold for legible, reviewable AI-assisted development",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/validate-context.js
+++ b/packages/cli/src/commands/validate-context.js
@@ -1,0 +1,68 @@
+/**
+ * `validate-context` sub-command — checks a CONTEXT.md against schema v1.
+ *
+ * Exit codes:
+ *   0 — file passes 16 MUST PASS + 6 inter-field constraints
+ *   1 — any failure (missing file, YAML error, schema violation)
+ *
+ * Modes:
+ *   default — human-readable output (chalk-colored, one error per line)
+ *   --json  — machine-readable JSON ({ valid, errors, data, body })
+ *
+ * Use cases (v1.1):
+ *   - CI gating: `npx mg-claude-dev-kit validate-context && build`
+ *   - Hand-edited CONTEXT.md verified before commit
+ *   - Reproducing the same MUST PASS check that `context` runs after write
+ */
+import path from 'node:path';
+import chalk from 'chalk';
+import { validateContextFile } from '../utils/validate-context.js';
+
+/**
+ * Build a stdout/stderr-bound output object for a validation result.
+ * Pure function — testable without touching process state.
+ *
+ * @param {string} filePath - Absolute path to the validated file
+ * @param {object} result - Output from validateContextFile()
+ * @param {boolean} asJson - true → emit JSON, false → human-readable
+ * @returns {{ text: string, exitCode: 0|1, stream: 'stdout'|'stderr' }}
+ */
+export function buildValidationOutput(filePath, result, asJson) {
+  if (asJson) {
+    return {
+      text: JSON.stringify(result, null, 2),
+      exitCode: result.valid ? 0 : 1,
+      stream: 'stdout',
+    };
+  }
+  const display = path.relative(process.cwd(), filePath) || path.basename(filePath);
+  if (result.valid) {
+    return {
+      text: chalk.green(`✓ ${display} is valid (schema v${result.data.schema_version})`),
+      exitCode: 0,
+      stream: 'stdout',
+    };
+  }
+  const lines = [chalk.red(`✗ ${display} failed validation:`)];
+  for (const err of result.errors) {
+    const dotted = err.path?.length ? err.path.join('.') : '(root)';
+    lines.push(`  [${err.code}] ${dotted}: ${err.message}`);
+  }
+  return { text: lines.join('\n'), exitCode: 1, stream: 'stderr' };
+}
+
+/**
+ * Run the validate-context sub-command.
+ *
+ * @param {string} [filePathArg] - Path to CONTEXT.md, defaults to ./CONTEXT.md
+ * @param {object} [options]
+ * @param {boolean} [options.json] - Emit JSON output instead of human-readable
+ */
+export async function validateContext(filePathArg, options = {}) {
+  const filePath = path.resolve(filePathArg ?? 'CONTEXT.md');
+  const result = validateContextFile(filePath);
+  const out = buildValidationOutput(filePath, result, Boolean(options.json));
+  if (out.stream === 'stderr') console.error(out.text);
+  else console.log(out.text);
+  process.exit(out.exitCode);
+}

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -4,6 +4,7 @@ import { readFileSync } from 'node:fs';
 import { program } from 'commander';
 import { init } from './commands/init.js';
 import { contextCommand } from './commands/context.js';
+import { validateContext } from './commands/validate-context.js';
 import { doctor } from './commands/doctor.js';
 import { upgrade } from './commands/upgrade.js';
 import { addSkill, addRule } from './commands/add.js';
@@ -39,6 +40,12 @@ program
   .option('--skip-llm', 'Skip Phase 2 LLM extraction (offline runs)')
   .option('--all', 'Auto-chain `init` after writing CONTEXT.md')
   .action(contextCommand);
+
+program
+  .command('validate-context [file]')
+  .description('Validate a CONTEXT.md against schema v1 (defaults to ./CONTEXT.md)')
+  .option('--json', 'Emit machine-readable JSON instead of human-readable output')
+  .action(validateContext);
 
 program
   .command('doctor')

--- a/packages/cli/test/unit/context-builder/validate-context-command.test.js
+++ b/packages/cli/test/unit/context-builder/validate-context-command.test.js
@@ -1,0 +1,156 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { buildValidationOutput } from '../../../src/commands/validate-context.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CLI = path.resolve(__dirname, '../../../src/index.js');
+const FIXTURES = path.resolve(__dirname, '../../fixtures/context-builder');
+
+function runCli(args, opts = {}) {
+  try {
+    const stdout = execSync(`node "${CLI}" ${args}`, {
+      stdio: 'pipe',
+      cwd: opts.cwd,
+      encoding: 'utf8',
+    });
+    return { stdout, stderr: '', exitCode: 0 };
+  } catch (e) {
+    return {
+      stdout: e.stdout?.toString() ?? '',
+      stderr: e.stderr?.toString() ?? '',
+      exitCode: e.status ?? 1,
+    };
+  }
+}
+
+// ── Pure builder ─────────────────────────────────────────────────────
+
+describe('buildValidationOutput', () => {
+  it('returns stdout+exit 0 for valid result (human-readable)', () => {
+    const out = buildValidationOutput(
+      '/tmp/CONTEXT.md',
+      { valid: true, errors: [], data: { schema_version: 1 }, body: '' },
+      false,
+    );
+    assert.equal(out.exitCode, 0);
+    assert.equal(out.stream, 'stdout');
+    assert.match(out.text, /is valid \(schema v1\)/);
+  });
+
+  it('returns stderr+exit 1 for invalid result (human-readable)', () => {
+    const out = buildValidationOutput(
+      '/tmp/bad.md',
+      {
+        valid: false,
+        errors: [{ code: 'SCHEMA_VIOLATION', message: 'missing field', path: ['stack'] }],
+        data: null,
+        body: null,
+      },
+      false,
+    );
+    assert.equal(out.exitCode, 1);
+    assert.equal(out.stream, 'stderr');
+    assert.match(out.text, /failed validation/);
+    assert.match(out.text, /\[SCHEMA_VIOLATION\] stack: missing field/);
+  });
+
+  it('returns JSON on stdout when asJson=true (valid)', () => {
+    const r = { valid: true, errors: [], data: { schema_version: 1 }, body: 'body' };
+    const out = buildValidationOutput('/tmp/CONTEXT.md', r, true);
+    assert.equal(out.exitCode, 0);
+    assert.equal(out.stream, 'stdout');
+    const parsed = JSON.parse(out.text);
+    assert.equal(parsed.valid, true);
+  });
+
+  it('returns JSON on stdout with exit 1 when asJson=true (invalid)', () => {
+    const r = {
+      valid: false,
+      errors: [{ code: 'EMPTY_FILE', message: 'empty', path: [] }],
+      data: null,
+      body: null,
+    };
+    const out = buildValidationOutput('/tmp/bad.md', r, true);
+    assert.equal(out.exitCode, 1);
+    assert.equal(out.stream, 'stdout');
+    const parsed = JSON.parse(out.text);
+    assert.equal(parsed.valid, false);
+  });
+
+  it('handles error.path as empty array → (root)', () => {
+    const out = buildValidationOutput(
+      '/tmp/bad.md',
+      {
+        valid: false,
+        errors: [{ code: 'NO_FRONTMATTER', message: 'no fm', path: [] }],
+        data: null,
+        body: null,
+      },
+      false,
+    );
+    assert.match(out.text, /\(root\)/);
+  });
+});
+
+// ── Integration (CLI as subprocess) ──────────────────────────────────
+
+describe('validate-context CLI (subprocess)', () => {
+  it('exits 0 on valid CONTEXT.md', () => {
+    const r = runCli(`validate-context "${path.join(FIXTURES, 'valid-greenfield.md')}"`);
+    assert.equal(r.exitCode, 0);
+    assert.match(r.stdout, /is valid/);
+  });
+
+  it('exits 1 on invalid CONTEXT.md (schema violation)', () => {
+    const r = runCli(`validate-context "${path.join(FIXTURES, 'invalid-missing-required.md')}"`);
+    assert.equal(r.exitCode, 1);
+    assert.match(r.stderr, /failed validation/);
+    assert.match(r.stderr, /\[SCHEMA_VIOLATION\]/);
+  });
+
+  it('exits 1 with FILE_NOT_FOUND when file missing', () => {
+    const r = runCli(`validate-context /tmp/does-not-exist-99999.md`);
+    assert.equal(r.exitCode, 1);
+    assert.match(r.stderr, /FILE_NOT_FOUND/);
+  });
+
+  it('--json flag emits JSON on stdout (valid)', () => {
+    const r = runCli(`validate-context "${path.join(FIXTURES, 'valid-greenfield.md')}" --json`);
+    assert.equal(r.exitCode, 0);
+    const parsed = JSON.parse(r.stdout);
+    assert.equal(parsed.valid, true);
+    assert.equal(parsed.data.schema_version, 1);
+  });
+
+  it('--json flag emits JSON on stdout with exit 1 (invalid)', () => {
+    const r = runCli(`validate-context "${path.join(FIXTURES, 'invalid-empty.md')}" --json`);
+    assert.equal(r.exitCode, 1);
+    const parsed = JSON.parse(r.stdout);
+    assert.equal(parsed.valid, false);
+    assert.equal(parsed.errors[0].code, 'EMPTY_FILE');
+  });
+
+  it('defaults to ./CONTEXT.md when no path given', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk-vc-'));
+    try {
+      fs.copyFileSync(path.join(FIXTURES, 'valid-greenfield.md'), path.join(tmpDir, 'CONTEXT.md'));
+      const r = runCli('validate-context', { cwd: tmpDir });
+      assert.equal(r.exitCode, 0);
+      assert.match(r.stdout, /is valid/);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('--help shows command description', () => {
+    const r = runCli('validate-context --help');
+    assert.equal(r.exitCode, 0);
+    assert.match(r.stdout, /Validate a CONTEXT\.md/);
+    assert.match(r.stdout, /--json/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes v1.1 P1 from the reopened roadmap. Adds `npx mg-claude-dev-kit validate-context [file]` as a standalone CLI sub-command — useful for CI gates, pre-commit hooks, and reproducible sanity checks on hand-edited or generated `CONTEXT.md` files.

**Stacked on PR #159** (`feat/v1.1-dev-flow-wizard-rewire`). Merge #159 first; this PR will rebase on the resulting main commit.

## What's in the box

```bash
npx mg-claude-dev-kit validate-context              # validates ./CONTEXT.md, exits 0/1
npx mg-claude-dev-kit validate-context path/to.md
npx mg-claude-dev-kit validate-context --json       # machine-readable output
```

- **`src/commands/validate-context.js`** (NEW): `buildValidationOutput()` pure formatter + `validateContext()` CLI entry.
- **`src/index.js`**: registers `validate-context [file]` with `--json` option.
- **`test/unit/context-builder/validate-context-command.test.js`** (NEW): 12 tests (5 pure-formatter + 7 CLI subprocess integration).
- **`packages/cli/package.json`** — 1.24.0 → 1.25.0
- **`CHANGELOG.md`** + **`docs/operational-guide.md`** — updated

## Test plan

- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] `npm run test:unit` — 539/539 pass (+12)
- [ ] CI integration suite

## Notes

- Validator logic unchanged from v1.23.0. This is a CLI surface, not a logic change.
- v1.1 P2 (`--from-yaml`) and P3 (tier M/L) remain ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)