### PR TITLE
docs: arch-audit v1.27.0 staleness sync (README + operational-guide)

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Read-only tools exposed:
 | `cdk_package_meta`      | CDK package name, version, CLI path, cwd                                                                                                                         |
 | `cdk_pr_review`         | reads existing `/pr-review` skill comments on a GitHub PR (verdict, severity counts). Read-only — to generate a fresh review, invoke the `/pr-review` CDK skill. |
 
-The server resolves the project root from `$CDK_PROJECT_ROOT` if set, otherwise from `process.cwd()`. v1.17.0 launched read-only by design; that posture is unchanged through v1.22.0.
+The server resolves the project root from `$CDK_PROJECT_ROOT` if set, otherwise from `process.cwd()`. v1.17.0 launched read-only by design; that posture is unchanged through v1.27.0.
 
 ---
 
@@ -218,7 +218,7 @@ The server resolves the project root from `$CDK_PROJECT_ROOT` if set, otherwise 
 
 ```bash
 node packages/cli/test/integration/run.js    # 1129 integration checks
-node --test packages/cli/test/unit/*.test.js   # 373 unit tests
+node --test packages/cli/test/unit/*.test.js   # 554 unit tests
 ```
 
 Covers: file structure per tier, Stop hook presence, pipeline gate counts, placeholder resolution, skill pruning, security variant selection, native stack adaptation, rubric scoring, cross-stack content invariants (10 stacks — the named stacks excluding the `other` fallback), golden-file assertions (Swift, Node-TS, Python), full CLI execution via `--answers` fixtures.
@@ -248,7 +248,7 @@ Covers: file structure per tier, Stop hook presence, pipeline gate counts, place
 
 See [GitHub Milestones](https://github.com/marcoguillermaz/claude-dev-kit/milestones) for the 12-month plan.
 
-**Current**: v1.22.0 ships the **`/skill-dev` v2 hotspot enhancement** — the differentiating piece of the closed `/debt-triage` sub-track (Issue #97 sub-track 2), folded into `/skill-dev` per the 2026-04-28 cross-LLM verdict. New Step 3b "Hotspot priority (churn × debt)" intersects per-file debt count with `git log --since="6.months.ago" --numstat` churn data, ranks files into a 4-quadrant matrix (Q1 hot mess / Q2 stable rot / Q3 flaky frontier / Q4 cold corner), and renders a top-10 hotspot table in the audit report. The hotspot section does NOT change which findings get added to the backlog (Step 4 still applies the same severity rules) — it re-orders backlog work by leverage. Stack-agnostic; gracefully skips on non-Git projects or projects with insufficient signal. Integration: 1129 checks (+15 from `scenarioSkillDevHotspot`). The v1.21.0 PreToolUse runtime enforcement remains in place; v1.20.0 MCP-aware audit skills (`/security-audit` + `/dependency-audit`) remain pinned to `mcp-nvd` and `package-registry-mcp`.
+**Current**: v1.27.0 closes the Context Builder v1.1 cycle. The `context` sub-command produces a schema-validated `CONTEXT.md` that `init` reads to scaffold the project without prompting (`context --all` runs both steps in one shot; `context --from-yaml file.md` skips the interview for templates and CI; `validate-context` runs as a standalone CI gate). The schema covers all four pipeline tiers (0/S/M/L), including a feature-flag block (`has_api`, `has_database`, `has_frontend`, `has_design_system` + `design_system_name`, `has_prd`) and an `audit_model` field on M/L. The dev-flow persona reuses the legacy wizard's technical questions and auto-derives `tier.rationale` from `teamSize + workScope`. Carried forward from earlier releases: v1.22.0's `/skill-dev` v2 hotspot step (Step 3b "Hotspot priority (churn × debt)"), v1.21.0's PreToolUse runtime enforcement, and v1.20.0's MCP-aware audit skills (`/security-audit` + `/dependency-audit`) pinned to `mcp-nvd` and `package-registry-mcp`.
 
 **Next**: `/arch-audit` MCP-aware once the upstream Anthropic spec MCP server lands. `/privacy-audit` re-eval (Issue #97 sub-track 3) when AST tracing matures or demand signal materializes. Q2 #3 VitePress docs site (ICE 432) stays on hold.
 

--- a/docs/operational-guide.md
+++ b/docs/operational-guide.md
@@ -1,6 +1,6 @@
 # claude-dev-kit - Operational Guide
 
-**Version**: 1.10.4
+**Version**: 1.27.0
 **Audience**: Builder PMs, tech leads, and senior developers using Claude Code - from first exploration to structured, reviewable delivery
 **Format**: Reference + step-by-step. Read section 1 and your target tier section first, then use the rest as a lookup.
 
@@ -40,7 +40,7 @@ Claude Code is a powerful CLI assistant that can read, write, and reason about y
 - A development pipeline Claude follows strictly - requirements reviewed before code is written, tests verified before declaring done
 - Pre-wired hooks that enforce the pipeline mechanically, not just as instructions
 - A tiered system matching process overhead to task complexity: a two-line bugfix does not go through the same process as a multi-week feature
-- 20 audit skills - executable multi-step programs with model routing (haiku for mechanical checks, sonnet for analysis)
+- 24 audit skills - executable multi-step programs with model routing (haiku for mechanical checks, sonnet for analysis)
 - Audit trails, commit attribution, secret scanning, and CODEOWNERS gates for full visibility over AI-generated changes
 - A discovery mechanism that teaches Claude about your existing codebase in a single structured session
 
@@ -433,7 +433,7 @@ npx mg-claude-dev-kit add skill commit
 
 This copies the SKILL.md file into `.claude/skills/<name>/` and appends it to the `## Active Skills` section in CLAUDE.md (if that section exists). No other files are modified.
 
-Available skills (16): `arch-audit`, `security-audit`, `perf-audit`, `skill-dev`, `skill-review`, `simplify`, `commit`, `api-design`, `skill-db`, `migration-audit`, `visual-audit`, `ux-audit`, `responsive-audit`, `ui-audit`, `accessibility-audit`, `test-audit`.
+Available skills (24): `arch-audit`, `security-audit`, `perf-audit`, `skill-dev`, `skill-review`, `simplify`, `commit`, `api-design`, `skill-db`, `migration-audit`, `visual-audit`, `ux-audit`, `responsive-audit`, `ui-audit`, `accessibility-audit`, `test-audit`, `dependency-audit`, `dependency-scan`, `pr-review`, `doc-audit`, `api-contract-audit`, `compliance-audit`, `infra-audit`, `context-review`.
 
 Options:
 
@@ -732,7 +732,7 @@ Defined in the `CLAUDE.md` template for Tier M/L. Governs how Claude handles non
 
 ## 10. Audit skills
 
-Twenty audit skills are scaffolded across the tiers. Run them as slash commands in Claude Code at any time - no pipeline phase required. Skills are **conditionally installed** based on wizard answers at init time.
+Twenty-four audit skills are scaffolded across the tiers (tier S installs 6, tier M installs 23, tier L installs all 24 with `context-review`). Run them as slash commands in Claude Code at any time - no pipeline phase required. Skills are **conditionally installed** based on wizard answers at init time.
 
 All skill applicability rules are managed by a central skill registry (`packages/cli/src/scaffold/skill-registry.js`). Each skill declares which tiers and project conditions it requires.
 
@@ -1314,7 +1314,7 @@ Wire up by adding to `.mcp.json` (project-scoped) or `~/.claude/.mcp.json` (user
 }
 ```
 
-The server resolves the project root from `$CDK_PROJECT_ROOT` if set, otherwise from the calling process's `cwd`. v1.17.0 launched read-only by design; that posture is unchanged through v1.22.0. A read-write surface remains a future-minor decision contingent on adoption signal.
+The server resolves the project root from `$CDK_PROJECT_ROOT` if set, otherwise from the calling process's `cwd`. v1.17.0 launched read-only by design; that posture is unchanged through v1.27.0. A read-write surface remains a future-minor decision contingent on adoption signal.
 
 ### Adding team-specific rules
 


### PR DESCRIPTION
## Summary

Apply 4 of 5 recommendations from the 2026-05-14 `/arch-audit` run. Item #5 (README "24 audit skills" header) was verified correct: tier-L installs 24 skills (the extra is `context-review`).

## Changes

### README.md

- `# 373 unit tests` → `# 554 unit tests` (line 221) — matches `CHANGELOG.md` v1.27.0.
- `posture is unchanged through v1.22.0` → `v1.27.0` (line 191) — MCP server posture statement.
- The `**Current**: v1.22.0 ships ...` paragraph (line 251) rewritten for v1.27.0. Leads with Context Builder v1.1 closure (`context`, `--all`, `--from-yaml`, `validate-context`, schema across all four tiers + feature flags + `audit_model`), then carries forward the v1.22 / v1.21 / v1.20 notes. Prose passed through `/humanize` per CDK rule R2.

### docs/operational-guide.md

- `**Version**: 1.10.4` → `1.27.0` (line 3) — 17 minor versions stale.
- `20 audit skills` → `24 audit skills` (line 43).
- `Available skills (16): ...` → `Available skills (24): ...` with the 8 missing skills appended (`dependency-audit`, `dependency-scan`, `pr-review`, `doc-audit`, `api-contract-audit`, `compliance-audit`, `infra-audit`, `context-review`).
- `Twenty audit skills are scaffolded` → `Twenty-four audit skills are scaffolded ... (tier S 6 / tier M 23 / tier L 24 with context-review)`.
- `posture is unchanged through v1.22.0` → `v1.27.0` (line 1317).

## Test plan

- [x] `prettier --write` clean
- [x] No code paths touched; 554/554 unit tests remain green (out of scope for this PR)
- [x] CI run

## Notes

- Docs-only sync. No code or behavior change.
- Verified tier inventory: tier-S 6 skills, tier-M 23 skills, tier-L 24 skills. Header "24 audit skills" in README stays as-is (correct).
- `auto-fixed` items from the audit (humanize/SKILL.md frontmatter + arch-audit/SKILL.md URL + skill counts inside arch-audit/SKILL.md) were applied directly by the audit and are present on `main` already.

🤖 Generated with [Claude Code](https://claude.com/claude-code)