### PR TITLE
docs: move Context Builder from roadmap to shipped section

### DIFF
--- a/docs/product-brief.md
+++ b/docs/product-brief.md
@@ -28,8 +28,11 @@ Lack of shared process - the issue is neither Claude nor the human, it is the ab
 - **Permissions**: a value area still unexplored - to be developed, especially for Tier L.
 - **Familiarity assumption**: the tiers themselves guide the expected familiarity level. Tier 0 = zero assumptions. Tier L = experienced user.
 
+## Shipped
+
+- **Context Builder (v1.23.0 → v1.27.0)** - now part of CDK as the `context` sub-command. Guided interview between Claude and the user (PM, Dev, Tech Lead, Founder, Other) that produces a schema-validated `CONTEXT.md` which `init` consumes to scaffold deterministically. Greenfield uses a PM-friendly interview or a developer-flow that reuses the legacy wizard's technical questions. Existing repos go through three-phase inference (algorithmic detection + LLM extraction + hybrid PM review). All four pipeline tiers (0/S/M/L) are covered by the schema. Companion CLI: `validate-context` for CI gating, `--from-yaml` bypass for templates and automation.
+
 ## Roadmap
 
-- **Context Builder** - a separate tool that PRECEDES claude-dev-kit. A guided interview between Claude and the user (PM, Dev, Designer) to define stack, team, goals, and constraints. Output: structured context that claude-dev-kit consumes to scaffold the right tier automatically. This is the product that makes CDK accessible to the non-developer Product Trio.
 - Specialised templates for common stacks (extensions, not core)
 - Permissions governance expansion (settings.json allow/deny tier-appropriate)

--- a/docs/product-brief.md
+++ b/docs/product-brief.md
@@ -30,7 +30,7 @@ Lack of shared process - the issue is neither Claude nor the human, it is the ab
 
 ## Shipped
 
-- **Context Builder (v1.23.0 → v1.27.0)** - now part of CDK as the `context` sub-command. Guided interview between Claude and the user (PM, Dev, Tech Lead, Founder, Other) that produces a schema-validated `CONTEXT.md` which `init` consumes to scaffold deterministically. Greenfield uses a PM-friendly interview or a developer-flow that reuses the legacy wizard's technical questions. Existing repos go through three-phase inference (algorithmic detection + LLM extraction + hybrid PM review). All four pipeline tiers (0/S/M/L) are covered by the schema. Companion CLI: `validate-context` for CI gating, `--from-yaml` bypass for templates and automation.
+- **Context Builder (v1.23.0 → v1.27.0)**: now part of CDK as the `context` sub-command. A guided interview between Claude and the user (PM, Dev, Tech Lead, Founder, Other) produces a schema-validated `CONTEXT.md`, which `init` then consumes to scaffold deterministically. Greenfield runs either a PM-friendly interview or a developer flow that reuses the legacy wizard's technical questions. Existing repos go through three-phase inference: algorithmic detection, LLM extraction, hybrid PM review. The schema covers all four pipeline tiers (0/S/M/L). Companion CLI: `validate-context` for CI gating, `--from-yaml` to bypass the interview for templates and automation.
 
 ## Roadmap
 


### PR DESCRIPTION
## Summary

Post-release docs sync. The Context Builder bullet in `docs/product-brief.md` was still listed under `## Roadmap` after v1.27.0 shipped — moves it into a new `## Shipped` section and updates the description to match the as-shipped state.

## Changes

- New `## Shipped` section in `docs/product-brief.md`.
- Context Builder entry rewritten to reflect v1.23.0 → v1.27.0 reality: `context` sub-command, PM + developer flows, three-phase inference for existing repos, all four pipeline tiers in the schema, `validate-context` and `--from-yaml` companion CLIs.
- `## Roadmap` section keeps the two remaining to-do items (Specialised templates for common stacks, Permissions governance expansion).

## Notes

- Docs-only sync. No code, no behavior change.
- Prose passed through `/humanize` per CDK rule R2.
- v1.27.0 (`mg-claude-dev-kit@1.27.0`) is live on npm and tagged on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)