### PR TITLE
fix: address CodeQL code scanning alerts (12 alerts)

### DIFF
--- a/.github/drift-tracker/check-drift.mjs
+++ b/.github/drift-tracker/check-drift.mjs
@@ -1,9 +1,9 @@
 // Anthropic drift tracker — scans Anthropic docs for features overlapping with CDK.
 // Zero external dependencies. Runs on Node.js >= 22 (native fetch).
 
-import { readFileSync, appendFileSync, existsSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
+import { readFileSync, appendFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -12,8 +12,8 @@ const REGEX_META = /[.*+?^${}()|[\]\\]/;
 // ── Feature manifest ────────────────────────────────────────────────────────
 
 export function loadFeatures(manifestPath) {
-  const p = manifestPath || join(__dirname, 'features.json');
-  const raw = JSON.parse(readFileSync(p, 'utf8'));
+  const p = manifestPath || join(__dirname, "features.json");
+  const raw = JSON.parse(readFileSync(p, "utf8"));
 
   if (!raw.features || !Array.isArray(raw.features)) {
     throw new Error('features.json must contain a "features" array');
@@ -22,9 +22,11 @@ export function loadFeatures(manifestPath) {
   const ids = new Set();
   for (const f of raw.features) {
     if (!f.id || !f.name || !f.risk || !f.keywords || !f.cdkFiles) {
-      throw new Error(`Feature "${f.id || '(unnamed)'}" missing required fields`);
+      throw new Error(
+        `Feature "${f.id || "(unnamed)"}" missing required fields`,
+      );
     }
-    if (!['high', 'medium', 'low'].includes(f.risk)) {
+    if (!["high", "medium", "low"].includes(f.risk)) {
       throw new Error(`Feature "${f.id}" has invalid risk: ${f.risk}`);
     }
     if (ids.has(f.id)) {
@@ -40,8 +42,8 @@ export function loadFeatures(manifestPath) {
 
 export async function fetchPage(url) {
   const res = await fetch(url, {
-    headers: { 'User-Agent': 'claude-dev-kit-drift-tracker/1.0' },
-    redirect: 'follow',
+    headers: { "User-Agent": "claude-dev-kit-drift-tracker/1.0" },
+    redirect: "follow",
   });
   if (!res.ok) {
     throw new Error(`Fetch failed: ${res.status} ${res.statusText} for ${url}`);
@@ -50,22 +52,22 @@ export async function fetchPage(url) {
 }
 
 export function stripHtml(html) {
-  if (!html) return '';
+  if (!html) return "";
   let text = html;
   // Remove script/style blocks (closing tag may contain whitespace or attributes)
-  text = text.replace(/<script[^>]*>[\s\S]*?<\/script[^>]*>/gi, ' ');
-  text = text.replace(/<style[^>]*>[\s\S]*?<\/style[^>]*>/gi, ' ');
+  text = text.replace(/<script[^>]*>[\s\S]*?<\/script[^>]*>/gi, " ");
+  text = text.replace(/<style[^>]*>[\s\S]*?<\/style[^>]*>/gi, " ");
   // Strip remaining tags
-  text = text.replace(/<[^>]+>/g, ' ');
+  text = text.replace(/<[^>]+>/g, " ");
   // Decode entities — &amp; must be decoded LAST to avoid double-unescaping
   text = text.replace(/&#(\d+);/g, (_, n) => String.fromCharCode(Number(n)));
   text = text.replace(/&#39;/g, "'");
   text = text.replace(/&quot;/g, '"');
-  text = text.replace(/&gt;/g, '>');
-  text = text.replace(/&lt;/g, '<');
-  text = text.replace(/&amp;/g, '&');
+  text = text.replace(/&gt;/g, ">");
+  text = text.replace(/&lt;/g, "<");
+  text = text.replace(/&amp;/g, "&");
   // Normalize whitespace
-  text = text.replace(/\s+/g, ' ');
+  text = text.replace(/\s+/g, " ");
   return text.trim();
 }
 
@@ -75,7 +77,8 @@ export function extractRecentChangelog(html, days = 7, now = new Date()) {
   cutoff.setHours(0, 0, 0, 0);
 
   const entries = [];
-  const blockRegex = /<Update\s+label="([^"]+)"\s+description="([^"]+)">([\s\S]*?)<\/Update>/gi;
+  const blockRegex =
+    /<Update\s+label="([^"]+)"\s+description="([^"]+)">([\s\S]*?)<\/Update>/gi;
   let match;
 
   while ((match = blockRegex.exec(html)) !== null) {
@@ -100,7 +103,9 @@ export function extractRecentChangelog(html, days = 7, now = new Date()) {
 // ── URL helpers ─────────────────────────────────────────────────────────────
 
 export function getISOWeek(date) {
-  const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+  const d = new Date(
+    Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()),
+  );
   const dayNum = d.getUTCDay() || 7;
   d.setUTCDate(d.getUTCDate() + 4 - dayNum);
   const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
@@ -110,7 +115,7 @@ export function getISOWeek(date) {
 export function currentWhatsNewUrl(now = new Date()) {
   const week = getISOWeek(now);
   const year = now.getFullYear();
-  return `https://docs.anthropic.com/en/docs/claude-code/whats-new/${year}-w${String(week).padStart(2, '0')}`;
+  return `https://docs.anthropic.com/en/docs/claude-code/whats-new/${year}-w${String(week).padStart(2, "0")}`;
 }
 
 // ── Keyword matching ────────────────────────────────────────────────────────
@@ -119,8 +124,8 @@ export function extractSnippet(text, position, radius = 100) {
   const start = Math.max(0, position - radius);
   const end = Math.min(text.length, position + radius);
   let snippet = text.slice(start, end).trim();
-  if (start > 0) snippet = '...' + snippet;
-  if (end < text.length) snippet = snippet + '...';
+  if (start > 0) snippet = "..." + snippet;
+  if (end < text.length) snippet = snippet + "...";
   return snippet;
 }
 
@@ -128,7 +133,7 @@ export function matchFeature(feature, text) {
   const lowerText = text.toLowerCase();
   const matchedKeywords = [];
   const snippets = [];
-  const mode = feature.keywordMode || 'any';
+  const mode = feature.keywordMode || "any";
 
   for (const kw of feature.keywords) {
     let found = false;
@@ -136,7 +141,7 @@ export function matchFeature(feature, text) {
 
     if (REGEX_META.test(kw)) {
       try {
-        const re = new RegExp(kw, 'i');
+        const re = new RegExp(kw, "i");
         const m = re.exec(text);
         if (m) {
           found = true;
@@ -162,7 +167,7 @@ export function matchFeature(feature, text) {
   }
 
   const matched =
-    mode === 'all'
+    mode === "all"
       ? matchedKeywords.length === feature.keywords.length
       : matchedKeywords.length > 0;
 
@@ -174,51 +179,56 @@ export function matchFeature(feature, text) {
 export function formatIssueBody(matchResult, feature, scanMeta) {
   const lines = [];
   lines.push(`## Anthropic Drift Alert: ${feature.name}`);
-  lines.push('');
+  lines.push("");
   lines.push(`**Risk level**: ${feature.risk.toUpperCase()}`);
   lines.push(`**Scan date**: ${scanMeta.scanDate}`);
   lines.push(`**Source**: ${scanMeta.changelogUrl}`);
-  lines.push('');
-  lines.push('### What was detected');
-  lines.push('');
-  lines.push('Keywords matched in Anthropic documentation:');
-  lines.push('');
-  lines.push('| Keyword | Context |');
-  lines.push('|---|---|');
+  lines.push("");
+  lines.push("### What was detected");
+  lines.push("");
+  lines.push("Keywords matched in Anthropic documentation:");
+  lines.push("");
+  lines.push("| Keyword | Context |");
+  lines.push("|---|---|");
   for (let i = 0; i < matchResult.matchedKeywords.length; i++) {
     const kw = matchResult.matchedKeywords[i];
-    const ctx = (matchResult.snippets[i] || '').replace(/\\/g, '\\\\').replace(/\|/g, '\\|').replace(/\n/g, ' ');
+    const ctx = (matchResult.snippets[i] || "")
+      .replace(/\\/g, "\\\\")
+      .replace(/\|/g, "\\|")
+      .replace(/\n/g, " ");
     lines.push(`| \`${kw}\` | ${ctx} |`);
   }
 
   if (feature.cdkFiles.length > 0) {
-    lines.push('');
-    lines.push('### CDK files at risk');
-    lines.push('');
+    lines.push("");
+    lines.push("### CDK files at risk");
+    lines.push("");
     for (const f of feature.cdkFiles) {
       lines.push(`- \`${f}\``);
     }
   }
 
-  lines.push('');
-  lines.push('### Recommended action');
-  lines.push('');
-  lines.push('Review the Anthropic documentation and assess whether CDK\'s implementation still adds value beyond the native capability.');
-  lines.push('');
+  lines.push("");
+  lines.push("### Recommended action");
+  lines.push("");
+  lines.push(
+    "Review the Anthropic documentation and assess whether CDK's implementation still adds value beyond the native capability.",
+  );
+  lines.push("");
   lines.push(`- [Changelog](${scanMeta.changelogUrl})`);
 
   if (feature.notes) {
-    lines.push('');
-    lines.push('### Context');
-    lines.push('');
+    lines.push("");
+    lines.push("### Context");
+    lines.push("");
     lines.push(feature.notes);
   }
 
-  lines.push('');
-  lines.push('---');
+  lines.push("");
+  lines.push("---");
   lines.push(`_Generated by drift-tracker workflow. ${scanMeta.scanDate}_`);
 
-  return lines.join('\n');
+  return lines.join("\n");
 }
 
 // ── Scan orchestrator ───────────────────────────────────────────────────────
@@ -230,17 +240,19 @@ export async function scan(manifest, options = {}) {
 
   const result = {
     matches: [],
-    scanDate: new Date().toISOString().split('T')[0],
+    scanDate: new Date().toISOString().split("T")[0],
     changelogUrl,
     featuresChecked: features.length,
   };
 
   // Fetch changelog
-  let changelogText = '';
+  let changelogText = "";
   try {
     const html = await fetchPage(changelogUrl);
     const entries = extractRecentChangelog(html, days);
-    changelogText = entries.map((e) => `${e.version} ${e.date} ${e.text}`).join(' ');
+    changelogText = entries
+      .map((e) => `${e.version} ${e.date} ${e.text}`)
+      .join(" ");
 
     if (changelogText.length < 50 && entries.length === 0) {
       // Fallback: use full page text (no Update blocks found — page format may have changed)
@@ -248,7 +260,9 @@ export async function scan(manifest, options = {}) {
     }
 
     if (changelogText.length < 500) {
-      console.warn(`Warning: changelog text is short (${changelogText.length} chars) — page may be SPA-rendered or empty`);
+      console.warn(
+        `Warning: changelog text is short (${changelogText.length} chars) — page may be SPA-rendered or empty`,
+      );
     }
   } catch (err) {
     console.error(`Failed to fetch changelog: ${err.message}`);
@@ -279,26 +293,30 @@ export async function scan(manifest, options = {}) {
 
 async function main() {
   const args = process.argv.slice(2);
-  const dryRun = args.includes('--dry-run') || process.env.DRY_RUN === 'true';
-  const daysArg = args.find((a) => a.startsWith('--days='));
-  const days = daysArg ? Number(daysArg.split('=')[1]) : 7;
-  const featuresArg = args.find((a) => a.startsWith('--features='));
-  const featuresPath = featuresArg ? featuresArg.split('=')[1] : undefined;
+  const dryRun = args.includes("--dry-run") || process.env.DRY_RUN === "true";
+  const daysArg = args.find((a) => a.startsWith("--days="));
+  const days = daysArg ? Number(daysArg.split("=")[1]) : 7;
+  const featuresArg = args.find((a) => a.startsWith("--features="));
+  const featuresPath = featuresArg ? featuresArg.split("=")[1] : undefined;
 
   const manifest = loadFeatures(featuresPath);
-  console.log(`Scanning ${manifest.features.length} features (lookback: ${days} days, dry-run: ${dryRun})`);
+  console.log(
+    `Scanning ${manifest.features.length} features (lookback: ${days} days, dry-run: ${dryRun})`,
+  );
 
   const result = await scan(manifest, { dryRun, days });
 
-  console.log(`Found ${result.matches.length} matches out of ${result.featuresChecked} features checked`);
+  console.log(
+    `Found ${result.matches.length} matches out of ${result.featuresChecked} features checked`,
+  );
 
   if (dryRun) {
     if (result.matches.length === 0) {
-      console.log('No drift detected.');
+      console.log("No drift detected.");
     } else {
       for (const m of result.matches) {
         console.log(`\n--- [${m.risk.toUpperCase()}] ${m.featureName} ---`);
-        console.log(`Keywords: ${m.matchedKeywords.join(', ')}`);
+        console.log(`Keywords: ${m.matchedKeywords.join(", ")}`);
         for (const s of m.snippets) {
           console.log(`  > ${s.slice(0, 120)}`);
         }
@@ -321,7 +339,9 @@ async function main() {
 }
 
 // Run if executed directly
-const isMain = process.argv[1] && fileURLToPath(import.meta.url).endsWith(process.argv[1].replace(/.*\//, ''));
+const isMain =
+  process.argv[1] &&
+  fileURLToPath(import.meta.url).endsWith(process.argv[1].replace(/.*\//, ""));
 if (isMain) {
   main().catch((err) => {
     console.error(err);

--- a/packages/cli/src/commands/new-skill.js
+++ b/packages/cli/src/commands/new-skill.js
@@ -253,15 +253,8 @@ export async function newSkill(options) {
     process.exit(1);
   }
 
-  // Conflict check
   const targetDir = path.join(cwd, '.claude', 'skills', answers.name);
   const targetSkill = path.join(targetDir, 'SKILL.md');
-
-  if (fs.existsSync(targetSkill)) {
-    console.log(chalk.yellow(`⚠ .claude/skills/${answers.name}/SKILL.md already exists.`));
-    console.log('Remove it first or choose a different name.');
-    return;
-  }
 
   // Build content
   const skillContent = buildSkillMd(answers);
@@ -284,9 +277,19 @@ export async function newSkill(options) {
     return;
   }
 
-  // Write files
+  // Write files — flag 'wx' fails atomically if SKILL.md already exists,
+  // closing the check/write race window CodeQL flags as js/file-system-race.
   await fs.ensureDir(targetDir);
-  await fs.writeFile(targetSkill, skillContent);
+  try {
+    await fs.writeFile(targetSkill, skillContent, { flag: 'wx' });
+  } catch (err) {
+    if (err.code === 'EEXIST') {
+      console.log(chalk.yellow(`⚠ .claude/skills/${answers.name}/SKILL.md already exists.`));
+      console.log('Remove it first or choose a different name.');
+      return;
+    }
+    throw err;
+  }
   console.log(`${chalk.green('✓')} Created .claude/skills/${answers.name}/SKILL.md`);
 
   const targetTest = path.join(targetDir, 'test-skill.js');

--- a/packages/cli/src/utils/claudemd-update.js
+++ b/packages/cli/src/utils/claudemd-update.js
@@ -13,11 +13,17 @@ import path from 'path';
 export function registerSkillInClaudeMd(cwd, skillName, description) {
   const claudePath = path.join(cwd, 'CLAUDE.md');
 
-  if (!fs.existsSync(claudePath)) {
-    return { updated: false, reason: 'CLAUDE.md not found' };
+  // Read directly with try/catch to avoid the existsSync → readFile race
+  // CodeQL flags as js/file-system-race.
+  let content;
+  try {
+    content = fs.readFileSync(claudePath, 'utf8');
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      return { updated: false, reason: 'CLAUDE.md not found' };
+    }
+    throw err;
   }
-
-  const content = fs.readFileSync(claudePath, 'utf8');
 
   if (!content.includes('## Active Skills')) {
     return { updated: false, reason: 'No Active Skills section in CLAUDE.md' };

--- a/packages/cli/test/integration/run.js
+++ b/packages/cli/test/integration/run.js
@@ -2637,11 +2637,13 @@ async function scenarioDoctorCrossFileValidation() {
     fillStopHookTestCmd(corruptTier);
     fillClaudeMdTestCmd(corruptTier);
     const pipelinePath = path.join(corruptTier, '.claude/rules/pipeline.md');
-    if (fs.existsSync(pipelinePath)) {
+    try {
       const raw = fs.readFileSync(pipelinePath, 'utf8');
       const wrongH1 =
         tier === 's' ? '# Full Development Pipeline - Tier L\n' : '# Fast Lane Pipeline\n';
       fs.writeFileSync(pipelinePath, raw.replace(/^#[^\n]*\n/, wrongH1));
+    } catch (err) {
+      if (err.code !== 'ENOENT') throw err;
     }
     const tierReport = runDoctor(corruptTier);
     const tierStatus = getCheckStatus(tierReport, 'pipeline-md-tier-coherence');
@@ -2657,12 +2659,10 @@ async function scenarioDoctorCrossFileValidation() {
     fillStopHookTestCmd(corruptSecurity);
     fillClaudeMdTestCmd(corruptSecurity);
     const securityPath = path.join(corruptSecurity, '.claude/rules/security.md');
-    if (fs.existsSync(securityPath)) {
-      fs.writeFileSync(
-        securityPath,
-        '# Security Rules - Native Apple (macOS / iOS)\n\nStore secrets in Keychain only.\n',
-      );
-    }
+    fs.writeFileSync(
+      securityPath,
+      '# Security Rules - Native Apple (macOS / iOS)\n\nStore secrets in Keychain only.\n',
+    );
     const secReport = runDoctor(corruptSecurity);
     const secStatus = getCheckStatus(secReport, 'security-md-stack-alignment');
     if (secStatus === 'warn' || secStatus === 'fail') {
@@ -3169,7 +3169,7 @@ async function scenarioMcpAwareSkillsV120() {
         fail(`Tier ${tier}: security-audit Step 3c missing MCP-aware structure or fallback text`);
       }
 
-      if (/github\.com\/marcoeg\/mcp-nvd/.test(body)) {
+      if (body.includes('github.com/marcoeg/mcp-nvd')) {
         pass(`Tier ${tier}: security-audit pins mcp-nvd repo URL`);
       } else {
         fail(`Tier ${tier}: security-audit missing mcp-nvd repo URL pin`);
@@ -3206,7 +3206,7 @@ async function scenarioMcpAwareSkillsV120() {
         fail(`Tier ${tier}: dependency-audit Step 2 missing MCP-aware structure or fallback text`);
       }
 
-      if (/github\.com\/Artmann\/package-registry-mcp/.test(body)) {
+      if (body.includes('github.com/Artmann/package-registry-mcp')) {
         pass(`Tier ${tier}: dependency-audit pins package-registry-mcp repo URL`);
       } else {
         fail(`Tier ${tier}: dependency-audit missing package-registry-mcp repo URL pin`);

--- a/scripts/external-review-bundle.mjs
+++ b/scripts/external-review-bundle.mjs
@@ -22,30 +22,30 @@
  *   2  bad arguments
  */
 
-import { readFile, writeFile, mkdir } from 'node:fs/promises';
-import { existsSync } from 'node:fs';
-import { resolve, dirname, basename, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { resolve, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const REPO_ROOT = resolve(__dirname, '..');
+const REPO_ROOT = resolve(__dirname, "..");
 
 const SOURCES = [
-  { src: 'README.md', dest: 'README.md', transform: null },
-  { src: 'CHANGELOG.md', dest: 'CHANGELOG.md', transform: lastThreeReleases },
+  { src: "README.md", dest: "README.md", transform: null },
+  { src: "CHANGELOG.md", dest: "CHANGELOG.md", transform: lastThreeReleases },
   {
-    src: 'packages/cli/templates/tier-m/.claude/skills/security-audit/SKILL.md',
-    dest: 'security-audit-SKILL.md',
+    src: "packages/cli/templates/tier-m/.claude/skills/security-audit/SKILL.md",
+    dest: "security-audit-SKILL.md",
     transform: null,
   },
   {
-    src: 'packages/cli/templates/tier-m/.claude/rules/pipeline.md',
-    dest: 'pipeline-tier-m.md',
+    src: "packages/cli/templates/tier-m/.claude/rules/pipeline.md",
+    dest: "pipeline-tier-m.md",
     transform: null,
   },
   {
-    src: '.claude/initiatives/roadmap-status.md',
-    dest: 'roadmap-status.md',
+    src: ".claude/initiatives/roadmap-status.md",
+    dest: "roadmap-status.md",
     transform: null,
   },
 ];
@@ -54,31 +54,30 @@ function parseArgs(argv) {
   const args = {};
   for (let i = 2; i < argv.length; i++) {
     const a = argv[i];
-    if (a === '--out') args.out = argv[++i];
-    else if (a === '--help' || a === '-h') args.help = true;
+    if (a === "--out") args.out = argv[++i];
+    else if (a === "--help" || a === "-h") args.help = true;
     else throw new Error(`Unknown arg: ${a}`);
   }
   return args;
 }
 
 function lastThreeReleases(content) {
-  const lines = content.split('\n');
+  const lines = content.split("\n");
   const releaseHeaders = [];
   lines.forEach((line, i) => {
     if (/^## \[\d+\.\d+\.\d+\]/.test(line)) releaseHeaders.push(i);
   });
   if (releaseHeaders.length === 0) return content;
   const startLine = releaseHeaders[0];
-  const endLine =
-    releaseHeaders.length >= 4 ? releaseHeaders[3] : lines.length;
+  const endLine = releaseHeaders.length >= 4 ? releaseHeaders[3] : lines.length;
   const head = lines.slice(0, startLine);
   const slice = lines.slice(startLine, endLine);
   return [
     ...head,
-    '> Bundle note: trimmed to the last three releases for review compactness.',
-    '',
+    "> Bundle note: trimmed to the last three releases for review compactness.",
+    "",
     ...slice,
-  ].join('\n');
+  ].join("\n");
 }
 
 async function main() {
@@ -91,9 +90,7 @@ async function main() {
   }
 
   if (args.help || !args.out) {
-    console.log(
-      'Usage: node scripts/external-review-bundle.mjs --out <dir>',
-    );
+    console.log("Usage: node scripts/external-review-bundle.mjs --out <dir>");
     process.exit(args.help ? 0 : 2);
   }
 
@@ -107,16 +104,18 @@ async function main() {
       missing.push(entry.src);
       continue;
     }
-    const raw = await readFile(srcPath, 'utf8');
+    const raw = await readFile(srcPath, "utf8");
     const content = entry.transform ? entry.transform(raw) : raw;
     const destPath = join(outDir, entry.dest);
     await writeFile(destPath, content);
-    const lines = content.split('\n').length;
+    const lines = content.split("\n").length;
     console.log(`  ✓ ${entry.dest} (${lines} lines)`);
   }
 
   if (missing.length > 0) {
-    console.error(`\nMissing sources:\n${missing.map((m) => `  - ${m}`).join('\n')}`);
+    console.error(
+      `\nMissing sources:\n${missing.map((m) => `  - ${m}`).join("\n")}`,
+    );
     process.exit(1);
   }
 
@@ -125,6 +124,6 @@ async function main() {
 }
 
 main().catch((err) => {
-  console.error('Fatal:', err.message);
+  console.error("Fatal:", err.message);
   process.exit(1);
 });

--- a/scripts/external-review.mjs
+++ b/scripts/external-review.mjs
@@ -31,25 +31,30 @@
  *   3  Critical findings detected in at least one response — resolve before closing the review
  */
 
-import { readFile, writeFile, mkdir, readdir, stat } from 'node:fs/promises';
-import { join, basename, resolve } from 'node:path';
-import { existsSync } from 'node:fs';
+import { readFile, writeFile, mkdir, readdir, stat } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { existsSync } from "node:fs";
 
 // ---- arg parsing -----------------------------------------------------------
 
 function parseArgs(argv) {
   const args = {};
   for (let i = 2; i < argv.length; i += 2) {
-    const key = argv[i]?.replace(/^--/, '');
+    const key = argv[i]?.replace(/^--/, "");
     const val = argv[i + 1];
     if (!key || val === undefined) exit(2, `bad argument near: ${argv[i]}`);
     args[key] = val;
   }
-  for (const required of ['prompt', 'bundle', 'out']) {
+  for (const required of ["prompt", "bundle", "out"]) {
     if (!args[required]) exit(2, `missing required --${required}`);
   }
-  args.only = args.only ? args.only.split(',').map((s) => s.trim()).filter(Boolean) : null;
-  args.suffix = args.suffix || '';
+  args.only = args.only
+    ? args.only
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : null;
+  args.suffix = args.suffix || "";
   return args;
 }
 
@@ -61,15 +66,15 @@ function exit(code, msg) {
 // ---- .env loader (no dependency) -------------------------------------------
 
 async function loadEnv(cwd) {
-  const envPath = join(cwd, '.env');
+  const envPath = join(cwd, ".env");
   if (!existsSync(envPath)) return;
-  const raw = await readFile(envPath, 'utf8');
-  for (const line of raw.split('\n')) {
+  const raw = await readFile(envPath, "utf8");
+  for (const line of raw.split("\n")) {
     const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*?)\s*$/);
     if (!m) continue;
     const [, key, rawVal] = m;
     if (process.env[key]) continue; // do not override existing
-    const val = rawVal.replace(/^["']|["']$/g, '');
+    const val = rawVal.replace(/^["']|["']$/g, "");
     process.env[key] = val;
   }
 }
@@ -83,8 +88,8 @@ async function collectBundle(dir) {
     for (const it of items.sort((a, b) => a.name.localeCompare(b.name))) {
       const p = join(current, it.name);
       if (it.isDirectory()) await walk(p);
-      else if (it.isFile() && it.name.endsWith('.md')) {
-        const content = await readFile(p, 'utf8');
+      else if (it.isFile() && it.name.endsWith(".md")) {
+        const content = await readFile(p, "utf8");
         entries.push({ path: p, content });
       }
     }
@@ -96,109 +101,124 @@ async function collectBundle(dir) {
 function renderBundle(entries, bundleRoot) {
   // Files contain their own triple-backtick code fences, so wrapping them in
   // another fence would break parsing. Use explicit plain-text delimiters.
-  const lines = ['# Context bundle', ''];
-  lines.push(`Files included: ${entries.length}`, '');
+  const lines = ["# Context bundle", ""];
+  lines.push(`Files included: ${entries.length}`, "");
   for (const e of entries) {
-    const rel = e.path.startsWith(bundleRoot) ? e.path.slice(bundleRoot.length).replace(/^\/+/, '') : e.path;
+    const rel = e.path.startsWith(bundleRoot)
+      ? e.path.slice(bundleRoot.length).replace(/^\/+/, "")
+      : e.path;
     lines.push(`===== FILE-START: ${rel} =====`);
     lines.push(e.content.trimEnd());
     lines.push(`===== FILE-END: ${rel} =====`);
-    lines.push('');
+    lines.push("");
   }
-  return lines.join('\n');
+  return lines.join("\n");
 }
 
 // ---- providers -------------------------------------------------------------
 
 const PROVIDERS = [
   {
-    name: 'openai',
-    envKey: 'OPENAI_API_KEY',
-    modelEnv: 'OPENAI_MODEL',
-    defaultModel: 'gpt-4.1',
+    name: "openai",
+    envKey: "OPENAI_API_KEY",
+    modelEnv: "OPENAI_MODEL",
+    defaultModel: "gpt-4.1",
     call: async ({ apiKey, model, system, user }) => {
-      const res = await fetch('https://api.openai.com/v1/chat/completions', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json', authorization: `Bearer ${apiKey}` },
+      const res = await fetch("https://api.openai.com/v1/chat/completions", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${apiKey}`,
+        },
         body: JSON.stringify({
           model,
           messages: [
-            { role: 'system', content: system },
-            { role: 'user', content: user },
+            { role: "system", content: system },
+            { role: "user", content: user },
           ],
           temperature: 0.2,
         }),
       });
       if (!res.ok) throw new Error(`openai ${res.status}: ${await res.text()}`);
       const j = await res.json();
-      return j.choices?.[0]?.message?.content ?? '';
+      return j.choices?.[0]?.message?.content ?? "";
     },
   },
   {
-    name: 'gemini',
-    envKey: 'GEMINI_API_KEY',
-    modelEnv: 'GEMINI_MODEL',
-    defaultModel: 'gemini-2.5-pro',
+    name: "gemini",
+    envKey: "GEMINI_API_KEY",
+    modelEnv: "GEMINI_MODEL",
+    defaultModel: "gemini-2.5-pro",
     call: async ({ apiKey, model, system, user }) => {
       const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`;
       const res = await fetch(url, {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
+        method: "POST",
+        headers: { "content-type": "application/json" },
         body: JSON.stringify({
-          systemInstruction: { role: 'system', parts: [{ text: system }] },
-          contents: [{ role: 'user', parts: [{ text: user }] }],
+          systemInstruction: { role: "system", parts: [{ text: system }] },
+          contents: [{ role: "user", parts: [{ text: user }] }],
           generationConfig: { temperature: 0.2 },
         }),
       });
       if (!res.ok) throw new Error(`gemini ${res.status}: ${await res.text()}`);
       const j = await res.json();
-      return j.candidates?.[0]?.content?.parts?.map((p) => p.text).join('\n') ?? '';
+      return (
+        j.candidates?.[0]?.content?.parts?.map((p) => p.text).join("\n") ?? ""
+      );
     },
   },
   {
-    name: 'mistral',
-    envKey: 'MISTRAL_API_KEY',
-    modelEnv: 'MISTRAL_MODEL',
-    defaultModel: 'mistral-large-latest',
+    name: "mistral",
+    envKey: "MISTRAL_API_KEY",
+    modelEnv: "MISTRAL_MODEL",
+    defaultModel: "mistral-large-latest",
     call: async ({ apiKey, model, system, user }) => {
-      const res = await fetch('https://api.mistral.ai/v1/chat/completions', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json', authorization: `Bearer ${apiKey}` },
+      const res = await fetch("https://api.mistral.ai/v1/chat/completions", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${apiKey}`,
+        },
         body: JSON.stringify({
           model,
           messages: [
-            { role: 'system', content: system },
-            { role: 'user', content: user },
+            { role: "system", content: system },
+            { role: "user", content: user },
           ],
           temperature: 0.2,
         }),
       });
-      if (!res.ok) throw new Error(`mistral ${res.status}: ${await res.text()}`);
+      if (!res.ok)
+        throw new Error(`mistral ${res.status}: ${await res.text()}`);
       const j = await res.json();
-      return j.choices?.[0]?.message?.content ?? '';
+      return j.choices?.[0]?.message?.content ?? "";
     },
   },
   {
-    name: 'perplexity',
-    envKey: 'PERPLEXITY_API_KEY',
-    modelEnv: 'PERPLEXITY_MODEL',
-    defaultModel: 'sonar-pro',
+    name: "perplexity",
+    envKey: "PERPLEXITY_API_KEY",
+    modelEnv: "PERPLEXITY_MODEL",
+    defaultModel: "sonar-pro",
     call: async ({ apiKey, model, system, user }) => {
-      const res = await fetch('https://api.perplexity.ai/chat/completions', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json', authorization: `Bearer ${apiKey}` },
+      const res = await fetch("https://api.perplexity.ai/chat/completions", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${apiKey}`,
+        },
         body: JSON.stringify({
           model,
           messages: [
-            { role: 'system', content: system },
-            { role: 'user', content: user },
+            { role: "system", content: system },
+            { role: "user", content: user },
           ],
           temperature: 0.2,
         }),
       });
-      if (!res.ok) throw new Error(`perplexity ${res.status}: ${await res.text()}`);
+      if (!res.ok)
+        throw new Error(`perplexity ${res.status}: ${await res.text()}`);
       const j = await res.json();
-      return j.choices?.[0]?.message?.content ?? '';
+      return j.choices?.[0]?.message?.content ?? "";
     },
   },
 ];
@@ -218,7 +238,7 @@ async function main() {
   if (!existsSync(bundleDir) || !(await stat(bundleDir)).isDirectory())
     exit(2, `bundle dir not found: ${bundleDir}`);
 
-  const system = await readFile(promptPath, 'utf8');
+  const system = await readFile(promptPath, "utf8");
   const bundle = await collectBundle(bundleDir);
   if (bundle.length === 0) exit(2, `bundle is empty: ${bundleDir}`);
   const userBlob = renderBundle(bundle, bundleDir);
@@ -229,30 +249,36 @@ async function main() {
   let active = PROVIDERS.filter((p) => process.env[p.envKey]);
   const missing = PROVIDERS.filter((p) => !process.env[p.envKey]);
   if (args.only) {
-    const unknown = args.only.filter((n) => !PROVIDERS.some((p) => p.name === n));
-    if (unknown.length) exit(2, `unknown provider(s) in --only: ${unknown.join(',')}`);
+    const unknown = args.only.filter(
+      (n) => !PROVIDERS.some((p) => p.name === n),
+    );
+    if (unknown.length)
+      exit(2, `unknown provider(s) in --only: ${unknown.join(",")}`);
     active = active.filter((p) => args.only.includes(p.name));
   }
-  if (active.length === 0) exit(2, 'no provider API keys found in env (after --only filter)');
+  if (active.length === 0)
+    exit(2, "no provider API keys found in env (after --only filter)");
 
-  process.stdout.write(`Bundle: ${bundle.length} files, ${userBlob.length} chars\n`);
+  process.stdout.write(
+    `Bundle: ${bundle.length} files, ${userBlob.length} chars\n`,
+  );
   process.stdout.write(
     `Preflight: ${active.length}/${PROVIDERS.length} provider(s) available\n`,
   );
-  process.stdout.write(`  active: ${active.map((p) => p.name).join(', ')}\n`);
+  process.stdout.write(`  active: ${active.map((p) => p.name).join(", ")}\n`);
   if (missing.length > 0 && !args.only) {
     process.stdout.write(
       `  missing: ${missing
         .map((p) => `${p.name} (set ${p.envKey})`)
-        .join(', ')}\n`,
+        .join(", ")}\n`,
     );
   }
   if (active.length < PROVIDERS.length && !args.only) {
     process.stdout.write(
-      'Warning: cross-LLM diversity is reduced; consider adding the missing keys for the next run.\n',
+      "Warning: cross-LLM diversity is reduced; consider adding the missing keys for the next run.\n",
     );
   }
-  process.stdout.write('\n');
+  process.stdout.write("\n");
 
   const started = Date.now();
   const results = await Promise.allSettled(
@@ -268,30 +294,36 @@ async function main() {
           user: userBlob,
         });
         const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
-        const outPath = join(outDir, `${p.name}${args.suffix ? '.' + args.suffix : ''}.md`);
+        const outPath = join(
+          outDir,
+          `${p.name}${args.suffix ? "." + args.suffix : ""}.md`,
+        );
         await writeFile(
           outPath,
           `# ${p.name} (${model}) — ${new Date().toISOString()}\n\nElapsed: ${elapsed}s\n\n---\n\n${content}\n`,
-          'utf8'
+          "utf8",
         );
         process.stdout.write(`[${p.name}] OK in ${elapsed}s → ${outPath}\n`);
         return { name: p.name, ok: true, outPath };
       } catch (err) {
-        const outPath = join(outDir, `${p.name}${args.suffix ? '.' + args.suffix : ''}.error.md`);
+        const outPath = join(
+          outDir,
+          `${p.name}${args.suffix ? "." + args.suffix : ""}.error.md`,
+        );
         await writeFile(
           outPath,
           `# ${p.name} (${model}) — ERROR — ${new Date().toISOString()}\n\n\`\`\`\n${err?.stack || err?.message || String(err)}\n\`\`\`\n`,
-          'utf8'
+          "utf8",
         );
         process.stdout.write(`[${p.name}] FAIL → ${outPath}\n`);
         return { name: p.name, ok: false, outPath };
       }
-    })
+    }),
   );
 
   const totalElapsed = ((Date.now() - started) / 1000).toFixed(1);
   process.stdout.write(`\nTotal elapsed: ${totalElapsed}s\n`);
-  const failed = results.filter((r) => r.status !== 'fulfilled' || !r.value.ok);
+  const failed = results.filter((r) => r.status !== "fulfilled" || !r.value.ok);
   if (failed.length > 0) {
     process.stdout.write(`Failed: ${failed.length}/${results.length}\n`);
     process.exit(1);
@@ -302,19 +334,24 @@ async function main() {
   const criticalPattern = /\*\*\[?Critical/;
   const criticalHits = [];
   for (const r of results) {
-    if (r.status === 'fulfilled' && r.value.ok) {
-      const content = await readFile(r.value.outPath, 'utf8');
-      const hits = content.split('\n').filter((l) => criticalPattern.test(l)).map((l) => l.trim());
+    if (r.status === "fulfilled" && r.value.ok) {
+      const content = await readFile(r.value.outPath, "utf8");
+      const hits = content
+        .split("\n")
+        .filter((l) => criticalPattern.test(l))
+        .map((l) => l.trim());
       if (hits.length > 0) criticalHits.push({ name: r.value.name, hits });
     }
   }
   if (criticalHits.length > 0) {
-    process.stdout.write('\nCritical findings detected:\n');
+    process.stdout.write("\nCritical findings detected:\n");
     for (const { name, hits } of criticalHits) {
       process.stdout.write(`\n[${name}] ${hits.length} Critical finding(s):\n`);
       for (const h of hits) process.stdout.write(`  ${h}\n`);
     }
-    process.stdout.write('\nResolve Critical findings before closing the review.\n');
+    process.stdout.write(
+      "\nResolve Critical findings before closing the review.\n",
+    );
     process.exit(3);
   }
 }


### PR DESCRIPTION
# Address CodeQL code-scanning alerts

12 alerts open on main, all from CodeQL. This PR closes all of them: 5 in-code fixes, 4 test hardening changes, and 3 dismissals via `gh` API with documented rationale (already applied — not gated on merge).

## Code fixes (5 alerts closed by code change)

- **#16 `src/commands/new-skill.js:289`** — TOCTOU race: `existsSync` followed by `writeFile` left a ~30-line window where a parallel process could create the file first. Replaced with `writeFile { flag: 'wx' }` (atomic exclusive write), catching `EEXIST` to keep the same user-facing message.
- **#17 `src/utils/claudemd-update.js:33`** — Same pattern on CLAUDE.md. Dropped `existsSync` and wrapped `readFileSync` in a try/catch with an explicit `ENOENT` short-circuit. No behavior change on the happy path.
- **#20 `.github/drift-tracker/check-drift.mjs:4`** — Unused `existsSync` import removed.
- **#21 `scripts/external-review-bundle.mjs:27`** + **#22 `scripts/external-review.mjs:35`** — Unused `basename` imports removed.

## Test hardening (4 alerts closed by code change)

- **#14, #15 `test/integration/run.js:3172, 3209`** — Regex on a markdown body flagged as `js/regex/missing-regexp-anchor`. CodeQL read it as a URL context. Replaced with `body.includes('github.com/.../...')` — same semantics, no regex, alert legitimately silenced.
- **#18, #19 `test/integration/run.js:2640, 2660`** — `existsSync` + `readFile`/`writeFile` in doctor corruption scenarios. The test runs in a single process with no adversarial concurrency, but the pattern triggers CodeQL regardless. One replaced with try/catch around the read+write; the gate on the other removed (`writeFileSync` creates the file by default — the doctor check that follows already asserts corruption is detected, so a missing scaffolded file would fail the test loudly elsewhere).

## Dismissed alerts (3 already dismissed via `gh` API)

- **#24 `inference/review.js:72`** — `js/prototype-pollution-utility` dismissed as **false positive**. `setDottedPath` validates every path segment against the `PROTO_POLLUTION_KEYS` deny-list at line 54 and calls `isOwnSafeProperty` at line 61 before any `Object.defineProperty`. The protection runs up front; CodeQL misses it.
- **#25 `context-builder/writer.js:58`** — `js/http-to-file-access` dismissed as **won't fix**. Writing the LLM response to CONTEXT.md is the core context-builder flow; the output is schema-validated before the write. Writing to a file is the point.
- **#13 `drift-tracker/check-drift.mjs:42`** — `js/file-access-to-http` dismissed as **won't fix**. The drift tracker reads `features.json` (in-repo, trusted) and fetches the Anthropic doc URLs declared there. Config-driven, version-controlled, not user-input-driven.

## Note on commit messages

The middle commit (`chore(scripts): apply prettier formatting…`) also removes the three unused imports (#20, #21, #22). The skill picked the dominant change in the diff for the subject; the body covers the formatting bulk, but the import deletions are part of the same commit.

## Verification

- Full integration suite: 1132 passed, 0 failed.
- Unit tests `new-skill.test.js`: 28 passed.
- Drift-tracker tests: 30 passed.
- Three dismissals confirmed via `gh api` PATCH response (`state: dismissed`).

## Test plan

- [ ] CI green (Lint + integration + unit + drift-tracker)
- [ ] CodeQL re-scan on the PR branch shows 0 open alerts on the touched lines (alerts #13, #24, #25 already dismissed; #14–#22 should close on next scan)
- [ ] `new-skill` integration: verify the exclusive-write path still surfaces the "already exists" message when the target SKILL.md is present
- [ ] `claudemd-update`: verify a missing CLAUDE.md still returns `{ updated: false, reason: 'CLAUDE.md not found' }`

Closes alerts #13, #14, #15, #16, #17, #18, #19, #20, #21, #22, #24, #25 on https://github.com/marcoguillermaz/claude-dev-kit/security/code-scanning