### PR TITLE
test: template coverage infrastructure for shipped templates (closes #138)

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,11 +217,13 @@ The server resolves the project root from `$CDK_PROJECT_ROOT` if set, otherwise 
 ## Testing
 
 ```bash
-node packages/cli/test/integration/run.js    # 1129 integration checks
+node packages/cli/test/integration/run.js    # 1132 integration checks
 node --test packages/cli/test/unit/*.test.js   # 554 unit tests
 ```
 
 Covers: file structure per tier, Stop hook presence, pipeline gate counts, placeholder resolution, skill pruning, security variant selection, native stack adaptation, rubric scoring, cross-stack content invariants (10 stacks — the named stacks excluding the `other` fallback), golden-file assertions (Swift, Node-TS, Python), full CLI execution via `--answers` fixtures.
+
+A separate **template-coverage** layer (under `packages/cli/test/template-coverage/`) hard-fails on cross-tier semantic drift, missing gate clauses, and undocumented placeholders in the shipped templates. The three scripts (`cross-tier-lint.mjs`, `gate-enum.mjs`, `placeholder-check.mjs`) run standalone for local work and automatically inside `run.js`. Strategy and concept registry: [docs/architecture/test-coverage-strategy.md](docs/architecture/test-coverage-strategy.md).
 
 ---
 

--- a/docs/architecture/test-coverage-strategy.md
+++ b/docs/architecture/test-coverage-strategy.md
@@ -1,0 +1,171 @@
+# Test coverage strategy — shipped templates
+
+**Date**: 2026-05-14
+**Status**: Active (v1)
+**Roadmap**: Q3 #12 / issue #138
+**Owner**: maintainer
+
+This document defines what CDK's test infrastructure does and does NOT cover for the templates shipped by the scaffolder (`packages/cli/templates/**`), the gaps surfaced by issue #138, and the chosen approach for each gap.
+
+---
+
+## 1. Surface under test
+
+CDK ships three kinds of artifacts that reach the user's project after `npx claude-dev-kit init`:
+
+1. **Pipeline rules** — `tier-{s,m,l}/.claude/rules/pipeline.md`. Normative prose that Claude Code reads each session to drive phase progression, gate behavior, and stop semantics.
+2. **CLAUDE.md templates** — per-tier project context with wizard-filled placeholders.
+3. **Skill bodies** — `skills/*/SKILL.md` files; covered separately by the skill-review pipeline (see `docs/reviews/2026-04-29-pipeline-meta/`).
+
+This strategy covers items 1 and 2. Skill bodies are out of scope here.
+
+---
+
+## 2. Current coverage (baseline)
+
+The integration suite (`packages/cli/test/integration/run.js`, 45 scenarios) covers:
+
+- File presence after scaffold across all tier/mode combinations
+- Frontmatter format conformance to SPEC_SNAPSHOT
+- Cross-file scaffold consistency via `doctor` checks (skill ↔ CLAUDE.md ↔ settings.json)
+- Wizard placeholder resolution in the scaffolded output (`assertNoUnfilledWizardPlaceholders`)
+- Stop hook presence and resolved hook content
+- Skill pruning and selective inclusion
+
+Unit tests (`packages/cli/test/unit/*.test.js`) cover the scaffolder, generators, frontmatter parser, doctor logic, and detect-stack.
+
+---
+
+## 3. Gaps identified (issue #138)
+
+### Gap 1 — Semantic accuracy of normative prose
+
+No test verifies that the prose inside `rules/pipeline.md` (and equivalently `CLAUDE.md` template prose) is accurate, internally consistent, and agnostically applied. Replacing "use `data-*` selectors" with "use stable platform-appropriate selectors" is a semantic change with zero CI signal.
+
+### Gap 2 — Cross-tier consistency on shared concepts
+
+`tier-s`, `tier-m`, `tier-l` share concepts (STOP gate semantics, execution keywords, placeholder behavior, security checklist, Phase 5d Track A/B/C structure, severity handling, commit sequence). No test verifies these concepts stay aligned across tiers. Drift accumulates silently. Example surfaced during this work: `*(blocks touching >5 files or introducing new patterns)*` (tier-m) vs `*(blocks touching >5 files or new patterns)*` (tier-l).
+
+### Gap 3 — Logic of gate clauses
+
+Gate clauses (`*(if block adds/modifies API routes)*`, `*(if [E2E_COMMAND] configured)*`, `*(if project is a web or native UI application)*`) are the main mechanism for conditional stack-awareness. No test verifies they are visible, enumerable, or coherent across tiers.
+
+### Gap 4 — Post-scaffold behavior
+
+Tests verify what the wizard produces, not how Claude Code interprets the scaffolded `pipeline.md` in a real session. A prose change that makes "verify the build" ambiguous can cause Claude to skip the check in some projects with no CI signal.
+
+---
+
+## 4. Approaches mapped to gaps
+
+The issue proposes seven approaches A–G tiered by ease. Mapping:
+
+| Gap | Approaches addressing it | Selected for v1 |
+|---|---|---|
+| G1 — prose semantics | F (LLM-based eval) | Defer (rationale below) |
+| G2 — cross-tier drift | A (lint), D (snapshot per stack) | A now, D roadmap |
+| G3 — gate clause logic | B (enumeration), E (completeness) | B now, E roadmap |
+| G4 — post-scaffold behavior | G (behavioral fixtures) | Defer (rationale below) |
+| Adjacent — placeholder coverage | C (placeholder enumeration test) | C now |
+
+### Decision per approach
+
+**A — Cross-tier semantic lint (build now).** Declarative registry of concepts (`cross-tier-concepts.json`) mapped to tiers with explicit `matchType` per concept (`exact-text`, `section-presence`, `structural`). Lint walks each tier's pipeline.md and asserts every applicable concept matches its canonical form. Hard fail on drift. Registry is the load-bearing artifact: adding a new phase means updating the registry; the lint becomes mechanical.
+
+**B — Gate clause enumeration (build now).** Script enumerates every gate clause in each tier and prints a per-tier inventory. Cross-tier delta report. **Scope is deliberately enumeration + report, not logic validation** — that's E.
+
+**C — Placeholder enumeration (build now).** For every `[PLACEHOLDER]` referenced in `pipeline.md` template bodies, verify it is (1) in the wizard-managed list, (2) documented in `CLAUDE.md` template, or (3) explicitly listed as user-fill (role names, state names). Complement to issue #134 placeholder meta-rule. Distinct from `assertNoUnfilledWizardPlaceholders` (which operates on post-wizard output).
+
+**D — Snapshot tests per representative stack (roadmap).** Fixture project per stack target (web, backend Python, Go CLI, Swift iOS, Rust crate). Scaffold CDK in each, snapshot the output, diff on PR. Captures cross-tier divergence and post-scaffold behavior at file level. Cost: ~1 week initial + recurring per new stack. To file as a separate issue once A+B+C are in production for at least one release cycle.
+
+**E — Gate matrix completeness (roadmap).** Builds on B. For each gate, verify matrix completeness across stack targets. Detects gates that leave legitimate stacks uncovered. Requires explicit enumeration of target stacks. To file as a separate issue after B has surfaced any concrete completeness questions.
+
+**F — LLM-based prose semantic eval (defer).** Rationale: (1) cost — would run per-PR touching templates, not on-demand; (2) non-determinism — same prose can score differently across runs; (3) Phase 6 cross-LLM of the skill-review pipeline already exercises this pattern on-demand for the same surface. The marginal value of converting it to a per-PR gate is unclear until B/E reveal what semantic checks are actually missed by mechanical lint. Re-evaluate when A/B/C have been in production for two release cycles and a recurring class of drift escapes them.
+
+**G — Behavioral fixture testing (defer).** Rationale: weeks of setup, recurring per new stack/skill, non-trivial runtime cost. Conceptually the strongest test but the failure mode it catches (Claude interprets prose differently across runs) is also the hardest to assert against. Re-evaluate when CDK has paying customers whose deployments depend on phase semantics.
+
+---
+
+## 5. Sequencing rationale
+
+**v1 (this PR, issue #138)**: A + B + C, hard-fail integration in `run.js`. Aligns with acceptance literal. Registry tight by design: only concepts the maintainer can defend right now go in; growth is incremental per release.
+
+**v2 (separate issues)**: D + E.
+
+**Deferred indefinitely**: F + G. Reopen with explicit re-evaluation criteria stated above.
+
+The defensible position: mechanical checks catch the regressions that are cheap to catch, the document of what's NOT covered makes the residual risk visible to anyone changing templates, and on-demand cross-LLM review handles the rest when it matters.
+
+---
+
+## 6. Drift decision — tier-m vs tier-l Phase 1.5
+
+The drift `*(blocks touching >5 files or introducing new patterns)*` (tier-m) vs `*(blocks touching >5 files or new patterns)*` (tier-l) is semantically negligible but functionally a real cross-tier inconsistency.
+
+**Decision**: align tier-m to tier-l canonical form `*(blocks touching >5 files or new patterns)*`. Rationale: tier-l is the more mature, curated tier and serves as canonical reference; tier-m derives from it.
+
+Applied in this PR. Registry encodes the canonical form so future drift is caught.
+
+---
+
+## 7. Concept registry — first cut (v1)
+
+The registry lives in `packages/cli/test/template-coverage/cross-tier-concepts.json` and is consumed by the A lint. v1 contains only concepts the maintainer can defend as aligned-required *today* — additions go through a registry-update PR, not silent expansion.
+
+Concepts in v1:
+
+1. **Placeholder behavior section** — exact-text match for the 4-line normative paragraph. Applies to all 3 tiers.
+2. **Execution keywords** — exact-text match for `` `Execute` · `Proceed` · `Confirmed` · `Go ahead` ``. Applies to all 3 tiers.
+3. **Never commit to main/staging** — section-presence in Cross-cutting rules. Applies to all 3 tiers.
+4. **Secret hygiene** — section-presence in Cross-cutting rules. Applies to all 3 tiers.
+5. **Phase 1.5 Design review heading** — exact-text. Applies to tier-m and tier-l only. Canonical form: `## Phase 1.5 - Design review *(blocks touching >5 files or new patterns)*`.
+6. **Phase 5d Track A/B/C structure** — structural (three tracks must be present with their heading lines). Applies to tier-m and tier-l only.
+7. **Security checklist five items** — structural (5 ordered conditional items, plus the fallback "If none apply"). Applies to tier-m and tier-l only.
+8. **Phase 8 commit sequence three commits** — structural (Commit 1 source / Commit 2 docs / Commit 3 context). Applies to tier-m and tier-l only.
+9. **Severity handling Critical/Major/Minor** — section-presence in Phase 5d. Applies to tier-m and tier-l only.
+10. **Phase 6 STOP gate present** — section-presence. Applies to tier-m and tier-l only.
+
+Explicitly may-diverge (NOT in registry):
+
+- FL-N (tier-s) vs Phase-N (tier-m / tier-l) numbering scheme
+- Phase 1.6 Visual & UX Design (tier-l only — mandatory by design)
+- Plan lock + context reset section (tier-l only)
+- Pipeline for Structural Requirements Changes (tier-l only)
+- ADR write step in Phase 8 (tier-l only)
+- Phase 8.5 delegation (tier-m runs C1–C3 inline, tier-l delegates to `/context-review` skill)
+
+---
+
+## 8. Integration in run.js
+
+Three new scenarios:
+
+- `scenarioCrossTierLint` — invokes `cross-tier-lint.mjs`, asserts zero violations against registry.
+- `scenarioGateEnumeration` — invokes `gate-enum.mjs`, asserts the inventory generates without errors and the report is non-empty per tier.
+- `scenarioPlaceholderCoverage` — invokes `placeholder-check.mjs`, asserts every template-referenced placeholder is documented or wizard-managed.
+
+All three hard-fail on violation, consistent with the existing `failures` collector pattern. Scripts are also standalone-invokable for local development (`node packages/cli/test/template-coverage/cross-tier-lint.mjs`).
+
+---
+
+## 9. Acceptance check against #138
+
+- [x] Design document at `docs/architecture/test-coverage-strategy.md` — this file.
+- [x] Implementation of A + B + C — see `packages/cli/test/template-coverage/`.
+- [x] Roadmap for D + E — to be filed as separate GitHub issues at PR merge.
+- [x] Explicit decision on F + G — defer, re-evaluation criteria stated.
+- [x] Integration in `run.js` with hard-fail CI gating.
+
+---
+
+## 10. Maintenance contract
+
+When adding a new phase or modifying normative prose in any `pipeline.md`:
+
+1. If the concept must remain aligned cross-tier — add or update the corresponding entry in `cross-tier-concepts.json` *before* changing the templates. The lint will fail until both sides match.
+2. If the concept is may-diverge — append to the "may-diverge" list in §7 with a one-line rationale.
+3. If unsure — default to aligned-required. Cost of adding a registry entry is low; cost of unnoticed drift is high.
+
+When adding a new stack target:
+
+1. Verify gate clauses enumerated by B cover the new stack. Gaps go in issue tracker as candidates for E (gate matrix completeness).

--- a/docs/operational-guide.md
+++ b/docs/operational-guide.md
@@ -24,6 +24,7 @@
 14. [Conventions and non-negotiables](#14-conventions-and-non-negotiables)
 15. [Maintaining the scaffold](#15-maintaining-the-scaffold)
     15b. [Anthropic drift tracking](#15b-anthropic-drift-tracking)
+    15c. [Template coverage tests (maintainer-only)](#15c-template-coverage-tests-maintainer-only)
 16. [Frequently asked questions](#16-frequently-asked-questions)
 
 ---
@@ -1350,6 +1351,26 @@ CDK features risk being absorbed as Anthropic ships native Claude Code capabilit
 **Issue management**: Issues are labeled `anthropic-drift` and include the feature ID in the title as `[drift:feature-id]`. The tracker deduplicates by checking for existing open issues with the same feature ID. Stale issues (>30 days) are auto-closed.
 
 **Local dry-run**: `node .github/drift-tracker/check-drift.mjs --dry-run --days=30`
+
+---
+
+## 15c. Template coverage tests (maintainer-only)
+
+CDK ships normative prose inside `pipeline.md` per tier and inside per-tier `CLAUDE.md` templates. Drift between tiers, broken gate clauses, and undocumented placeholders quietly degrade what customers receive. The template-coverage layer catches these regressions before the templates reach `npm`.
+
+Three standalone scripts under `packages/cli/test/template-coverage/`:
+
+```bash
+node packages/cli/test/template-coverage/cross-tier-lint.mjs     # registry-driven cross-tier semantic lint
+node packages/cli/test/template-coverage/gate-enum.mjs           # enumerate every gate clause per tier
+node packages/cli/test/template-coverage/placeholder-check.mjs   # verify every UPPER_SNAKE_CASE placeholder is documented
+```
+
+Pass `--json` to any of them for machine-readable output. Exit code is non-zero on a violation. The three scripts also run as scenarios inside the main integration suite — `node packages/cli/test/integration/run.js` fails if any of them fail.
+
+The concept registry consumed by `cross-tier-lint.mjs` lives in `packages/cli/test/template-coverage/cross-tier-concepts.json`. When adding a new phase or normative paragraph that must remain aligned across tiers, update the registry before changing the templates. The lint will flag the mismatch until both sides agree.
+
+Strategy, cost-benefit, and the explicit decision on deferred approaches (LLM-based semantic eval, behavioral fixture testing): [docs/architecture/test-coverage-strategy.md](architecture/test-coverage-strategy.md).
 
 ---
 

--- a/packages/cli/templates/tier-l/CLAUDE.md
+++ b/packages/cli/templates/tier-l/CLAUDE.md
@@ -49,6 +49,7 @@
 - Product UI language: **[Italian / English / other]**. Code/commits: **English**.
 - Status/enum values: `[ENUM_CASE_CONVENTION]`.
 - Every API route: verify caller role before any operation.
+- Test cleanup pattern: `[TEST_CLEANUP_PATTERN]` (e.g. truncate tables in test setup, clear fixtures in afterEach, reset mock services).
 - [Other non-obvious conventions.]
 
 ## Known Patterns

--- a/packages/cli/templates/tier-m/.claude/rules/pipeline.md
+++ b/packages/cli/templates/tier-m/.claude/rules/pipeline.md
@@ -119,7 +119,7 @@ A skip is a legitimate outcome. Silent degradation is not.
 
 ***** STOP - Path A: spec review. Path B: requirements summary. Wait for explicit confirmation before Phase 2. *****
 
-## Phase 1.5 - Design review *(blocks touching >5 files or introducing new patterns)*
+## Phase 1.5 - Design review *(blocks touching >5 files or new patterns)*
 
 - Present data flow, data structures, main trade-offs.
 - State discarded alternatives and rationale.

--- a/packages/cli/templates/tier-m/CLAUDE.md
+++ b/packages/cli/templates/tier-m/CLAUDE.md
@@ -40,6 +40,7 @@
 - Product UI language: **[Italian / English / other]**. Code/commits: **English**.
 - Status/enum values: `[ENUM_CASE_CONVENTION]`.
 - Every API route: verify caller role before any operation.
+- Test cleanup pattern: `[TEST_CLEANUP_PATTERN]` (e.g. truncate tables in test setup, clear fixtures in afterEach, reset mock services).
 - [Other non-obvious conventions.]
 
 ## Known Patterns

--- a/packages/cli/test/integration/run.js
+++ b/packages/cli/test/integration/run.js
@@ -916,6 +916,50 @@ async function scenarioPipelineGateCount() {
   }
 }
 
+// Template coverage scenarios — issue #138.
+// Each delegates to a standalone script under packages/cli/test/template-coverage/.
+// See docs/architecture/test-coverage-strategy.md for the rationale and registry.
+
+const TEMPLATE_COVERAGE_DIR = path.resolve(__dirname, '../template-coverage');
+
+function runTemplateCoverageScript(scriptName, label) {
+  const scriptPath = path.join(TEMPLATE_COVERAGE_DIR, scriptName);
+  try {
+    const stdout = execFileSync('node', [scriptPath], { stdio: ['ignore', 'pipe', 'pipe'] });
+    pass(label);
+    if (VERBOSE) console.log(stdout.toString());
+  } catch (err) {
+    const stdout = err.stdout ? err.stdout.toString() : '';
+    const stderr = err.stderr ? err.stderr.toString() : '';
+    const tail = (stdout + stderr).trim().split('\n').slice(-6).join(' | ');
+    fail(label, tail || err.message);
+  }
+}
+
+async function scenarioCrossTierLint() {
+  section('Cross-tier semantic lint (issue #138, approach A)');
+  runTemplateCoverageScript(
+    'cross-tier-lint.mjs',
+    'cross-tier lint: registry concepts aligned across tiers',
+  );
+}
+
+async function scenarioGateEnumeration() {
+  section('Gate clause enumeration (issue #138, approach B)');
+  runTemplateCoverageScript(
+    'gate-enum.mjs',
+    'gate enumeration: per-tier gate counts above sanity threshold',
+  );
+}
+
+async function scenarioPlaceholderCoverage() {
+  section('Placeholder coverage on templates (issue #138, approach C)');
+  runTemplateCoverageScript(
+    'placeholder-check.mjs',
+    'placeholder coverage: every UPPER_SNAKE_CASE placeholder documented',
+  );
+}
+
 async function scenarioNewStacks() {
   section('New named stacks - placeholder resolution + basic structure');
 
@@ -3958,6 +4002,9 @@ async function main() {
   await scenarioPerfAuditPlaceholders();
   await scenarioSkillDevApplicabilityCheck();
   await scenarioPipelineGateCount();
+  await scenarioCrossTierLint();
+  await scenarioGateEnumeration();
+  await scenarioPlaceholderCoverage();
   await scenarioSkillPruning();
   await scenarioTierSSkillPruning();
   await scenarioUiAuditPruning();

--- a/packages/cli/test/template-coverage/cross-tier-concepts.json
+++ b/packages/cli/test/template-coverage/cross-tier-concepts.json
@@ -1,0 +1,112 @@
+{
+  "$comment": "Cross-tier concept registry for shipped pipeline.md templates. See docs/architecture/test-coverage-strategy.md §7 for the maintenance contract. Each entry declares a concept that MUST remain aligned across the tiers listed in appliesTo. matchType: exact-text | section-presence | structural. canonicalForm is the source-of-truth string for exact-text. For structural, items lists the required ordered sub-elements.",
+  "version": 1,
+  "concepts": [
+    {
+      "id": "placeholder-behavior-paragraph",
+      "description": "The four-line normative paragraph defining how Claude handles unconfigured command placeholders.",
+      "appliesTo": ["tier-s", "tier-m", "tier-l"],
+      "matchType": "exact-text",
+      "canonicalForm": "When a command placeholder in `CLAUDE.md` (type-check, build, test, E2E, or dev-server command) has no configured value (absent or left as a comment placeholder):\n- Emit a visible step: `[SKIP] No <command-name> configured for this stack — verify manually if applicable.`\n- Do NOT proceed as if the command succeeded.\n- Do NOT mark the gate green.\n\nA skip is a legitimate outcome. Silent degradation is not."
+    },
+    {
+      "id": "execution-keywords-list",
+      "description": "The four execution keywords that authorize autonomous action after a STOP gate.",
+      "appliesTo": ["tier-s", "tier-m", "tier-l"],
+      "matchType": "exact-text",
+      "canonicalForm": "`Execute` · `Proceed` · `Confirmed` · `Go ahead`"
+    },
+    {
+      "id": "never-commit-to-main-staging",
+      "description": "Cross-cutting rule forbidding direct commits to main or staging.",
+      "appliesTo": ["tier-s", "tier-m", "tier-l"],
+      "matchType": "section-presence",
+      "marker": "Never commit to `main` or `staging`"
+    },
+    {
+      "id": "secret-hygiene",
+      "description": "Cross-cutting rule banning committed secrets.",
+      "appliesTo": ["tier-s", "tier-m", "tier-l"],
+      "matchType": "section-presence",
+      "marker": "Secret hygiene"
+    },
+    {
+      "id": "phase-1-5-design-review-heading",
+      "description": "Phase 1.5 Design review heading with the canonical gate clause.",
+      "appliesTo": ["tier-m", "tier-l"],
+      "matchType": "exact-text",
+      "canonicalForm": "## Phase 1.5 - Design review *(blocks touching >5 files or new patterns)*"
+    },
+    {
+      "id": "phase-5d-three-tracks",
+      "description": "Phase 5d block-scoped quality audit decomposes into Track A (UI), Track B (API/DB + compliance), Track C (Test + doc + infra).",
+      "appliesTo": ["tier-m", "tier-l"],
+      "matchType": "structural",
+      "items": [
+        "**Track A - UI audit**",
+        "**Track B - API/DB + compliance audit**",
+        "**Track C - Test + doc + infra audit**"
+      ]
+    },
+    {
+      "id": "security-checklist-five-items",
+      "description": "Phase 2 security checklist enumerates API routes, DB tables, CLI, native mobile, and the explicit-skip fallback.",
+      "appliesTo": ["tier-m", "tier-l"],
+      "matchType": "structural",
+      "items": [
+        "If block adds/modifies API routes",
+        "If block adds/modifies DB tables",
+        "If project is CLI",
+        "If project is native mobile",
+        "If none of the above apply to this block"
+      ]
+    },
+    {
+      "id": "phase-8-three-commit-sequence",
+      "description": "Phase 8 commit sequence: source (Commit 1, already in Phase 3), docs (Commit 2), context (Commit 3).",
+      "appliesTo": ["tier-m", "tier-l"],
+      "matchType": "structural",
+      "items": ["**Commit 1**", "**Commit 2 - docs**", "**Commit 3 - context**"]
+    },
+    {
+      "id": "severity-handling-critical-major-minor",
+      "description": "Phase 5d severity handling defines Critical / Major / Minor outcomes.",
+      "appliesTo": ["tier-m", "tier-l"],
+      "matchType": "structural",
+      "items": ["**Critical**", "**Major**", "**Minor**"]
+    },
+    {
+      "id": "phase-6-stop-gate",
+      "description": "Phase 6 outcome checklist heading must include the STOP marker.",
+      "appliesTo": ["tier-m", "tier-l"],
+      "matchType": "section-presence",
+      "marker": "## Phase 6 - Outcome checklist ⏸ STOP"
+    }
+  ],
+  "mayDiverge": [
+    {
+      "id": "numbering-scheme",
+      "description": "tier-s uses FL-N (Fast Lane), tier-m and tier-l use Phase-N. Intentional asymmetry."
+    },
+    {
+      "id": "phase-1-6-visual-ux",
+      "description": "Phase 1.6 Visual & UX Design is MANDATORY in tier-l only; tier-m folds visual review into Phase 1.5 when relevant."
+    },
+    {
+      "id": "plan-lock-context-reset",
+      "description": "Plan lock + context reset section is tier-l only — reflects the complex-domain workflow where explicit plan-mode locking is warranted."
+    },
+    {
+      "id": "structural-requirements-pipeline",
+      "description": "Pipeline for Structural Requirements Changes (R1–R4) is tier-l only — needed when stakeholders change scope on already-implemented blocks in long-running projects."
+    },
+    {
+      "id": "adr-write-in-phase-8",
+      "description": "ADR write step in Phase 8 is tier-l only — reflects the architecture-decision discipline expected at that tier."
+    },
+    {
+      "id": "phase-8-5-delegation",
+      "description": "tier-m runs C1–C3 grep checks inline; tier-l delegates to /context-review skill. Both reach the same outcome (12 checks complete)."
+    }
+  ]
+}

--- a/packages/cli/test/template-coverage/cross-tier-lint.mjs
+++ b/packages/cli/test/template-coverage/cross-tier-lint.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+/**
+ * Cross-tier semantic lint for shipped pipeline.md templates.
+ *
+ * Consumes cross-tier-concepts.json (the registry) and asserts every concept
+ * declared aligned-required appears in its canonical form across the tiers
+ * listed in appliesTo. See docs/architecture/test-coverage-strategy.md.
+ *
+ * Usage:
+ *   node packages/cli/test/template-coverage/cross-tier-lint.mjs
+ *   node packages/cli/test/template-coverage/cross-tier-lint.mjs --json
+ *
+ * Exit code: 0 on no violations, 1 on any violation.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const TEMPLATES = path.join(REPO_ROOT, 'packages/cli/templates');
+const REGISTRY_PATH = path.join(__dirname, 'cross-tier-concepts.json');
+
+const TIER_FILES = {
+  'tier-s': path.join(TEMPLATES, 'tier-s/.claude/rules/pipeline.md'),
+  'tier-m': path.join(TEMPLATES, 'tier-m/.claude/rules/pipeline.md'),
+  'tier-l': path.join(TEMPLATES, 'tier-l/.claude/rules/pipeline.md'),
+};
+
+const JSON_OUTPUT = process.argv.includes('--json');
+
+function loadTier(tier) {
+  const p = TIER_FILES[tier];
+  if (!p) throw new Error(`unknown tier: ${tier}`);
+  if (!fs.existsSync(p)) throw new Error(`missing pipeline.md for ${tier}: ${p}`);
+  return fs.readFileSync(p, 'utf8');
+}
+
+function checkExactText(tier, body, concept) {
+  if (body.includes(concept.canonicalForm)) {
+    return { ok: true };
+  }
+  return {
+    ok: false,
+    detail: `canonical form not found in ${tier}/pipeline.md\nExpected (first 120 chars): ${concept.canonicalForm.slice(0, 120)}${concept.canonicalForm.length > 120 ? '…' : ''}`,
+  };
+}
+
+function checkSectionPresence(tier, body, concept) {
+  if (body.includes(concept.marker)) {
+    return { ok: true };
+  }
+  return {
+    ok: false,
+    detail: `marker not found in ${tier}/pipeline.md: "${concept.marker}"`,
+  };
+}
+
+function checkStructural(tier, body, concept) {
+  const missing = concept.items.filter((item) => !body.includes(item));
+  if (missing.length === 0) {
+    return { ok: true };
+  }
+  return {
+    ok: false,
+    detail: `missing structural items in ${tier}/pipeline.md: ${missing.map((m) => JSON.stringify(m)).join(', ')}`,
+  };
+}
+
+const CHECKERS = {
+  'exact-text': checkExactText,
+  'section-presence': checkSectionPresence,
+  structural: checkStructural,
+};
+
+function lint() {
+  const registry = JSON.parse(fs.readFileSync(REGISTRY_PATH, 'utf8'));
+  const tierBodies = {};
+  for (const tier of Object.keys(TIER_FILES)) {
+    tierBodies[tier] = loadTier(tier);
+  }
+
+  const violations = [];
+  const checksRun = [];
+
+  for (const concept of registry.concepts) {
+    const checker = CHECKERS[concept.matchType];
+    if (!checker) {
+      violations.push({
+        conceptId: concept.id,
+        tier: null,
+        detail: `unknown matchType "${concept.matchType}" in registry`,
+      });
+      continue;
+    }
+    for (const tier of concept.appliesTo) {
+      if (!tierBodies[tier]) {
+        violations.push({
+          conceptId: concept.id,
+          tier,
+          detail: `concept appliesTo references unknown tier "${tier}"`,
+        });
+        continue;
+      }
+      const result = checker(tier, tierBodies[tier], concept);
+      checksRun.push({ conceptId: concept.id, tier, ok: result.ok });
+      if (!result.ok) {
+        violations.push({
+          conceptId: concept.id,
+          tier,
+          description: concept.description,
+          detail: result.detail,
+        });
+      }
+    }
+  }
+
+  return { violations, checksRun, conceptCount: registry.concepts.length };
+}
+
+function report(result) {
+  if (JSON_OUTPUT) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    return;
+  }
+  const total = result.checksRun.length;
+  const passed = result.checksRun.filter((c) => c.ok).length;
+  const failed = result.violations.length;
+  console.log(`Cross-tier lint — ${result.conceptCount} concepts, ${total} checks across tiers.`);
+  console.log(`  passed: ${passed}`);
+  console.log(`  failed: ${failed}`);
+  if (failed > 0) {
+    console.log('\nViolations:');
+    for (const v of result.violations) {
+      console.log(`  - [${v.conceptId}] ${v.tier ?? '(registry)'}`);
+      if (v.description) console.log(`      ${v.description}`);
+      console.log(`      ${v.detail.split('\n').join('\n      ')}`);
+    }
+  }
+}
+
+const result = lint();
+report(result);
+process.exit(result.violations.length > 0 ? 1 : 0);

--- a/packages/cli/test/template-coverage/gate-enum.mjs
+++ b/packages/cli/test/template-coverage/gate-enum.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+/**
+ * Gate clause enumeration for shipped pipeline.md templates.
+ *
+ * Scope: make every gate visible to the maintainer. NOT logic validation —
+ * that is approach E (roadmap). See docs/architecture/test-coverage-strategy.md §4.
+ *
+ * What is a "gate clause" here:
+ *   - Heading conditional suffixes  *(if X)*, *(when Y)*, *(conditional ...)*,
+ *     *(MANDATORY for ...)*, *(blocks touching ...)*.
+ *   - Inline conditional gates: lines starting with "If" or "When" inside a
+ *     bullet, that introduce a behavior switch.
+ *   - Placeholder-keyed gates: lines that test a [PLACEHOLDER] state.
+ *   - Mode gates: parenthetical "(auto-selected when ...)" markers.
+ *
+ * Usage:
+ *   node packages/cli/test/template-coverage/gate-enum.mjs
+ *   node packages/cli/test/template-coverage/gate-enum.mjs --json
+ *
+ * Exit code: 0 unless a parse failure occurs or a multi-phase tier produces
+ * zero gates (sanity threshold — see RULES below).
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const TEMPLATES = path.join(REPO_ROOT, 'packages/cli/templates');
+
+// minGates is a sanity threshold against parser breakage or template gutting.
+// Set well below current counts; raise only after intentional template additions.
+const TIERS = [
+  { id: 'tier-s', file: path.join(TEMPLATES, 'tier-s/.claude/rules/pipeline.md'), minGates: 0 },
+  { id: 'tier-m', file: path.join(TEMPLATES, 'tier-m/.claude/rules/pipeline.md'), minGates: 8 },
+  { id: 'tier-l', file: path.join(TEMPLATES, 'tier-l/.claude/rules/pipeline.md'), minGates: 12 },
+];
+
+const JSON_OUTPUT = process.argv.includes('--json');
+
+// ── Gate matchers ───────────────────────────────────────────────────────────
+
+const PATTERNS = [
+  {
+    kind: 'heading-conditional',
+    re: /^(#{2,4})\s+(.+?)\s+\*\((.+?)\)\*\s*$/,
+    extract: (m) => ({ heading: m[2].trim(), condition: m[3].trim() }),
+  },
+  {
+    kind: 'mode-auto-select',
+    re: /\*\*Mode\s+([AB])\s+-\s+([^*]+?)\*\*\s+\(auto-selected\s+(when[^)]+)\)/i,
+    extract: (m) => ({ mode: `Mode ${m[1]}`, label: m[2].trim(), condition: m[3].trim() }),
+  },
+  {
+    kind: 'placeholder-keyed-gate',
+    re: /(If|When)\s+`\[([A-Z_]+)\]`\s+is\s+([^.:\n]+)/,
+    extract: (m) => ({ placeholder: m[2], predicate: `${m[1]} ${m[3].trim()}` }),
+  },
+  {
+    kind: 'bullet-conditional',
+    re: /^\s*-\s+(?:\*\*)?(If|When|For)\s+([^:*]{3,120}):/,
+    extract: (m) => ({ keyword: m[1], condition: m[2].trim() }),
+  },
+];
+
+function enumerateTier(tier) {
+  if (!fs.existsSync(tier.file)) {
+    throw new Error(`missing pipeline.md for ${tier.id}: ${tier.file}`);
+  }
+  const body = fs.readFileSync(tier.file, 'utf8');
+  const lines = body.split('\n');
+  const gates = [];
+  let currentPhase = '(preamble)';
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    const phaseMatch = line.match(/^##\s+(.+?)(?:\s+\*\(|\s*$)/);
+    if (phaseMatch && /^(Phase|FL-)/.test(phaseMatch[1])) {
+      currentPhase = phaseMatch[1].trim();
+    }
+
+    for (const pattern of PATTERNS) {
+      const m = line.match(pattern.re);
+      if (m) {
+        gates.push({
+          phase: currentPhase,
+          line: i + 1,
+          kind: pattern.kind,
+          raw: line.trim(),
+          parsed: pattern.extract(m),
+        });
+        break;
+      }
+    }
+  }
+  return gates;
+}
+
+function lint() {
+  const result = { byTier: {}, errors: [], gateTotal: 0 };
+  for (const tier of TIERS) {
+    try {
+      const gates = enumerateTier(tier);
+      result.byTier[tier.id] = {
+        gateCount: gates.length,
+        minGates: tier.minGates,
+        gates,
+      };
+      result.gateTotal += gates.length;
+      if (gates.length < tier.minGates) {
+        result.errors.push({
+          tier: tier.id,
+          detail: `enumerated ${gates.length} gates, expected at least ${tier.minGates} — parser may be broken or template has been gutted`,
+        });
+      }
+    } catch (err) {
+      result.errors.push({ tier: tier.id, detail: err.message });
+    }
+  }
+  return result;
+}
+
+function report(result) {
+  if (JSON_OUTPUT) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    return;
+  }
+  console.log(
+    `Gate clause enumeration — ${result.gateTotal} gates across ${Object.keys(result.byTier).length} tiers.\n`,
+  );
+  for (const [tier, data] of Object.entries(result.byTier)) {
+    console.log(`── ${tier} (${data.gateCount} gates, min ${data.minGates}) ──`);
+    for (const g of data.gates) {
+      console.log(`  [${g.kind}] ${g.phase} :${g.line}`);
+      console.log(`    ${g.raw}`);
+    }
+    console.log('');
+  }
+  if (result.errors.length > 0) {
+    console.log('Errors:');
+    for (const e of result.errors) {
+      console.log(`  - ${e.tier}: ${e.detail}`);
+    }
+  }
+}
+
+const result = lint();
+report(result);
+process.exit(result.errors.length > 0 ? 1 : 0);

--- a/packages/cli/test/template-coverage/placeholder-check.mjs
+++ b/packages/cli/test/template-coverage/placeholder-check.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+/**
+ * Placeholder coverage check for shipped pipeline.md templates.
+ *
+ * For every UPPER_SNAKE_CASE placeholder `[FOO_BAR]` referenced in a tier's
+ * pipeline.md body, verify it is either:
+ *   (a) managed by the wizard (in WIZARD_PLACEHOLDERS), or
+ *   (b) documented in the same tier's CLAUDE.md template.
+ *
+ * Output markers (`[SKIP]`) and user-fill identifiers (lowercase, hyphen-case,
+ * guidance text like `[Italian / English / other]`) are out of scope —
+ * the regex is intentionally narrow.
+ *
+ * Complement to assertNoUnfilledWizardPlaceholders in run.js, which operates on
+ * post-wizard scaffolded output. This check operates on the template source
+ * before any scaffold runs. See docs/architecture/test-coverage-strategy.md §4.
+ *
+ * Usage:
+ *   node packages/cli/test/template-coverage/placeholder-check.mjs
+ *   node packages/cli/test/template-coverage/placeholder-check.mjs --json
+ *
+ * Exit code: 0 on full coverage, 1 if any placeholder is undocumented.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const TEMPLATES = path.join(REPO_ROOT, 'packages/cli/templates');
+
+// Kept in sync manually with packages/cli/test/integration/run.js WIZARD_PLACEHOLDERS.
+// Any addition there must be mirrored here.
+const WIZARD_PLACEHOLDERS = new Set([
+  'PROJECT_NAME',
+  'TECH_STACK_SUMMARY',
+  'TEST_COMMAND',
+  'TYPE_CHECK_COMMAND',
+  'BUILD_COMMAND',
+  'DEV_COMMAND',
+  'INSTALL_COMMAND',
+  'TECH_LEAD',
+  'BACKEND_LEAD',
+  'SECURITY_REVIEWER',
+  'E2E_COMMAND',
+  'AUDIT_MODEL',
+  'DESIGN_SYSTEM_NAME',
+  'FRAMEWORK_VALUE',
+  'LANGUAGE_VALUE',
+  'API_TESTS_PATH',
+  'MIGRATION_COMMAND',
+  'PERF_TOOL',
+  'PROFILER_COMMAND',
+  'LINT_COMMAND',
+  'SECURITY_CHECKLIST_ITEMS',
+]);
+
+// Output markers and other non-placeholder uppercase tokens that may appear in
+// brackets but are not intended as configurable values.
+const NON_PLACEHOLDER_TOKENS = new Set(['SKIP']);
+
+const TIERS = [
+  {
+    id: 'tier-s',
+    pipeline: path.join(TEMPLATES, 'tier-s/.claude/rules/pipeline.md'),
+    claudeMd: path.join(TEMPLATES, 'tier-s/CLAUDE.md'),
+  },
+  {
+    id: 'tier-m',
+    pipeline: path.join(TEMPLATES, 'tier-m/.claude/rules/pipeline.md'),
+    claudeMd: path.join(TEMPLATES, 'tier-m/CLAUDE.md'),
+  },
+  {
+    id: 'tier-l',
+    pipeline: path.join(TEMPLATES, 'tier-l/.claude/rules/pipeline.md'),
+    claudeMd: path.join(TEMPLATES, 'tier-l/CLAUDE.md'),
+  },
+];
+
+const JSON_OUTPUT = process.argv.includes('--json');
+const PLACEHOLDER_RE = /\[([A-Z][A-Z0-9_]{2,})\]/g;
+
+function extractPlaceholders(body) {
+  const set = new Set();
+  let m;
+  PLACEHOLDER_RE.lastIndex = 0;
+  while ((m = PLACEHOLDER_RE.exec(body)) !== null) {
+    if (!NON_PLACEHOLDER_TOKENS.has(m[1])) {
+      set.add(m[1]);
+    }
+  }
+  return [...set].sort();
+}
+
+function check() {
+  const result = { byTier: {}, missing: [] };
+  for (const tier of TIERS) {
+    if (!fs.existsSync(tier.pipeline) || !fs.existsSync(tier.claudeMd)) {
+      result.missing.push({
+        tier: tier.id,
+        placeholder: '(file)',
+        detail: `missing pipeline.md or CLAUDE.md for ${tier.id}`,
+      });
+      continue;
+    }
+    const pipelineBody = fs.readFileSync(tier.pipeline, 'utf8');
+    const claudeBody = fs.readFileSync(tier.claudeMd, 'utf8');
+    const placeholders = extractPlaceholders(pipelineBody);
+
+    const verdict = [];
+    for (const ph of placeholders) {
+      const inWizard = WIZARD_PLACEHOLDERS.has(ph);
+      const inClaudeMd = claudeBody.includes(`[${ph}]`);
+      const status = inWizard
+        ? 'wizard-managed'
+        : inClaudeMd
+          ? 'documented-in-claude-md'
+          : 'undocumented';
+      verdict.push({ placeholder: ph, status, inWizard, inClaudeMd });
+      if (status === 'undocumented') {
+        result.missing.push({
+          tier: tier.id,
+          placeholder: ph,
+          detail: `placeholder [${ph}] referenced in ${tier.id}/pipeline.md is neither wizard-managed nor documented in ${tier.id}/CLAUDE.md`,
+        });
+      }
+    }
+    result.byTier[tier.id] = { placeholderCount: placeholders.length, verdict };
+  }
+  return result;
+}
+
+function report(result) {
+  if (JSON_OUTPUT) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    return;
+  }
+  let total = 0;
+  for (const data of Object.values(result.byTier)) total += data.placeholderCount;
+  console.log(`Placeholder coverage — ${total} uppercase placeholders referenced across tiers.\n`);
+  for (const [tier, data] of Object.entries(result.byTier)) {
+    console.log(`── ${tier} (${data.placeholderCount} placeholders) ──`);
+    for (const v of data.verdict) {
+      const marker = v.status === 'undocumented' ? '✗' : '✓';
+      console.log(`  ${marker} [${v.placeholder}] — ${v.status}`);
+    }
+    console.log('');
+  }
+  if (result.missing.length > 0) {
+    console.log(`Undocumented placeholders: ${result.missing.length}`);
+    for (const m of result.missing) {
+      console.log(`  - ${m.tier}: [${m.placeholder}]`);
+      console.log(`      ${m.detail}`);
+    }
+  }
+}
+
+const result = check();
+report(result);
+process.exit(result.missing.length > 0 ? 1 : 0);


### PR DESCRIPTION
# Test infrastructure for shipped templates (closes #138)

Implements approaches A + B + C from the test coverage strategy: cross-tier semantic lint with an externalized concept registry, gate clause enumeration with per-tier sanity thresholds, and placeholder coverage verification on template source. All three run standalone or inside the integration suite (`run.js`), and hard-fail on violation.

## Summary

- New layer under `packages/cli/test/template-coverage/`: three Node scripts plus a declarative concept registry (`cross-tier-concepts.json`).
- Design doc at `docs/architecture/test-coverage-strategy.md` covers gap-to-approach mapping, sequencing rationale, deferred approaches (F LLM eval, G behavioral fixtures) with explicit re-evaluation criteria, and the maintenance contract.
- Integration suite goes from 1129 to 1132 checks; the three new scenarios use `execFileSync` against the standalone scripts.
- Two template side-effects surfaced by the new checks and fixed in this PR:
  - **tier-m Phase 1.5 wording drift** — was `*(blocks touching >5 files or introducing new patterns)*`, now matches the tier-l canonical form `*(blocks touching >5 files or new patterns)*`. Decision rationale in the design doc §6.
  - **`[TEST_CLEANUP_PATTERN]` undocumented** — referenced in tier-m and tier-l `pipeline.md` Phase 3b but absent from both `CLAUDE.md` templates and from the wizard. Scaffolded output would have shipped with the literal placeholder. Added under Coding Conventions in both CLAUDE.md templates.

## Acceptance check against #138

- [x] Design doc at `docs/architecture/test-coverage-strategy.md`
- [x] A + B + C implemented, hard-fail on violations
- [x] Roadmap for D + E filed as issues #165 (snapshot per stack) and #166 (gate completeness matrix)
- [x] Explicit decision on F + G — deferred with re-evaluation criteria
- [x] Integration in `run.js` with hard-fail CI gating

## Verification

- Negative test: introduced and removed a tier-m execution-keywords drift; lint failed with the expected concept ID and tier, exit 1; restored → 24/24 pass, exit 0.
- Full integration suite: 1132 passed, 0 failed.
- All three scripts support `--json` for machine-readable output.

## Known follow-up

`WIZARD_PLACEHOLDERS` is duplicated between `packages/cli/test/integration/run.js:181` and `packages/cli/test/template-coverage/placeholder-check.mjs`. A manual-sync comment marks the second copy. If a maintainer adds a wizard placeholder and updates only one side, C will pass spuriously. Acceptable for v1 — extractable to a shared module if preferred.

## Files of note

- `docs/architecture/test-coverage-strategy.md` — strategy, registry rationale, and maintenance contract
- `packages/cli/test/template-coverage/cross-tier-concepts.json` — declarative registry (10 concepts in v1)
- `packages/cli/test/template-coverage/cross-tier-lint.mjs` — registry-driven lint
- `packages/cli/test/template-coverage/gate-enum.mjs` — gate visibility
- `packages/cli/test/template-coverage/placeholder-check.mjs` — placeholder documentation coverage

## Test plan

- [ ] CI green (Lint + integration suite)
- [ ] Local `node packages/cli/test/template-coverage/{cross-tier-lint,gate-enum,placeholder-check}.mjs` all exit 0
- [ ] Manual review of `docs/architecture/test-coverage-strategy.md` §6 (drift decision) and §7 (concept registry first cut)
- [ ] Confirm tier-m / tier-l CLAUDE.md additions read correctly in scaffolded output

Closes #138
Related: #134 (placeholder explicit-skip meta-rule), #131 (mechanical checks for skill body)