### PR TITLE
feat(context-builder): v1.27.0 — tier M/L coverage in schema (v1.1 P3, final)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,34 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.27.0] — 2026-05-14
+
+### Added
+
+- **Tier M and L coverage in the schema.** v1.0-1.2.6 capped `tier.selected` to `'0' | 's'` and raised `TIER_NOT_SUPPORTED_V1` on M/L. v1.27.0 widens the enum to `'0' | 's' | 'm' | 'l'` and reintroduces the feature flags the legacy wizard already collected:
+  - `commands.build`, `commands.e2e` (optional, nullable)
+  - `features` block (optional, tier M/L only): `has_api`, `has_database`, `has_frontend`, `has_design_system`, `design_system_name`, `has_prd`
+  - `audit_model` (string, optional)
+- **Inter-field constraints** added to the Zod schema:
+  - **C7** — `features.has_design_system=true` requires `features.design_system_name`
+  - **C8** — `features` block forbidden on tier 0/S (no consumers in the scaffold)
+- PM flow + dev flow ask the M/L extras only when `tier in {m, l}` (and `hasDesignSystem`/`auditModel` only when `hasFrontend=true`).
+- `init.dispatchFromContext` forwards the new fields to the legacy `init-*` sub-flows so a CONTEXT.md with tier M/L scaffolds deterministically without re-prompting.
+- 4 new fixtures: `valid-tier-m.md`, `valid-tier-l.md`, `invalid-c7-design-system-missing-name.md`, `invalid-c8-features-on-tier-s.md`.
+- 2 new tests in `validate-context.test.js` for C7 and C8; 4 new flow tests (PM tier M, PM tier L, dev tier M, dev tier L).
+
+### Changed
+
+- `HARD_STOP_TIERS` export in both `pm-flow.js` and `dev-flow.js` is now an empty array — kept for source-compat with any plugin that imports it. Legacy callers stop seeing the `TIER_NOT_SUPPORTED_V1` throw.
+
+### Notes
+
+- 554/554 unit tests pass (+4 from the new tier M/L coverage). Lint + format clean.
+- Backward-compatible by construction: every CONTEXT.md produced by v1.23-v1.26 (tier 0/S, no `features` block) still validates without change.
+- Closes v1.1 P3, the last item from the reopened roadmap. v1.1 is now feature-complete.
+
+---
+
 ## [1.26.0] — 2026-05-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -33,18 +33,21 @@ The wizard detects your project state and guides you through setup. Three paths 
 
 After init, open Claude Code and start working. The scaffold is active immediately.
 
-### Context Builder (v1.24.0)
+### Context Builder (v1.27.0)
 
-Want the scaffold to come out the same way every time, and to leave a written record of what you asked for? Run `context` before `init`:
+Run `context` before `init` if you want the scaffold to come out the same way every time, with a written record of what you asked for:
 
 ```bash
-npx mg-claude-dev-kit context        # produces CONTEXT.md
-npx mg-claude-dev-kit init           # reads CONTEXT.md, scaffolds with no further prompts
-# or one-shot:
-npx mg-claude-dev-kit context --all  # runs context then init
+npx mg-claude-dev-kit context                       # produces CONTEXT.md
+npx mg-claude-dev-kit init                          # reads CONTEXT.md, scaffolds with no further prompts
+npx mg-claude-dev-kit context --all                 # one-shot: context then init
+npx mg-claude-dev-kit context --from-yaml file.md   # bypass interview, validate + copy
+npx mg-claude-dev-kit validate-context              # CI gate: exit 0/1 on schema check
 ```
 
-`CONTEXT.md` is a schema-validated project context file. Greenfield runs a PM-friendly interview; existing repos go through three-phase inference (algorithmic detection, LLM extraction, hybrid PM review). The first question routes you to a PM or developer flow. The developer flow (v1.24.0+) reuses the technical questions from the legacy `init` wizards (projectName, stack, commands, scaffold options) and auto-derives `tier.rationale` from team size + work scope, so devs are not asked to write PM rationale prose. Tier M and L are not covered by the v1 schema yet; the legacy wizard still handles them.
+`CONTEXT.md` is a schema-validated project context file. Greenfield runs a PM-friendly interview. Existing repos go through three-phase inference: algorithmic detection, LLM extraction, hybrid PM review. The first question routes you to a PM or developer flow. The developer flow reuses the technical questions from the legacy `init` wizards (projectName, stack, commands, scaffold options) and auto-derives `tier.rationale` from team size + work scope, so devs are not asked to write PM rationale prose.
+
+As of v1.27.0, the schema covers all four pipeline tiers: tier 0 (Discovery) and tier S (Fast Lane) for solo or bugfix work, tier M (Standard) for feature-block work with feature flags (`has_api`, `has_database`, `has_frontend`, `has_design_system`, `has_prd`), and tier L (Full) for complex domain projects.
 
 ---
 

--- a/docs/operational-guide.md
+++ b/docs/operational-guide.md
@@ -1439,4 +1439,4 @@ Nine example fixtures are in `packages/cli/test/fixtures/wizard-answers/`. Copy 
 
 ---
 
-_Last updated: 2026-05-14 - v1.26.0_
+_Last updated: 2026-05-14 - v1.27.0_

--- a/docs/operational-guide.md
+++ b/docs/operational-guide.md
@@ -140,16 +140,23 @@ Three init paths are available. All support `--dry-run` (preview without writing
 
 #### Optional: `context` sub-command (v1.23.0+)
 
-If you want the scaffold to be reproducible and reviewable, run `context` before `init`:
+Run `context` before `init` to make the scaffold reproducible and reviewable:
 
 ```bash
-npx mg-claude-dev-kit context        # produces CONTEXT.md
-npx mg-claude-dev-kit init           # reads CONTEXT.md, scaffolds with no further prompts
+npx mg-claude-dev-kit context                       # produces CONTEXT.md
+npx mg-claude-dev-kit init                          # reads CONTEXT.md, scaffolds with no further prompts
+npx mg-claude-dev-kit context --all                 # one-shot: context then init
+npx mg-claude-dev-kit context --from-yaml file.md   # bypass: validate + copy an existing CONTEXT.md (v1.26.0+)
+npx mg-claude-dev-kit validate-context              # CI gate: exits 0 on pass, 1 on fail (v1.25.0+)
 ```
 
-Or chain them: `context --all`. When `CONTEXT.md` is present in the cwd, `init` reads it and scaffolds without asking anything else. Pass `--ignore-context` to fall back to the prompt-based flow.
+When `CONTEXT.md` is present in the cwd, `init` reads it and scaffolds without asking anything else. Pass `--ignore-context` to fall back to the prompt-based flow.
 
-`CONTEXT.md` is a schema-validated project context file: Zod schema v1, 16 MUST PASS structural checks, plus six inter-field constraints. Greenfield gets a PM-friendly interview; existing repos go through three-phase inference — algorithmic detection wrapping `detect-stack`, optional LLM extraction, hybrid PM review. The first question routes you to a PM or developer flow. The developer flow is a stub in v1.23.0; a research-backed design replaces it later. Tier M and L are not covered by the v1 schema and still go through the legacy wizard.
+`CONTEXT.md` is a schema-validated project context file: Zod schema, 16 MUST PASS structural checks, plus eight inter-field constraints (tier-0 forces scaffold options off, mode invariants, dotted-path keys, `design_system_name` required when `has_design_system=true`, features block forbidden on tier 0/S, and so on).
+
+Greenfield gets a PM-friendly interview. Existing repos go through three-phase inference: algorithmic detection wrapping `detect-stack`, optional LLM extraction, hybrid PM review. The first question routes you to a PM or developer flow. As of v1.24.0, the developer flow reuses the legacy `init` wizard's technical questions and auto-derives `tier.rationale` from `teamSize` + `workScope`, so devs skip the prose prompts.
+
+As of v1.27.0, the schema covers all four pipeline tiers. Tier M and L pick up the feature-flag block: `has_api`, `has_database`, `has_frontend`, `has_design_system` (plus `design_system_name`), `has_prd`, plus `audit_model` and the optional `commands.build` / `commands.e2e` fields.
 
 ---
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mg-claude-dev-kit",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "description": "Scaffold for legible, reviewable AI-assisted development",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/init.js
+++ b/packages/cli/src/commands/init.js
@@ -97,6 +97,23 @@ async function dispatchFromContext(data, options) {
     includePreCommit: data.scaffold_options.include_pre_commit,
     includeGithub: data.scaffold_options.include_github,
   };
+  // v1.27.0+ tier M/L: forward the optional feature flags and extra
+  // commands so the legacy init-* sub-flows can scaffold M/L without
+  // re-prompting.
+  if (data.commands.e2e !== undefined) answersFromContext.e2eCommand = data.commands.e2e ?? '';
+  if (data.commands.build !== undefined)
+    answersFromContext.buildCommand = data.commands.build ?? '';
+  if (data.features?.has_api !== undefined) answersFromContext.hasApi = data.features.has_api;
+  if (data.features?.has_database !== undefined)
+    answersFromContext.hasDatabase = data.features.has_database;
+  if (data.features?.has_frontend !== undefined)
+    answersFromContext.hasFrontend = data.features.has_frontend;
+  if (data.features?.has_design_system !== undefined)
+    answersFromContext.hasDesignSystem = data.features.has_design_system;
+  if (data.features?.design_system_name)
+    answersFromContext.designSystemName = data.features.design_system_name;
+  if (data.features?.has_prd !== undefined) answersFromContext.hasPrd = data.features.has_prd;
+  if (data.audit_model) answersFromContext.auditModel = data.audit_model;
   const passthrough = { ...options, answers: JSON.stringify(answersFromContext) };
   switch (data.project.mode) {
     case 'greenfield':

--- a/packages/cli/src/context-builder/interview/dev-flow.js
+++ b/packages/cli/src/context-builder/interview/dev-flow.js
@@ -96,8 +96,8 @@ export function assembleDevQuestions({ mode, projectNameDefault, algoDefaults } 
       default: 's',
       choices: [
         { name: 'S — Fast Lane (bugfixes, ≤3 files)', value: 's' },
-        { name: 'M — Standard (v1.1+ — use legacy `init` for now)', value: 'm' },
-        { name: 'L — Full (v1.1+ — use legacy `init` for now)', value: 'l' },
+        { name: 'M — Standard (feature blocks, 1-2 weeks)', value: 'm' },
+        { name: 'L — Full (complex domain, team)', value: 'l' },
       ],
     },
     {
@@ -122,6 +122,66 @@ export function assembleDevQuestions({ mode, projectNameDefault, algoDefaults } 
       when: (a) => a.familiarity !== '0',
       default: (a) => cmdDefaults.dev ?? STACK_DEFAULTS[a.techStack]?.dev ?? '',
     },
+    // ── Tier M / L extras (v1.27.0+) — same questions as PM flow ─
+    {
+      type: 'input',
+      name: 'e2eCommand',
+      message: 'E2E / integration test command? (leave blank to skip)',
+      when: (a) => a.tier === 'm' || a.tier === 'l',
+      default: '',
+    },
+    {
+      type: 'confirm',
+      name: 'hasApi',
+      message: 'Does this project expose an API?',
+      when: (a) => a.tier === 'm' || a.tier === 'l',
+      default: false,
+    },
+    {
+      type: 'confirm',
+      name: 'hasDatabase',
+      message: 'Does this project use a database?',
+      when: (a) => a.tier === 'm' || a.tier === 'l',
+      default: true,
+    },
+    {
+      type: 'confirm',
+      name: 'hasFrontend',
+      message: 'Does this project have a UI?',
+      when: (a) => a.tier === 'm' || a.tier === 'l',
+      default: true,
+    },
+    {
+      type: 'confirm',
+      name: 'hasDesignSystem',
+      message: 'Component library / design system?',
+      when: (a) => (a.tier === 'm' || a.tier === 'l') && a.hasFrontend === true,
+      default: true,
+    },
+    {
+      type: 'input',
+      name: 'designSystemName',
+      message: 'Design system name:',
+      when: (a) =>
+        (a.tier === 'm' || a.tier === 'l') && a.hasFrontend === true && a.hasDesignSystem === true,
+      default: 'component library',
+      validate: (v) => v.trim().length > 0 || 'Required',
+    },
+    {
+      type: 'confirm',
+      name: 'hasPrd',
+      message: 'Track a PRD per feature block?',
+      when: (a) => a.tier === 'm' || a.tier === 'l',
+      default: false,
+    },
+    {
+      type: 'input',
+      name: 'auditModel',
+      message: 'Preferred Claude model for deep-analysis skills?',
+      when: (a) => (a.tier === 'm' || a.tier === 'l') && a.hasFrontend === true,
+      default: 'claude-sonnet-4-6',
+    },
+    // ──────────────────────────────────────────────────────────────
     {
       type: 'confirm',
       name: 'includePreCommit',
@@ -213,6 +273,25 @@ export function buildDevFrontmatter({ answers, mode, generatedByVersion, algoOut
     if (algoOutput?.pending_decisions?.length > 0) {
       fm.pending_decisions = algoOutput.pending_decisions;
     }
+  }
+
+  // v1.27.0+ tier M/L feature flags + audit_model + extra commands.
+  if (answers.e2eCommand !== undefined) {
+    fm.commands.e2e = answers.e2eCommand.trim() === '' ? null : answers.e2eCommand.trim();
+  }
+  if (answers.buildCommand !== undefined) {
+    fm.commands.build = answers.buildCommand.trim() === '' ? null : answers.buildCommand.trim();
+  }
+  if (tierSelected === 'm' || tierSelected === 'l') {
+    const features = {};
+    if (answers.hasApi !== undefined) features.has_api = answers.hasApi;
+    if (answers.hasDatabase !== undefined) features.has_database = answers.hasDatabase;
+    if (answers.hasFrontend !== undefined) features.has_frontend = answers.hasFrontend;
+    if (answers.hasDesignSystem !== undefined) features.has_design_system = answers.hasDesignSystem;
+    if (answers.designSystemName) features.design_system_name = answers.designSystemName;
+    if (answers.hasPrd !== undefined) features.has_prd = answers.hasPrd;
+    if (Object.keys(features).length > 0) fm.features = features;
+    if (answers.auditModel) fm.audit_model = answers.auditModel;
   }
 
   return fm;

--- a/packages/cli/src/context-builder/interview/pm-flow.js
+++ b/packages/cli/src/context-builder/interview/pm-flow.js
@@ -18,7 +18,10 @@
 import inquirer from 'inquirer';
 import { DEFAULT_BODY } from '../writer.js';
 
-export const HARD_STOP_TIERS = ['m', 'l'];
+// HARD_STOP_TIERS was used in v1.0-v1.2 to block tier M/L. Kept as an
+// empty array in v1.27.0+ so legacy callers (tests, plugins) still find
+// the export but the hard-stop no longer triggers.
+export const HARD_STOP_TIERS = Object.freeze([]);
 
 /**
  * Default command suggestions per stack. Used as inquirer defaults so
@@ -134,6 +137,13 @@ export function buildFrontmatterFromAnswers(answers, ctx) {
   } else if (stackDefaults.dev) {
     commands.dev = stackDefaults.dev;
   }
+  // v1.27.0+ tier M/L extras
+  if (answers.e2eCommand !== undefined) {
+    commands.e2e = answers.e2eCommand.trim() === '' ? null : answers.e2eCommand.trim();
+  }
+  if (answers.buildCommand !== undefined) {
+    commands.build = answers.buildCommand.trim() === '' ? null : answers.buildCommand.trim();
+  }
 
   const frontmatter = {
     schema_version: 1,
@@ -156,6 +166,20 @@ export function buildFrontmatterFromAnswers(answers, ctx) {
       include_github: isTier0 ? false : (answers.includeGithub ?? false),
     },
   };
+
+  // v1.27.0+ tier M/L feature flags + audit_model.
+  // Only emit features block when tier is M or L (schema C8).
+  if (tierSelected === 'm' || tierSelected === 'l') {
+    const features = {};
+    if (answers.hasApi !== undefined) features.has_api = answers.hasApi;
+    if (answers.hasDatabase !== undefined) features.has_database = answers.hasDatabase;
+    if (answers.hasFrontend !== undefined) features.has_frontend = answers.hasFrontend;
+    if (answers.hasDesignSystem !== undefined) features.has_design_system = answers.hasDesignSystem;
+    if (answers.designSystemName) features.design_system_name = answers.designSystemName;
+    if (answers.hasPrd !== undefined) features.has_prd = answers.hasPrd;
+    if (Object.keys(features).length > 0) frontmatter.features = features;
+    if (answers.auditModel) frontmatter.audit_model = answers.auditModel;
+  }
 
   return frontmatter;
 }
@@ -261,8 +285,8 @@ export function assembleQuestions({ projectNameDefault } = {}) {
       default: (a) => suggestTier(a),
       choices: [
         { name: 'S — Fast Lane (bugfixes, ≤3 files)', value: 's' },
-        { name: 'M — Standard (v1.1 — use legacy wizard for now)', value: 'm' },
-        { name: 'L — Full (v1.1 — use legacy wizard for now)', value: 'l' },
+        { name: 'M — Standard (feature blocks, 1-2 weeks)', value: 'm' },
+        { name: 'L — Full (complex domain, team)', value: 'l' },
       ],
     },
     {
@@ -315,6 +339,66 @@ export function assembleQuestions({ projectNameDefault } = {}) {
       when: (a) => a.familiarity !== '0',
       default: (a) => STACK_DEFAULTS[a.techStack]?.dev ?? '',
     },
+    // ── Tier M / L extras (v1.27.0+) ──────────────────────────────
+    {
+      type: 'input',
+      name: 'e2eCommand',
+      message: 'E2E / integration test command? (leave blank to skip)',
+      when: (a) => a.tier === 'm' || a.tier === 'l',
+      default: '',
+    },
+    {
+      type: 'confirm',
+      name: 'hasApi',
+      message: 'Does this project expose an API (REST / GraphQL / RPC)?',
+      when: (a) => a.tier === 'm' || a.tier === 'l',
+      default: false,
+    },
+    {
+      type: 'confirm',
+      name: 'hasDatabase',
+      message: 'Does this project use a database?',
+      when: (a) => a.tier === 'm' || a.tier === 'l',
+      default: true,
+    },
+    {
+      type: 'confirm',
+      name: 'hasFrontend',
+      message: 'Does this project have a UI?',
+      when: (a) => a.tier === 'm' || a.tier === 'l',
+      default: true,
+    },
+    {
+      type: 'confirm',
+      name: 'hasDesignSystem',
+      message: 'Do you use a component library or design system (shadcn, MUI, Tailwind, …)?',
+      when: (a) => (a.tier === 'm' || a.tier === 'l') && a.hasFrontend === true,
+      default: true,
+    },
+    {
+      type: 'input',
+      name: 'designSystemName',
+      message: 'Design system name (e.g. shadcn/ui, MUI, Tailwind):',
+      when: (a) =>
+        (a.tier === 'm' || a.tier === 'l') && a.hasFrontend === true && a.hasDesignSystem === true,
+      default: 'component library',
+      validate: (v) => v.trim().length > 0 || 'Required when hasDesignSystem=true',
+    },
+    {
+      type: 'confirm',
+      name: 'hasPrd',
+      message: 'Track a PRD per feature block?',
+      when: (a) => a.tier === 'm' || a.tier === 'l',
+      default: false,
+    },
+    {
+      type: 'input',
+      name: 'auditModel',
+      message: 'Preferred Claude model for deep-analysis skills (visual-audit, ux-audit)?',
+      when: (a) => (a.tier === 'm' || a.tier === 'l') && a.hasFrontend === true,
+      default: 'claude-sonnet-4-6',
+    },
+    // ──────────────────────────────────────────────────────────────
     {
       type: 'confirm',
       name: 'includePreCommit',

--- a/packages/cli/src/context-builder/interview/shared/stack-defaults.js
+++ b/packages/cli/src/context-builder/interview/shared/stack-defaults.js
@@ -88,4 +88,7 @@ export const TECH_STACK_CHOICES = [
   { name: 'Other / mixed', value: 'other' },
 ];
 
-export const HARD_STOP_TIERS = Object.freeze(['m', 'l']);
+// As of v1.27.0 tier M/L are supported in the schema. The constant is
+// retained as an empty array so callers that import it still find the
+// export but the hard-stop no longer triggers.
+export const HARD_STOP_TIERS = Object.freeze([]);

--- a/packages/cli/src/context-builder/schema.js
+++ b/packages/cli/src/context-builder/schema.js
@@ -29,7 +29,10 @@ export const STACK_PRIMARY = z.enum([
 
 export const PROJECT_MODE = z.enum(['greenfield', 'in-place', 'from-context']);
 
-export const TIER_V1 = z.enum(['0', 's']);
+// TIER_V1 keeps the legacy export name for source compatibility with
+// v1.0-v1.2 callers. As of v1.27.0 it accepts the full 0/S/M/L matrix.
+export const TIER_V1 = z.enum(['0', 's', 'm', 'l']);
+export const TIER_VALUES = TIER_V1;
 
 export const CONFIDENCE = z.enum(['high', 'medium', 'low', 'declared']);
 
@@ -44,11 +47,20 @@ export const VALID_DOTTED_PATHS = [
   'commands.test',
   'commands.type_check',
   'commands.dev',
+  'commands.build',
+  'commands.e2e',
   'tier.selected',
   'tier.rationale',
   'scaffold_options.include_pre_commit',
   'scaffold_options.include_github',
   'sources.primary_repo',
+  'features.has_api',
+  'features.has_database',
+  'features.has_frontend',
+  'features.has_design_system',
+  'features.design_system_name',
+  'features.has_prd',
+  'audit_model',
 ];
 
 // ── Sub-schemas ──────────────────────────────────────────────────────
@@ -73,6 +85,22 @@ const commandsSchema = z
     test: z.string().min(1),
     type_check: z.string().nullable().optional(),
     dev: z.string().nullable().optional(),
+    // v1.27.0+ (tier M/L): optional build / e2e commands.
+    build: z.string().nullable().optional(),
+    e2e: z.string().nullable().optional(),
+  })
+  .strict();
+
+// v1.27.0+ tier M/L feature flags. All optional — tier 0/S projects skip
+// the block entirely.
+const featuresSchema = z
+  .object({
+    has_api: z.boolean().optional(),
+    has_database: z.boolean().optional(),
+    has_frontend: z.boolean().optional(),
+    has_design_system: z.boolean().optional(),
+    design_system_name: z.string().min(1).optional(),
+    has_prd: z.boolean().optional(),
   })
   .strict();
 
@@ -130,10 +158,14 @@ const baseContextSchema = z
     sources: sourcesSchema.optional(),
     inference: inferenceSchema.optional(),
     pending_decisions: z.array(pendingDecisionSchema).optional(),
+
+    // v1.27.0+ tier M/L extensions (all optional, additive vs v1.0-1.2).
+    features: featuresSchema.optional(),
+    audit_model: z.string().min(1).optional(),
   })
   .strict();
 
-// ── Full schema with 6 inter-field constraints ───────────────────────
+// ── Full schema with inter-field constraints ─────────────────────────
 
 export const CONTEXT_SCHEMA_V1 = baseContextSchema.superRefine((data, ctx) => {
   // C1 — Tier 0 requires include_pre_commit=false AND include_github=false
@@ -215,6 +247,25 @@ export const CONTEXT_SCHEMA_V1 = baseContextSchema.superRefine((data, ctx) => {
           message: `Invalid dotted-path "${p.field}". Allowed paths: ${VALID_DOTTED_PATHS.join(', ')}`,
         });
       }
+    });
+  }
+
+  // C7 (v1.27.0+) — features.has_design_system=true requires design_system_name
+  if (data.features?.has_design_system === true && !data.features?.design_system_name) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['features', 'design_system_name'],
+      message: 'features.has_design_system=true requires features.design_system_name',
+    });
+  }
+
+  // C8 (v1.27.0+) — features block belongs to tier M/L. Tier 0/S projects
+  // must not carry feature flags (they have no consumers in the scaffold).
+  if (data.features && (data.tier.selected === '0' || data.tier.selected === 's')) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['features'],
+      message: `features block requires tier M or L; tier ${data.tier.selected} has no consumers for feature flags`,
     });
   }
 });

--- a/packages/cli/test/fixtures/context-builder/invalid-c7-design-system-missing-name.md
+++ b/packages/cli/test/fixtures/context-builder/invalid-c7-design-system-missing-name.md
@@ -1,0 +1,24 @@
+---
+schema_version: 1
+generated_at: '2026-05-14T18:00:00Z'
+generated_by: context-builder
+generated_by_version: 1.27.0
+project:
+  name: bad-c7
+  description: design system flag without name
+  mode: greenfield
+stack:
+  primary: node-ts
+commands:
+  install: npm install
+  test: npx vitest run
+tier:
+  selected: m
+  rationale: Small team, feature blocks
+scaffold_options:
+  include_pre_commit: true
+  include_github: false
+features:
+  has_frontend: true
+  has_design_system: true
+---

--- a/packages/cli/test/fixtures/context-builder/invalid-c8-features-on-tier-s.md
+++ b/packages/cli/test/fixtures/context-builder/invalid-c8-features-on-tier-s.md
@@ -1,0 +1,23 @@
+---
+schema_version: 1
+generated_at: '2026-05-14T18:00:00Z'
+generated_by: context-builder
+generated_by_version: 1.27.0
+project:
+  name: bad-c8
+  description: features block on tier S — not allowed
+  mode: greenfield
+stack:
+  primary: node-ts
+commands:
+  install: npm install
+  test: npx vitest run
+tier:
+  selected: s
+  rationale: Solo dev
+scaffold_options:
+  include_pre_commit: true
+  include_github: false
+features:
+  has_api: true
+---

--- a/packages/cli/test/fixtures/context-builder/valid-tier-l.md
+++ b/packages/cli/test/fixtures/context-builder/valid-tier-l.md
@@ -1,0 +1,26 @@
+---
+schema_version: 1
+generated_at: '2026-05-14T18:00:00Z'
+generated_by: context-builder
+generated_by_version: 1.27.0
+project:
+  name: tier-l-app
+  description: A large-scope project with long-running complexity.
+  mode: greenfield
+stack:
+  primary: python
+commands:
+  install: pip install -r requirements.txt
+  test: pytest
+tier:
+  selected: l
+  rationale: Larger team, complex domain changes
+scaffold_options:
+  include_pre_commit: true
+  include_github: true
+features:
+  has_api: true
+  has_database: true
+  has_frontend: false
+  has_prd: true
+---

--- a/packages/cli/test/fixtures/context-builder/valid-tier-m.md
+++ b/packages/cli/test/fixtures/context-builder/valid-tier-m.md
@@ -1,0 +1,32 @@
+---
+schema_version: 1
+generated_at: '2026-05-14T18:00:00Z'
+generated_by: context-builder
+generated_by_version: 1.27.0
+project:
+  name: tier-m-app
+  description: A medium-complexity app spanning feature blocks.
+  mode: greenfield
+stack:
+  primary: node-ts
+commands:
+  install: npm install
+  test: npx vitest run
+  type_check: npx tsc --noEmit
+  dev: npm run dev
+  e2e: npx playwright test
+tier:
+  selected: m
+  rationale: Small team, feature-block work in 1-2 week chunks
+scaffold_options:
+  include_pre_commit: true
+  include_github: true
+features:
+  has_api: true
+  has_database: true
+  has_frontend: true
+  has_design_system: true
+  design_system_name: shadcn/ui
+  has_prd: false
+audit_model: claude-sonnet-4-6
+---

--- a/packages/cli/test/unit/context-builder/dev-flow.test.js
+++ b/packages/cli/test/unit/context-builder/dev-flow.test.js
@@ -206,24 +206,34 @@ describe('runDevInterview — greenfield', () => {
     assert.equal(frontmatter.tier.rationale, 'Brand new to Claude Code, exploring');
   });
 
-  it('throws TIER_NOT_SUPPORTED_V1 on tier=m', async () => {
-    await assert.rejects(
-      runDevInterview({
-        mode: 'greenfield',
-        prefilledAnswers: { ...baseGreenfield, tier: 'm' },
-      }),
-      (err) => err.code === 'TIER_NOT_SUPPORTED_V1',
-    );
+  it('accepts tier=m in v1.27.0+ with feature flags', async () => {
+    const { frontmatter, body } = await runDevInterview({
+      mode: 'greenfield',
+      generatedByVersion: '1.27.0',
+      prefilledAnswers: {
+        ...baseGreenfield,
+        tier: 'm',
+        hasApi: true,
+        hasDatabase: false,
+        hasFrontend: true,
+        hasDesignSystem: true,
+        designSystemName: 'Tailwind',
+        hasPrd: false,
+      },
+    });
+    const result = validateContextContent(serializeContext(frontmatter, body));
+    assert.equal(result.valid, true, `errors: ${JSON.stringify(result.errors)}`);
+    assert.equal(frontmatter.tier.selected, 'm');
+    assert.equal(frontmatter.features.design_system_name, 'Tailwind');
   });
 
-  it('throws TIER_NOT_SUPPORTED_V1 on tier=l', async () => {
-    await assert.rejects(
-      runDevInterview({
-        mode: 'greenfield',
-        prefilledAnswers: { ...baseGreenfield, tier: 'l' },
-      }),
-      (err) => err.code === 'TIER_NOT_SUPPORTED_V1',
-    );
+  it('accepts tier=l in v1.27.0+', async () => {
+    const { frontmatter } = await runDevInterview({
+      mode: 'greenfield',
+      generatedByVersion: '1.27.0',
+      prefilledAnswers: { ...baseGreenfield, tier: 'l', hasDatabase: true, hasFrontend: false },
+    });
+    assert.equal(frontmatter.tier.selected, 'l');
   });
 });
 
@@ -297,7 +307,7 @@ describe('runDevInterview — existing mode', () => {
 });
 
 describe('HARD_STOP_TIERS', () => {
-  it('lists m and l as blocked', () => {
-    assert.deepEqual([...HARD_STOP_TIERS].sort(), ['l', 'm']);
+  it('is empty in v1.27.0+ (tier M/L are supported)', () => {
+    assert.deepEqual([...HARD_STOP_TIERS], []);
   });
 });

--- a/packages/cli/test/unit/context-builder/pm-flow.test.js
+++ b/packages/cli/test/unit/context-builder/pm-flow.test.js
@@ -196,29 +196,49 @@ describe('runPmInterview (prefilledAnswers)', () => {
     assert.equal(frontmatter.tier.selected, '0');
   });
 
-  it('throws TIER_NOT_SUPPORTED_V1 when tier=m', async () => {
-    await assert.rejects(
-      runPmInterview({
-        mode: 'greenfield',
-        prefilledAnswers: { ...baseExperienced, tier: 'm' },
-      }),
-      (err) => err.code === 'TIER_NOT_SUPPORTED_V1',
-    );
+  it('accepts tier=m in v1.27.0+ (no hard stop)', async () => {
+    const { frontmatter, body } = await runPmInterview({
+      mode: 'greenfield',
+      prefilledAnswers: {
+        ...baseExperienced,
+        tier: 'm',
+        hasApi: true,
+        hasDatabase: true,
+        hasFrontend: true,
+        hasDesignSystem: true,
+        designSystemName: 'shadcn/ui',
+        hasPrd: false,
+        auditModel: 'claude-sonnet-4-6',
+        e2eCommand: 'npx playwright test',
+      },
+    });
+    const result = validateContextContent(serializeContext(frontmatter, body));
+    assert.equal(result.valid, true, `errors: ${JSON.stringify(result.errors)}`);
+    assert.equal(frontmatter.tier.selected, 'm');
+    assert.equal(frontmatter.features.has_api, true);
+    assert.equal(frontmatter.features.design_system_name, 'shadcn/ui');
+    assert.equal(frontmatter.audit_model, 'claude-sonnet-4-6');
   });
 
-  it('throws TIER_NOT_SUPPORTED_V1 when tier=l', async () => {
-    await assert.rejects(
-      runPmInterview({
-        mode: 'greenfield',
-        prefilledAnswers: { ...baseExperienced, tier: 'l' },
-      }),
-      (err) => err.code === 'TIER_NOT_SUPPORTED_V1',
-    );
+  it('accepts tier=l in v1.27.0+', async () => {
+    const { frontmatter } = await runPmInterview({
+      mode: 'greenfield',
+      prefilledAnswers: {
+        ...baseExperienced,
+        tier: 'l',
+        hasApi: false,
+        hasDatabase: true,
+        hasFrontend: false,
+        hasPrd: true,
+      },
+    });
+    assert.equal(frontmatter.tier.selected, 'l');
+    assert.equal(frontmatter.features.has_prd, true);
   });
 });
 
 describe('HARD_STOP_TIERS export', () => {
-  it('lists m and l as blocked tiers', () => {
-    assert.deepEqual([...HARD_STOP_TIERS].sort(), ['l', 'm']);
+  it('is empty in v1.27.0+ (tier M/L are supported)', () => {
+    assert.deepEqual([...HARD_STOP_TIERS], []);
   });
 });

--- a/packages/cli/test/unit/context-builder/validate-context.test.js
+++ b/packages/cli/test/unit/context-builder/validate-context.test.js
@@ -42,6 +42,8 @@ describe('validateContextFile — valid fixtures', () => {
     'valid-in-place.md',
     'valid-from-context.md',
     'valid-tier-0.md',
+    'valid-tier-m.md',
+    'valid-tier-l.md',
   ]) {
     it(`${file} passes`, () => {
       const result = validateContextFile(fx(file));
@@ -156,6 +158,22 @@ describe('validateContextFile — inter-field constraints', () => {
       hasC6,
       `expected a pending_decisions dotted-path error, got: ${JSON.stringify(result.errors)}`,
     );
+  });
+
+  it('C7 (v1.27.0+): has_design_system=true without design_system_name fails', () => {
+    const result = validateContextFile(fx('invalid-c7-design-system-missing-name.md'));
+    assert.equal(result.valid, false);
+    const hasC7 = result.errors.some(
+      (e) => /design_system_name/.test(e.message) && e.path.includes('design_system_name'),
+    );
+    assert.ok(hasC7, `expected design_system_name error, got: ${JSON.stringify(result.errors)}`);
+  });
+
+  it('C8 (v1.27.0+): features block on tier S fails', () => {
+    const result = validateContextFile(fx('invalid-c8-features-on-tier-s.md'));
+    assert.equal(result.valid, false);
+    const hasC8 = result.errors.some((e) => /features block requires tier M or L/.test(e.message));
+    assert.ok(hasC8, `expected C8 error, got: ${JSON.stringify(result.errors)}`);
   });
 });
 


### PR DESCRIPTION
## Summary

Closes v1.1 P3, the final item of the reopened roadmap. v1.1 is now feature-complete.

Schema widened from `tier: '0'|'s'` to `'0'|'s'|'m'|'l'` plus the optional feature flags the legacy wizard already collects.

## Usage

```bash
npx mg-claude-dev-kit context
# Pipeline tier: M — Standard (feature blocks, 1-2 weeks)
# Does this project expose an API? Y
# Does this project use a database? Y
# ...
```

## What's in the box

- **Schema** (`packages/cli/src/context-builder/schema.js`):
  - `TIER_V1` enum widened to `'0' | 's' | 'm' | 'l'`
  - New optional fields: `commands.build`, `commands.e2e`, `features` (has_api / has_database / has_frontend / has_design_system / design_system_name / has_prd), `audit_model`
  - **C7** — `features.has_design_system=true` requires `features.design_system_name`
  - **C8** — `features` block forbidden on tier 0/S

- **PM flow + dev flow**:
  - Tier M/L extras prompted only when `tier in {m, l}`
  - `hasDesignSystem` and `auditModel` conditional on `hasFrontend=true`
  - `buildFrontmatter*` builders emit `features` + `audit_model` when applicable
  - `HARD_STOP_TIERS` reduced to `[]` (kept for source-compat with any importers)

- **init.dispatchFromContext** — forwards the new fields to the legacy `init-*` sub-flows so a CONTEXT.md with M/L scaffolds deterministically without re-prompting.

- **Fixtures** (4 new): `valid-tier-m.md`, `valid-tier-l.md`, `invalid-c7-design-system-missing-name.md`, `invalid-c8-features-on-tier-s.md`.

- **Tests** (+4): C7 + C8 in `validate-context.test.js`; positive M/L coverage in `pm-flow.test.js` + `dev-flow.test.js`.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] `npm run test:unit` — 554/554 pass (+4 from new tier M/L coverage)
- [ ] CI integration suite

## Backward compatibility

Every CONTEXT.md produced by v1.23.0 through v1.26.0 still validates without change. The new fields are additive and optional.

## Roadmap status

- ✅ **P0** v1.24.0 — Dev flow ricablato sul wizard tecnico legacy
- ✅ **P1** v1.25.0 — `validate-context` CLI standalone
- ✅ **P2** v1.26.0 — `--from-yaml` bypass
- ✅ **P3** v1.27.0 — Tier M/L coverage in schema (this PR)

**v1.1 feature-complete.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)