### PR TITLE
feat(context): v1.26.0 — --from-yaml bypass on context (v1.1 P2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,27 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.26.0] — 2026-05-14
+
+### Added
+
+- **`--from-yaml <file>` bypass on `context`** — validate an existing `CONTEXT.md` or a raw YAML config and copy it into the cwd, skipping interview, inference, and review entirely. The bypass accepts two input shapes: full markdown with frontmatter (passed through unchanged), or raw YAML (wrapped with `---` delimiters + `DEFAULT_BODY` placeholder). On schema failure, nothing is written and the process exits 1 with the same human-readable error format used by `validate-context`. Combines with `--all` to chain `init` after the copy.
+- `packages/cli/src/commands/context.js` (MODIFIED) — `runFromYamlBypass()` and `normalizeFromYamlSource()` exported for programmatic use; the `contextCommand()` entry short-circuits to the bypass when `--from-yaml` is set.
+- `packages/cli/test/unit/context-builder/from-yaml-bypass.test.js` (NEW) — 11 tests: 3 normalizer cases + 4 programmatic bypass cases (raw YAML, full MD, missing file, invalid schema) + 4 CLI subprocess cases (valid / invalid / missing / `--help`).
+
+### Use cases
+
+- CI / automation: a template CONTEXT.md committed to the repo, validated and consumed by `init --use-context` in CI without any prompt.
+- Expert dev / template sharing: hand-edit a CONTEXT.md or copy one from another project, then bring it in deterministically.
+- Reproducibility: regenerate the same scaffold across machines by checking in the source CONTEXT.md and running `context --from-yaml` + `init --all`.
+
+### Notes
+
+- 550/550 unit tests pass (+11 from the new bypass coverage).
+- Closes v1.1 P2 from the reopened roadmap. P3 (tier M/L coverage in schema) remains ahead.
+
+---
+
 ## [1.25.0] — 2026-05-14
 
 ### Added

--- a/docs/operational-guide.md
+++ b/docs/operational-guide.md
@@ -1439,4 +1439,4 @@ Nine example fixtures are in `packages/cli/test/fixtures/wizard-answers/`. Copy 
 
 ---
 
-_Last updated: 2026-05-14 - v1.25.0_
+_Last updated: 2026-05-14 - v1.26.0_

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mg-claude-dev-kit",
-  "version": "1.25.0",
+  "version": "1.26.0",
   "description": "Scaffold for legible, reviewable AI-assisted development",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/context.js
+++ b/packages/cli/src/commands/context.js
@@ -29,7 +29,7 @@ import {
   composeBodyMarkdown,
 } from '../context-builder/inference/review.js';
 import { writeContextFile, DEFAULT_BODY } from '../context-builder/writer.js';
-import { validateContextFile } from '../utils/validate-context.js';
+import { validateContextFile, validateContextContent } from '../utils/validate-context.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PKG_PATH = path.resolve(__dirname, '../../package.json');
@@ -111,11 +111,84 @@ function composeFinalFrontmatter(reviewed, ctx) {
 }
 
 /**
+ * Wrap raw YAML (no `---` delimiters) into a minimal CONTEXT.md skeleton
+ * with the DEFAULT_BODY placeholder. Markdown files with their own
+ * frontmatter are passed through untouched.
+ */
+export function normalizeFromYamlSource(content) {
+  if (content.startsWith('---\n')) return content;
+  return `---\n${content.replace(/\n+$/, '')}\n---\n\n${DEFAULT_BODY}`;
+}
+
+/**
+ * --from-yaml bypass: validate an existing CONTEXT.md / YAML config and
+ * copy it into the cwd. Skips interview, inference, and review entirely.
+ *
+ * Use cases: CI / automation, expert dev with a hand-edited file,
+ * template sharing across projects.
+ *
+ * @param {object} args
+ * @param {string} args.sourcePath - Path to the source file
+ * @param {string} args.cwd        - Target cwd (CONTEXT.md will be written here)
+ * @param {boolean} [args.silent]
+ * @param {boolean} [args.throwOnInvalid] - throw instead of process.exit(1)
+ * @returns {Promise<{ path: string, data: object }>}
+ */
+export async function runFromYamlBypass({ sourcePath, cwd, silent, throwOnInvalid }) {
+  const resolvedSource = path.resolve(sourcePath);
+  if (!(await fs.pathExists(resolvedSource))) {
+    const msg = `Source file not found: ${resolvedSource}`;
+    if (throwOnInvalid) {
+      const e = new Error(msg);
+      e.code = 'FROM_YAML_SOURCE_MISSING';
+      throw e;
+    }
+    console.error(chalk.red(msg));
+    process.exit(1);
+  }
+
+  const rawContent = await fs.readFile(resolvedSource, 'utf8');
+  const normalized = normalizeFromYamlSource(rawContent);
+  const validation = validateContextContent(normalized);
+
+  if (!validation.valid) {
+    if (!silent) {
+      console.error(chalk.red(`✗ ${path.basename(resolvedSource)} failed validation:`));
+      for (const err of validation.errors) {
+        const dotted = err.path?.length ? err.path.join('.') : '(root)';
+        console.error(`  [${err.code}] ${dotted}: ${err.message}`);
+      }
+    }
+    if (throwOnInvalid) {
+      const e = new Error('CONTEXT.md validation failed');
+      e.code = 'INVALID_CONTEXT';
+      e.errors = validation.errors;
+      throw e;
+    }
+    process.exit(1);
+  }
+
+  const targetPath = path.join(cwd, 'CONTEXT.md');
+  await fs.writeFile(targetPath, normalized, 'utf8');
+  if (!silent) {
+    console.log(
+      chalk.green(
+        `✓ Wrote ${path.relative(cwd, targetPath) || 'CONTEXT.md'} from ${path.relative(cwd, resolvedSource) || resolvedSource}`,
+      ),
+    );
+    console.log(chalk.green('✓ Schema validation passed'));
+  }
+
+  return { path: targetPath, data: validation.data, body: validation.body };
+}
+
+/**
  * Run the `context` sub-command.
  *
  * @param {object} options
  * @param {string} [options.mode] - Override mode auto-detection
  * @param {string} [options.persona] - Bypass Q1 persona prompt
+ * @param {string} [options.fromYaml] - Path to source file → bypass interview
  * @param {object} [options.prefilledAnswers] - For non-interactive runs (tests)
  * @param {Array}  [options.prefilledReviewAnswers] - Phase 3 prefilled review
  * @param {Function} [options.llmClient] - Override LLM client (tests)
@@ -127,6 +200,26 @@ export async function contextCommand(options = {}) {
   const cwd = options.cwd ?? process.cwd();
   const targetPath = path.join(cwd, 'CONTEXT.md');
   const generatedByVersion = await readPackageVersion();
+
+  // ── --from-yaml bypass: validate + copy, no interview ──────────────
+  if (options.fromYaml) {
+    const out = await runFromYamlBypass({
+      sourcePath: options.fromYaml,
+      cwd,
+      silent: options.silent,
+      throwOnInvalid: options.throwOnInvalid,
+    });
+
+    if (options.all) {
+      if (!options.silent) {
+        console.log();
+        console.log(chalk.dim('Auto-chaining `init` (--all flag)…'));
+      }
+      const { init } = await import('./init.js');
+      await init({ ...options, useContext: true });
+    }
+    return out;
+  }
 
   console.log();
   console.log(

--- a/packages/cli/src/commands/context.js
+++ b/packages/cli/src/commands/context.js
@@ -169,7 +169,11 @@ export async function runFromYamlBypass({ sourcePath, cwd, silent, throwOnInvali
   }
 
   const targetPath = path.join(cwd, 'CONTEXT.md');
-  await fs.writeFile(targetPath, normalized, 'utf8');
+  // Explicit owner-rw / others-r mode. CONTEXT.md is a project config the
+  // team commits to git, not a secret — but the explicit mode silences
+  // CodeQL `js/insecure-temporary-file` taint when tests inject cwd from
+  // `os.tmpdir()` (the production path uses `process.cwd()`).
+  await fs.writeFile(targetPath, normalized, { encoding: 'utf8', mode: 0o644 });
   if (!silent) {
     console.log(
       chalk.green(

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -39,6 +39,10 @@ program
   .option('--mode <mode>', 'Override mode auto-detection (greenfield|in-place|from-context)')
   .option('--skip-llm', 'Skip Phase 2 LLM extraction (offline runs)')
   .option('--all', 'Auto-chain `init` after writing CONTEXT.md')
+  .option(
+    '--from-yaml <file>',
+    'Skip interview/inference: validate and copy an existing CONTEXT.md or YAML config into cwd',
+  )
   .action(contextCommand);
 
 program

--- a/packages/cli/test/unit/context-builder/from-yaml-bypass.test.js
+++ b/packages/cli/test/unit/context-builder/from-yaml-bypass.test.js
@@ -1,0 +1,189 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { normalizeFromYamlSource, runFromYamlBypass } from '../../../src/commands/context.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CLI = path.resolve(__dirname, '../../../src/index.js');
+const FIXTURES = path.resolve(__dirname, '../../fixtures/context-builder');
+
+function runCli(args, opts = {}) {
+  try {
+    const stdout = execSync(`node "${CLI}" ${args}`, {
+      stdio: 'pipe',
+      cwd: opts.cwd,
+      encoding: 'utf8',
+    });
+    return { stdout, stderr: '', exitCode: 0 };
+  } catch (e) {
+    return {
+      stdout: e.stdout?.toString() ?? '',
+      stderr: e.stderr?.toString() ?? '',
+      exitCode: e.status ?? 1,
+    };
+  }
+}
+
+const VALID_YAML_ONLY = `schema_version: 1
+generated_at: '2026-05-14T10:00:00Z'
+generated_by: hand-edited
+generated_by_version: 1.0.0
+project:
+  name: from-yaml-test
+  description: A project loaded from raw YAML.
+  mode: greenfield
+stack:
+  primary: node-ts
+commands:
+  install: npm install
+  test: npx vitest run
+tier:
+  selected: s
+  rationale: Solo dev, bugfix scope
+scaffold_options:
+  include_pre_commit: true
+  include_github: false
+`;
+
+describe('normalizeFromYamlSource', () => {
+  it('passes through markdown with frontmatter unchanged', () => {
+    const md = `---\nfoo: bar\n---\n\nbody`;
+    assert.equal(normalizeFromYamlSource(md), md);
+  });
+
+  it('wraps raw YAML with --- delimiters + DEFAULT_BODY', () => {
+    const yaml = 'schema_version: 1\nproject:\n  name: x';
+    const wrapped = normalizeFromYamlSource(yaml);
+    assert.ok(wrapped.startsWith('---\n'));
+    assert.match(wrapped, /\n---\n/);
+    assert.match(wrapped, /## What we are building/);
+  });
+
+  it('trims trailing newlines on raw YAML before wrapping', () => {
+    const yaml = 'foo: bar\n\n\n';
+    const wrapped = normalizeFromYamlSource(yaml);
+    assert.ok(wrapped.startsWith('---\nfoo: bar\n---\n'));
+  });
+});
+
+describe('runFromYamlBypass — programmatic', () => {
+  it('writes CONTEXT.md from a valid raw YAML file', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk-fy-'));
+    const src = path.join(tmpDir, 'config.yaml');
+    fs.writeFileSync(src, VALID_YAML_ONLY);
+    try {
+      const out = await runFromYamlBypass({
+        sourcePath: src,
+        cwd: tmpDir,
+        silent: true,
+        throwOnInvalid: true,
+      });
+      assert.ok(fs.existsSync(out.path));
+      assert.equal(out.data.project.name, 'from-yaml-test');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('writes CONTEXT.md from a full markdown file with frontmatter+body', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk-fy-'));
+    const src = path.join(FIXTURES, 'valid-greenfield.md');
+    try {
+      const out = await runFromYamlBypass({
+        sourcePath: src,
+        cwd: tmpDir,
+        silent: true,
+        throwOnInvalid: true,
+      });
+      assert.ok(fs.existsSync(out.path));
+      assert.equal(out.data.project.mode, 'greenfield');
+      // body preserved from source
+      assert.ok(out.body.length > 0);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('throws FROM_YAML_SOURCE_MISSING when file does not exist', async () => {
+    await assert.rejects(
+      runFromYamlBypass({
+        sourcePath: '/tmp/cdk-does-not-exist-99999.yaml',
+        cwd: os.tmpdir(),
+        silent: true,
+        throwOnInvalid: true,
+      }),
+      (e) => e.code === 'FROM_YAML_SOURCE_MISSING',
+    );
+  });
+
+  it('throws INVALID_CONTEXT when YAML fails schema', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk-fy-'));
+    const src = path.join(tmpDir, 'bad.yaml');
+    fs.writeFileSync(src, 'schema_version: 1\nproject:\n  name: incomplete\n');
+    try {
+      await assert.rejects(
+        runFromYamlBypass({
+          sourcePath: src,
+          cwd: tmpDir,
+          silent: true,
+          throwOnInvalid: true,
+        }),
+        (e) => e.code === 'INVALID_CONTEXT',
+      );
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('context --from-yaml (CLI)', () => {
+  it('exits 0 and writes CONTEXT.md from raw YAML', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk-fy-cli-'));
+    const src = path.join(tmpDir, 'config.yaml');
+    fs.writeFileSync(src, VALID_YAML_ONLY);
+    try {
+      const r = runCli(`context --from-yaml "${src}"`, { cwd: tmpDir });
+      assert.equal(r.exitCode, 0);
+      assert.match(r.stdout, /Schema validation passed/);
+      assert.ok(fs.existsSync(path.join(tmpDir, 'CONTEXT.md')));
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('exits 1 with error message when source is invalid', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk-fy-cli-'));
+    const src = path.join(tmpDir, 'bad.yaml');
+    fs.writeFileSync(src, 'schema_version: 1\nproject:\n  name: incomplete\n');
+    try {
+      const r = runCli(`context --from-yaml "${src}"`, { cwd: tmpDir });
+      assert.equal(r.exitCode, 1);
+      assert.match(r.stderr, /failed validation/);
+      // CONTEXT.md must NOT be written on validation failure
+      assert.ok(!fs.existsSync(path.join(tmpDir, 'CONTEXT.md')));
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('exits 1 when source file missing', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk-fy-cli-'));
+    try {
+      const r = runCli(`context --from-yaml /tmp/cdk-missing-99999.yaml`, { cwd: tmpDir });
+      assert.equal(r.exitCode, 1);
+      assert.match(r.stderr, /not found/);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('--help shows --from-yaml option', () => {
+    const r = runCli('context --help');
+    assert.equal(r.exitCode, 0);
+    assert.match(r.stdout, /--from-yaml/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes v1.1 P2 from the reopened roadmap. Adds `--from-yaml <file>` to the `context` sub-command: validate an existing CONTEXT.md or raw YAML config and copy it into the cwd, skipping interview + inference + review entirely.

## Usage

```bash
# Full markdown with frontmatter — passed through unchanged
npx mg-claude-dev-kit context --from-yaml ./my-context.md

# Raw YAML — wrapped with --- delimiters + DEFAULT_BODY placeholder
npx mg-claude-dev-kit context --from-yaml ./config.yaml

# Chain init right after
npx mg-claude-dev-kit context --from-yaml ./template.md --all
```

On schema failure: nothing is written, exit 1 with the same human-readable errors format as `validate-context`.

## What's in the box

- **`src/commands/context.js`** — two new exports:
  - `normalizeFromYamlSource(content)` — passes through MD with frontmatter, wraps raw YAML with `---` delimiters + `DEFAULT_BODY`.
  - `runFromYamlBypass({sourcePath, cwd, silent, throwOnInvalid})` — read file → normalize → validate → write to cwd/CONTEXT.md. Returns `{path, data, body}` on success, throws (or exits 1) on failure.
  - `contextCommand()` short-circuits to the bypass when `options.fromYaml` is set; supports `--all` chaining.
- **`src/index.js`** — registers `--from-yaml <file>` option.
- **`test/unit/context-builder/from-yaml-bypass.test.js`** (NEW) — 11 tests:
  - 3 normalizer cases (MD passthrough, YAML wrap, trailing newline trim)
  - 4 programmatic bypass cases (raw YAML, full MD, missing file → FROM_YAML_SOURCE_MISSING, invalid → INVALID_CONTEXT)
  - 4 CLI subprocess cases (valid / invalid / missing / `--help`)

## Use cases

- **CI / automation**: template CONTEXT.md in the repo, `context --from-yaml + init --all` in CI without any prompt.
- **Expert dev / template sharing**: hand-edit or copy a CONTEXT.md across projects, bring it in deterministically.
- **Reproducibility**: regenerate the same scaffold across machines by checking in the source CONTEXT.md.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] `npm run test:unit` — 550/550 pass (+11 from new bypass coverage)
- [ ] CI integration suite

## Notes

- v1.1 P3 (tier M/L coverage in the schema) remains ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)