### PR TITLE
v1.28.0 — skill-review P3 process robustness (#132)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,30 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.28.0] — 2026-05-15
+
+### Added
+
+- **Skill-review pipeline P3 process robustness** (closes Q3 #10e, issue #132). Cross-LLM synthesis from `docs/reviews/2026-04-29-pipeline-meta/synthesis.md` identified three process-integrity gaps; this release closes all three.
+  - **P3.1 — Phase 1 → Phase 2 mechanical gate (CC5).** Before Phase 2 of `/skill-review` can begin, the reviewer must emit a PASS\|FAIL table covering all 8 Phase 1 preflight steps. Phase 2 entry requires 100% PASS — a FAIL row cannot be overridden by reviewer judgment. This closes the "Stage A → Stage B" gate that existed in the framework as a declaration but had no enforcement artifact behind it. Added to `REVIEW_FRAMEWORK.md` (tier-M and tier-L) and to the Interactive decision points list.
+  - **P3.2 — Behavioral fixture targets expanded from 6 to 11 stack-dependent skills (CC7).** The D1 fixture target set covered ui-audit, visual-audit, accessibility-audit, security-audit, api-design, and migration-audit; P3.2 adds perf-audit, responsive-audit, test-audit, ux-audit, and skill-db. Each added skill is stack-dependent — mode dispatch, dialect-specific output, parser auto-detection, browser-specific behavior — and textual review alone misses the defect classes the fixture pack is designed to catch. Updated `SKILLS_INVENTORY.md` (canonical list with rationale and D1\|P3.2 source tags), `REVIEW_FRAMEWORK.md` Phase 2.E header and Review closing criterion #8, and `SKILL.md` tier-L mode description and Phase 2.E anchor. Side-effect: a pre-existing disagreement between `REVIEW_FRAMEWORK.md` (which listed a different set of 6 skills) and `SKILLS_INVENTORY.md` is now resolved — the canonical list lives in the inventory and is referenced everywhere else.
+  - **P3.3 — Phase 10 final mechanical sweep at cycle closure (CC6).** New phase added to `REVIEW_FRAMEWORK.md` (tier-M and tier-L): after the Phase 6 GO on the last skill, re-run Phase 1 preflight against the final framework spec across all 17 reviewed skills. The sweep is mechanical only — no MITL, no LLM jury, no walkthrough. FAIL rows don't block closure but must be logged as follow-up items for the next cycle; the sweep itself cannot be silently skipped. This addresses drift from pipeline hardening that lands incrementally during a cycle, leaving early-reviewed skills calibrated to an earlier framework version. Tier-M lite mode skips Phase 10 alongside Phase 4 and Phase 9 (portfolios under 6 skills).
+- New "Phase 10" section in `SKILL.md` tier-L runbook; lite-mode skip statement in `SKILL.md` tier-M extended to cover Phase 10.
+
+### Changed
+
+- `REVIEW_FRAMEWORK.md` "Per-skill pipeline" intro: now reads "Six phases per skill + Phase 9 midpoint (mid-cycle) + Phase 10 final mechanical sweep (cycle closure)."
+- `REVIEW_FRAMEWORK.md` Phase 1 fail handling: routes findings through the new mechanical gate instead of the prior informal "Critical findings block Phase 2" wording.
+- `docs/operational-guide.md` `/skill-review` entry rewritten to reflect the gate, the 11-skill fixture target set, and Phase 10.
+- `REVIEW_FRAMEWORK.md` Review closing criterion grew from 8 to 9 conditions: Phase 10 execution + follow-up logging is now a release gate.
+
+### Notes
+
+- Vocabulary alignment: the synthesis used "Stage A / Stage B", "Phase 1b", "C1-C14", "MITL stop #1" from the meta-review prompt bundle. Shipped framework vocabulary (Phase 1 / Phase 2 / ... / Phase 9 / Phase 10, C1-C8) is preserved — the gate and fixture-set changes are mapped to the shipped names. No double-vocabulary debt added.
+- Files touched: 6 (4 framework/inventory mirrors + 2 SKILL.md runbooks). Strict parity between tier-M and tier-L for `REVIEW_FRAMEWORK.md` and `SKILLS_INVENTORY.md`.
+
+---
+
 ## [1.27.0] — 2026-05-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Read-only tools exposed:
 | `cdk_package_meta`      | CDK package name, version, CLI path, cwd                                                                                                                         |
 | `cdk_pr_review`         | reads existing `/pr-review` skill comments on a GitHub PR (verdict, severity counts). Read-only — to generate a fresh review, invoke the `/pr-review` CDK skill. |
 
-The server resolves the project root from `$CDK_PROJECT_ROOT` if set, otherwise from `process.cwd()`. v1.17.0 launched read-only by design; that posture is unchanged through v1.27.0.
+The server resolves the project root from `$CDK_PROJECT_ROOT` if set, otherwise from `process.cwd()`. v1.17.0 launched read-only by design; that posture is unchanged through v1.28.0.
 
 ---
 
@@ -250,7 +250,7 @@ A separate **template-coverage** layer (under `packages/cli/test/template-covera
 
 See [GitHub Milestones](https://github.com/marcoguillermaz/claude-dev-kit/milestones) for the 12-month plan.
 
-**Current**: v1.27.0 closes the Context Builder v1.1 cycle. The `context` sub-command produces a schema-validated `CONTEXT.md` that `init` reads to scaffold the project without prompting (`context --all` runs both steps in one shot; `context --from-yaml file.md` skips the interview for templates and CI; `validate-context` runs as a standalone CI gate). The schema covers all four pipeline tiers (0/S/M/L), including a feature-flag block (`has_api`, `has_database`, `has_frontend`, `has_design_system` + `design_system_name`, `has_prd`) and an `audit_model` field on M/L. The dev-flow persona reuses the legacy wizard's technical questions and auto-derives `tier.rationale` from `teamSize + workScope`. Carried forward from earlier releases: v1.22.0's `/skill-dev` v2 hotspot step (Step 3b "Hotspot priority (churn × debt)"), v1.21.0's PreToolUse runtime enforcement, and v1.20.0's MCP-aware audit skills (`/security-audit` + `/dependency-audit`) pinned to `mcp-nvd` and `package-registry-mcp`.
+**Current**: v1.28.0 closes Q3 #10e (skill-review pipeline P3 process robustness). Three gaps surfaced by the cross-LLM meta-review are now closed: a Phase 1 → Phase 2 gate that no longer yields to maintainer judgment, behavioral-fixture coverage up from 6 to 11 stack-dependent skills, and a Phase 10 mechanical sweep at cycle closure that catches drift on early-cycle skills against the final pipeline version. Carried forward: v1.27.0's Context Builder v1.1 cycle (schema-validated `CONTEXT.md` driving non-interactive scaffolding across all four tiers), v1.22.0's `/skill-dev` v2 hotspot step (churn × debt), v1.21.0's PreToolUse runtime enforcement, and v1.20.0's MCP-aware audit skills pinned to `mcp-nvd` and `package-registry-mcp`.
 
 **Next**: `/arch-audit` MCP-aware once the upstream Anthropic spec MCP server lands. `/privacy-audit` re-eval (Issue #97 sub-track 3) when AST tracing matures or demand signal materializes. Q2 #3 VitePress docs site (ICE 432) stays on hold.
 

--- a/docs/operational-guide.md
+++ b/docs/operational-guide.md
@@ -1,6 +1,6 @@
 # claude-dev-kit - Operational Guide
 
-**Version**: 1.27.0
+**Version**: 1.28.0
 **Audience**: Builder PMs, tech leads, and senior developers using Claude Code - from first exploration to structured, reviewable delivery
 **Format**: Reference + step-by-step. Read section 1 and your target tier section first, then use the rest as a lookup.
 
@@ -984,7 +984,7 @@ Backlog prefix: `GDPR-` (SOC 2 and HIPAA reserve `SOC2-` / `HIPAA-` for v1.15+).
 
 **File**: `.claude/skills/skill-review/SKILL.md` | **Tier**: M (lite), L (full)
 
-Quality review pipeline for skill portfolios. Orchestrates Phase 1 preflight (C1-C8 spec compliance), Phase 2 structural review (fundamentals, cross-tier coherence, refinements, behavioral fixtures), Phase 3 fix + rollback, Phase 6 closeout. Tier M lite mode skips Phase 4 (external LLM review) and Phase 9 (midpoint drift check). Tier L full mode includes all phases. Includes 5 supporting documents: REVIEW_FRAMEWORK.md, SEVERITY_SCALE.md, SPEC_SNAPSHOT.md, SKILLS_INVENTORY.md, CALIBRATION_KIT.md.
+Quality review pipeline for skill portfolios. Runs Phase 1 preflight (C1–C8 spec compliance) → **Phase 1 → Phase 2 mechanical gate** (8-step PASS|FAIL table, no judgment override) → Phase 2 structural review (fundamentals, cross-tier coherence, refinements, behavioral fixtures across 11 stack-dependent skills) → Phase 3 fix + rollback → Phase 6 closeout. Tier M lite mode skips Phase 4 (external LLM review), Phase 9 (midpoint drift check), and Phase 10 (final mechanical sweep). Tier L full mode runs all phases, including a portfolio-level Phase 10 mechanical sweep at cycle closure: Phase 1 is re-run against the final framework spec to surface residual drift on skills reviewed early in the cycle. Ships with 5 supporting documents: REVIEW_FRAMEWORK.md, SEVERITY_SCALE.md, SPEC_SNAPSHOT.md, SKILLS_INVENTORY.md, CALIBRATION_KIT.md.
 
 #### /simplify
 
@@ -1315,7 +1315,7 @@ Wire up by adding to `.mcp.json` (project-scoped) or `~/.claude/.mcp.json` (user
 }
 ```
 
-The server resolves the project root from `$CDK_PROJECT_ROOT` if set, otherwise from the calling process's `cwd`. v1.17.0 launched read-only by design; that posture is unchanged through v1.27.0. A read-write surface remains a future-minor decision contingent on adoption signal.
+The server resolves the project root from `$CDK_PROJECT_ROOT` if set, otherwise from the calling process's `cwd`. v1.17.0 launched read-only by design; that posture is unchanged through v1.28.0. A read-write surface remains a future-minor decision contingent on adoption signal.
 
 ### Adding team-specific rules
 
@@ -1467,4 +1467,4 @@ Nine example fixtures are in `packages/cli/test/fixtures/wizard-answers/`. Copy 
 
 ---
 
-_Last updated: 2026-05-14 - v1.27.0_
+_Last updated: 2026-05-15 - v1.28.0_

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mg-claude-dev-kit",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "description": "Scaffold for legible, reviewable AI-assisted development",
   "type": "module",
   "bin": {

--- a/packages/cli/templates/tier-l/.claude/skills/skill-review/REVIEW_FRAMEWORK.md
+++ b/packages/cli/templates/tier-l/.claude/skills/skill-review/REVIEW_FRAMEWORK.md
@@ -155,7 +155,7 @@ After skill #12 (of 17), only Criticals under rule (c) enter current cycle. All 
 
 ## Per-skill pipeline
 
-Six phases per skill + Phase 9 midpoint (runs once across cycle).
+Six phases per skill + Phase 9 midpoint (mid-cycle) + Phase 10 final mechanical sweep (cycle closure).
 
 ### Phase 1 - Mechanical preflight
 
@@ -176,7 +176,24 @@ Checks:
    A match is flagged unless adjacent to a non-web context clause (`or equivalent`, `[web only]`, `if applicable`, `if the project has`). Output: list of unguarded matches per term. Feeds Phase 2.A (d)+(e) for human judgment on each candidate.
 8. **Reference file coverage check (stack-dependent skills only)** - for each check ID found in the body (grep pattern: `\*\*[A-Z][0-9]\+`), verify the same ID appears in the reference file (e.g., `PATTERNS.md`). Each missing ID = High candidate (skill silently provides no guidance for that check on any stack variant lacking coverage). Stack-agnostic skills: skip.
 
-**Fail handling**: Critical findings block Phase 2. Fixed in Phase 3.
+**Fail handling**: any FAIL row blocks Phase 2 entry per the Phase 1 → Phase 2 mechanical gate below. Critical findings route through Phase 3 first.
+
+#### Phase 1 → Phase 2 mechanical gate *(P3.1 — prevents Stage A drift to Stage B)*
+
+Before Phase 2 begins, emit a PASS/FAIL table over the 8 Phase 1 steps. Phase 2 MUST NOT start until every row reads PASS. A FAIL row routes findings through Phase 3 first; once fixed, re-run Phase 1 from step 1 and re-emit the table. The reviewer cannot mark a row PASS by judgment alone — each step has a mechanical verification (grep result, `wc -l` output, file existence, integration test count).
+
+| Step | Check | Status | Evidence required |
+|---|---|---|---|
+| 1 | Anthropic spec compliance (P1 C1-C8) | PASS\|FAIL | C1-C8 result table |
+| 2 | Line count ≤ 500 | PASS\|FAIL | `wc -l SKILL.md` |
+| 3 | Registry ↔ body coherence | PASS\|FAIL | grep diff vs `skill-registry.js` |
+| 4 | Allowed-tools ↔ body instructions | PASS\|FAIL | capability keyword grep |
+| 5 | Placeholder resolution | PASS\|FAIL | `[PLACEHOLDER]` token scan |
+| 6 | Model ↔ complexity alignment | PASS\|FAIL | line count + subagent heuristic |
+| 7 | Architectural + paradigm vocabulary scan (forms 4+5) | PASS\|FAIL | unguarded-match list |
+| 8 | Reference file coverage check (stack-dependent only) | PASS\|FAIL | check ID match across files |
+
+***** STOP - Phase 1 → Phase 2 gate. Phase 2 entry requires 100% PASS in the table above. Reviewer judgment cannot override a FAIL row. *****
 
 ### Phase 2 - Internal analysis + walkthrough
 
@@ -232,11 +249,11 @@ Grouped by gravity. 2.A/2.B/2.C autonomous; 2.D interactive; 2.E targeted on hig
 
 ***** STOP - cross-tier diff approval. Wait for execution keyword before Phase 2.E or Phase 3. *****
 
-#### 2.E - Behavioral fixtures *(D1 - targeted, 6 skills only)*
+#### 2.E - Behavioral fixtures *(D1 + P3.2 - targeted, 11 stack-dependent skills)*
 
-**Applies to**: ui-audit, visual-audit, ux-audit, responsive-audit, accessibility-audit, security-audit.
-**Rationale**: these skills have the highest false-positive / behavioral-drift risk (browser-based, pattern-heavy, subjective).
-**Skipped for**: all other 11 skills (document-audit sufficient).
+**Applies to**: ui-audit, visual-audit, accessibility-audit, responsive-audit, ux-audit, security-audit, api-design, migration-audit, perf-audit, test-audit, skill-db. Canonical list in `SKILLS_INVENTORY.md § Behavioral fixture targets`.
+**Rationale**: these 11 skills are stack-dependent — their checks vary by stack (web/native/CLI), depend on stack-conditional dispatch, or run live verification whose output differs by dialect/runtime. Textual correctness alone cannot catch known defect classes (false-positive on system colors, dialect-specific SQL, parser-format mismatch, viewport behavior).
+**Skipped for**: the other 6 skills (arch-audit, commit, context-review, dependency-scan, simplify, skill-dev) which are stack-agnostic — textual review is sufficient.
 
 **Procedure**:
 1. Define fixture pack per skill:
@@ -336,19 +353,43 @@ Same scrutiny as Phase 2 findings. **Emerging principle capture (O4)**: if a Pha
 
 **Fail handling**: if drift detected and unresolvable (calibration set itself ambiguous), pause cycle, update P5, user decides alignment direction.
 
+### Phase 10 - Final mechanical sweep *(new P3.3, cycle closure, portfolio-level)*
+
+**When**: after Phase 6 GO on the last skill of the cycle, before declaring cycle CLOSED per `## Review closing criterion`.
+**Executor**: Claude (mechanical-only, no MITL, no LLM jury, no walkthrough).
+**Input**: final-state `REVIEW_FRAMEWORK.md` + final-state `SPEC_SNAPSHOT.md` (authoritative reference at cycle close) + all 17 reviewed skills on disk.
+
+**Rationale (CC6)**: pipeline hardening commits (e.g. P1.1, P1.2, P1.3, P2, P3.1 of this same cycle) land progressively during the cycle. Skills reviewed early in the cycle were calibrated against an earlier pipeline version. Without this sweep, those skills retain residual drift against the final pipeline definition that ships with the release — the drift is invisible at midpoint (Phase 9 only scores the first 3 skills) and accumulates across cycles.
+
+**Procedure**:
+1. Read final `REVIEW_FRAMEWORK.md` and `SPEC_SNAPSHOT.md` as authoritative — these are the version that ships, not the version any individual skill was originally reviewed against.
+2. For each of the 17 reviewed skills, re-run **Phase 1 only** (the 8-step mechanical preflight). Do not re-run Phase 2 (walkthrough), Phase 3 (fixes), Phase 4 (LLM jury), or Phase 9 (drift). This sweep is preflight-only.
+3. Emit one consolidated report at `outputs/phase10-drift-sweep-<YYYY-MM-DD>.md` with a 17 × 8 PASS\|FAIL grid (skills × Phase 1 steps).
+4. **Any FAIL row → open a follow-up review item for next cycle** (e.g. record in `MEMORY.md` or roadmap backlog). Do NOT block current cycle closeout. Do NOT auto-fix. Do NOT escalate severity from the original review.
+
+**Output**: drift-sweep report + 0 or more follow-up items for next cycle.
+
+**Why preflight-only (not full Phase 1-6 re-run)**:
+- Phase 2 walkthrough and Phase 3 fixes are MITL — re-running on 17 skills would cost the same as a full second cycle.
+- Phase 1 mechanical steps catch the most common drift modes (frontmatter syntax updates, line-budget changes, registry/inventory drift, allowed-tools spec changes, placeholder grammar).
+- Anything Phase 1 cannot catch (semantic / behavioral drift) goes into the next cycle's normal Phase 2-3 flow — the follow-up item ensures it isn't lost.
+
+**Fail handling**: this phase cannot itself fail. A FAIL row is data, not a blocker. The cycle still CLOSES; the follow-up item carries the drift into the next cycle as input.
+
 ---
 
 ## Interactive decision points (man-in-the-loop)
 
 1. **Post-pre-work**: confirm P1, P2, P3, P4, P5 sequentially.
-2. **Phase 2.D #13**: per Anthropic opportunity, apply/roadmap/ignore.
-3. **Phase 2.D #14**: section-by-section walkthrough.
-4. **Phase 2.D #15 (C6)**: cross-tier diff approval (multi-tier skills only).
-5. **Phase 3 step 2**: confirm findings to apply before fixes.
-6. **Phase 3 → Phase 4 STOP (C7)**: approve fix diff before external LLMs.
-7. **Phase 5 confirmation**: confirm LLM finding fixes.
-8. **Phase 6 GO**: explicit authorization to proceed.
-9. **Phase 9 (D2)**: drift check resolution if drift detected.
+2. **Phase 1 → Phase 2 gate (P3.1)**: confirm 100% PASS on the 8-step mechanical table before Phase 2 starts. A FAIL row cannot be waived.
+3. **Phase 2.D #13**: per Anthropic opportunity, apply/roadmap/ignore.
+4. **Phase 2.D #14**: section-by-section walkthrough.
+5. **Phase 2.D #15 (C6)**: cross-tier diff approval (multi-tier skills only).
+6. **Phase 3 step 2**: confirm findings to apply before fixes.
+7. **Phase 3 → Phase 4 STOP (C7)**: approve fix diff before external LLMs.
+8. **Phase 5 confirmation**: confirm LLM finding fixes.
+9. **Phase 6 GO**: explicit authorization to proceed.
+10. **Phase 9 (D2)**: drift check resolution if drift detected.
 
 All other steps autonomous once corresponding gate is open.
 
@@ -361,7 +402,7 @@ Each skill review produces:
 - Decision log for opportunities (apply/roadmap/ignore with rationale).
 - Updated SKILL.md.
 - Updated integration test count.
-- **If in 6-skill fixture set (D1)**: fixture pack + expected/actual outputs.
+- **If in 11-skill stack-dependent fixture set (D1 + P3.2)**: fixture pack + expected/actual outputs.
 - Optional: roadmap entries in MEMORY.md.
 - **If emerging principle (O4)**: auto-memory feedback entry + framework amendment.
 
@@ -380,9 +421,10 @@ Cycle CLOSED only when ALL hold:
 5. Integration tests green on final state.
 6. Release note summarizing the cycle drafted (blocks affected, principles captured, severity mapping changes, behavioral fixture results).
 7. **Phase 9 midpoint drift check (D2)** executed and resolved.
-8. **All behavioral fixtures on 6-skill target (D1)** green.
+8. **All behavioral fixtures on 11-skill stack-dependent target (D1 + P3.2)** green.
+9. **Phase 10 final mechanical sweep (P3.3)** executed; the 17 × 8 drift-sweep report exists at `outputs/phase10-drift-sweep-<date>.md`. FAIL rows do NOT block closure but MUST be logged as follow-up items for the next cycle (the sweep itself is not allowed to be silently skipped).
 
-Until all eight hold, cycle OPEN. No version bump claiming "skills quality-reviewed" can ship.
+Until all nine hold, cycle OPEN. No version bump claiming "skills quality-reviewed" can ship.
 
 ---
 

--- a/packages/cli/templates/tier-l/.claude/skills/skill-review/SKILL.md
+++ b/packages/cli/templates/tier-l/.claude/skills/skill-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-review
-description: Orchestrate the skill-review framework v1.2 pipeline on a target skill or cross-tier family. Runs Phase 1 preflight, Phase 2 structural review with interactive walkthrough, Phase 3 fix + rollback, optional Phase 4 external LLM review, Phase 5 integration, Phase 6 closeout. Supports full, preflight-only, and fixtures-only modes. Enforces STOP gates and Phase 9 midpoint drift check when reviewing a portfolio.
+description: Orchestrate the skill-review framework v1.2 pipeline on a target skill or cross-tier family. Runs Phase 1 preflight, Phase 2 structural review with interactive walkthrough, Phase 3 fix + rollback, optional Phase 4 external LLM review, Phase 5 integration, Phase 6 closeout. Supports full, preflight-only, and fixtures-only modes. Enforces STOP gates, Phase 9 midpoint drift check, and Phase 10 final mechanical sweep at cycle closure when reviewing a portfolio.
 user-invocable: true
 model: opus
 context: fork
@@ -14,7 +14,7 @@ You are a skill-quality reviewer running the framework v1.2 pipeline. Your job: 
 
 - `skill-name` (required): target skill directory name (e.g. `ui-audit`, `security-audit`).
 - `tier` (optional, default `all`): which tier variants to review. `all` triggers cross-tier family review per framework §Phase 2.B.
-- `mode` (optional, default `full`): `full` runs all phases; `preflight-only` stops after Phase 1; `fixtures-only` runs only Phase 2.E behavioral fixtures (for the 6 UI/security skills targeted by D1).
+- `mode` (optional, default `full`): `full` runs all phases; `preflight-only` stops after Phase 1; `fixtures-only` runs only Phase 2.E behavioral fixtures (for the 11 stack-dependent skills targeted by D1 + P3.2 — canonical list in `SKILLS_INVENTORY.md § Behavioral fixture targets`).
 
 ## Supporting documents (load order at cycle-start)
 
@@ -102,7 +102,7 @@ If `tier:all`: load every tier variant, produce a column-by-column diff artifact
 
 Present findings to user. For multi-option review questions, ALWAYS use `AskUserQuestion` tool - never inline prose.
 
-### 2.E - Behavioral fixtures _(only for 6 targeted skills per D1: ui-audit, visual-audit, accessibility-audit, security-audit, api-design, migration-audit)_
+### 2.E - Behavioral fixtures _(only for 11 stack-dependent skills per D1 + P3.2 — canonical list in `SKILLS_INVENTORY.md § Behavioral fixture targets`)_
 
 - 3 representative cases: run the skill, record output, verify expected severity labels.
 - 2 adversarial cases: craft input that should trip the skill; verify skill catches it.
@@ -186,6 +186,21 @@ Procedure per `CALIBRATION_KIT.md §4`:
 5. Major drift → run `CALIBRATION_KIT.md §5` recalibration before next skill.
 
 Log outcome in `DRIFT_LOG.md` (create if absent).
+
+---
+
+## Phase 10 - Final mechanical sweep _(portfolio-level, cycle closure)_
+
+Trigger: after Phase 6 GO on the last skill of the cycle, before declaring cycle CLOSED.
+
+Procedure per `REVIEW_FRAMEWORK.md §Phase 10` (mechanical-only — no MITL, no LLM jury, no walkthrough):
+
+1. Treat final `REVIEW_FRAMEWORK.md` + `SPEC_SNAPSHOT.md` as authoritative — the version that ships.
+2. For each of the 17 reviewed skills, re-run **Phase 1 only** against the final spec (the 8-step preflight table). Skip Phase 2-6.
+3. Emit consolidated report at `outputs/phase10-drift-sweep-<YYYY-MM-DD>.md` with a 17 × 8 PASS\|FAIL grid.
+4. Any FAIL row → log as follow-up review item for next cycle (e.g. in `MEMORY.md` or roadmap backlog). Do NOT block closure, do NOT auto-fix, do NOT re-escalate severity.
+
+Rationale: pipeline hardening lands progressively during the cycle. Skills reviewed early are calibrated to an earlier framework version. Phase 9 catches mid-cycle drift on the first 3 skills only; without Phase 10, late-cycle hardening creates silent residual drift on early-cycle skills.
 
 ---
 

--- a/packages/cli/templates/tier-l/.claude/skills/skill-review/SKILLS_INVENTORY.md
+++ b/packages/cli/templates/tier-l/.claude/skills/skill-review/SKILLS_INVENTORY.md
@@ -99,18 +99,23 @@ Skills with 2 or 3 tier variants. Review approach per framework v1.2 Phase 2.B: 
 
 ---
 
-## Behavioral fixture targets (per D1: targeted)
+## Behavioral fixture targets (per D1 + P3.2)
 
-Framework v1.2 D1 decision: T2.1 behavioral fixtures applied to 6 UI/security skills where textual correctness is insufficient to catch known defect classes.
+Framework v1.2 D1 + P3.2 (cross-LLM synthesis 2026-04-29) decision: T2.1 behavioral fixtures applied to **11 stack-dependent skills** where textual correctness is insufficient to catch known defect classes. P3.2 expands the original 6-skill D1 set with 5 stack-dependent skills previously excluded (perf-audit, responsive-audit, test-audit, ux-audit, skill-db) — same rationale, same procedure.
 
-| Target skill | Rationale |
-|---|---|
-| ui-audit | stack-specific literals (e.g. system colors flagged as hardcoded) prove literal-correctness misses stack-sensitive defects |
-| visual-audit | subjective scoring (10 aesthetic dimensions) prone to domain-emotion labeling |
-| accessibility-audit | axe-core rule interpretation is judgment-heavy; false positives on hidden elements |
-| security-audit | false-negative risk highest (missed invariant violation) - hard invariants need fixture confirmation |
-| api-design | invocation context sensitivity (runs on routes that may not exist in all stacks) |
-| migration-audit | destructive-op severity depends on deployment model; fixtures pin expected labels |
+| Target skill | Rationale | Source |
+|---|---|---|
+| ui-audit | stack-specific literals (e.g. system colors flagged as hardcoded) prove literal-correctness misses stack-sensitive defects | D1 |
+| visual-audit | subjective scoring (10 aesthetic dimensions) prone to domain-emotion labeling | D1 |
+| accessibility-audit | axe-core rule interpretation is judgment-heavy; false positives on hidden elements | D1 |
+| responsive-audit | breakpoint behavior is browser-specific; fixtures pin expected viewport-handling at 375/768/1024 | P3.2 |
+| ux-audit | Nielsen heuristics interpretation is judgment-heavy; fixtures anchor task-completion + cognitive-load measurements | P3.2 |
+| security-audit | false-negative risk highest (missed invariant violation) - hard invariants need fixture confirmation | D1 |
+| api-design | invocation context sensitivity (runs on routes that may not exist in all stacks) | D1 |
+| migration-audit | destructive-op severity depends on deployment model; fixtures pin expected labels | D1 |
+| perf-audit | mode dispatch (web bundle / native I/O) is stack-conditional; fixtures validate each mode path | P3.2 |
+| test-audit | coverage parser auto-detects lcov/Istanbul/Cobertura/go/tarpaulin/xcresult — fixtures validate each parser path | P3.2 |
+| skill-db | live SQL verification with dialect-specific queries (Postgres / SQLite / MongoDB); fixtures pin expected reports per dialect | P3.2 |
 
 Per skill: 3 representative cases + 2 adversarial + 1 contamination probe + 1 severity-calibration case.
 
@@ -120,17 +125,17 @@ Per skill: 3 representative cases + 2 adversarial + 1 contamination probe + 1 se
 
 Framework v1.2 recommends the following sequence. Rationale: start with the skill that produced the motivating defect (ui-audit, Color.red), cross-tier families reviewed together, single-tier last.
 
-1. **ui-audit** (M + L) - motivating defect, behavioral fixtures required
-2. **visual-audit** (M + L) - behavioral fixtures required
-3. **accessibility-audit** (M + L) - behavioral fixtures required
-4. **responsive-audit** (M + L) - UI family closure
-5. **ux-audit** (M + L) - UI family closure
-6. **security-audit** (S + M + L) - behavioral fixtures required
-7. **api-design** (M + L) - behavioral fixtures required
-8. **migration-audit** (M + L) - behavioral fixtures required
-9. **skill-db** (M + L) - **Phase 9 midpoint drift check triggers after this skill**
-10. **test-audit** (M + L)
-11. **perf-audit** (S + M + L)
+1. **ui-audit** (M + L) - motivating defect, behavioral fixtures required (D1)
+2. **visual-audit** (M + L) - behavioral fixtures required (D1)
+3. **accessibility-audit** (M + L) - behavioral fixtures required (D1)
+4. **responsive-audit** (M + L) - behavioral fixtures required (P3.2)
+5. **ux-audit** (M + L) - behavioral fixtures required (P3.2)
+6. **security-audit** (S + M + L) - behavioral fixtures required (D1)
+7. **api-design** (M + L) - behavioral fixtures required (D1)
+8. **migration-audit** (M + L) - behavioral fixtures required (D1)
+9. **skill-db** (M + L) - behavioral fixtures required (P3.2); **Phase 9 midpoint drift check triggers after this skill**
+10. **test-audit** (M + L) - behavioral fixtures required (P3.2)
+11. **perf-audit** (S + M + L) - behavioral fixtures required (P3.2)
 12. **arch-audit** (S + M + L) - **freeze cutoff: after this skill, only Critical principles enter current cycle**
 13. **skill-dev** (S + M + L)
 14. **dependency-scan** (M + L)

--- a/packages/cli/templates/tier-m/.claude/skills/skill-review/REVIEW_FRAMEWORK.md
+++ b/packages/cli/templates/tier-m/.claude/skills/skill-review/REVIEW_FRAMEWORK.md
@@ -155,7 +155,7 @@ After skill #12 (of 17), only Criticals under rule (c) enter current cycle. All 
 
 ## Per-skill pipeline
 
-Six phases per skill + Phase 9 midpoint (runs once across cycle).
+Six phases per skill + Phase 9 midpoint (mid-cycle) + Phase 10 final mechanical sweep (cycle closure).
 
 ### Phase 1 - Mechanical preflight
 
@@ -176,7 +176,24 @@ Checks:
    A match is flagged unless adjacent to a non-web context clause (`or equivalent`, `[web only]`, `if applicable`, `if the project has`). Output: list of unguarded matches per term. Feeds Phase 2.A (d)+(e) for human judgment on each candidate.
 8. **Reference file coverage check (stack-dependent skills only)** - for each check ID found in the body (grep pattern: `\*\*[A-Z][0-9]\+`), verify the same ID appears in the reference file (e.g., `PATTERNS.md`). Each missing ID = High candidate (skill silently provides no guidance for that check on any stack variant lacking coverage). Stack-agnostic skills: skip.
 
-**Fail handling**: Critical findings block Phase 2. Fixed in Phase 3.
+**Fail handling**: any FAIL row blocks Phase 2 entry per the Phase 1 → Phase 2 mechanical gate below. Critical findings route through Phase 3 first.
+
+#### Phase 1 → Phase 2 mechanical gate *(P3.1 — prevents Stage A drift to Stage B)*
+
+Before Phase 2 begins, emit a PASS/FAIL table over the 8 Phase 1 steps. Phase 2 MUST NOT start until every row reads PASS. A FAIL row routes findings through Phase 3 first; once fixed, re-run Phase 1 from step 1 and re-emit the table. The reviewer cannot mark a row PASS by judgment alone — each step has a mechanical verification (grep result, `wc -l` output, file existence, integration test count).
+
+| Step | Check | Status | Evidence required |
+|---|---|---|---|
+| 1 | Anthropic spec compliance (P1 C1-C8) | PASS\|FAIL | C1-C8 result table |
+| 2 | Line count ≤ 500 | PASS\|FAIL | `wc -l SKILL.md` |
+| 3 | Registry ↔ body coherence | PASS\|FAIL | grep diff vs `skill-registry.js` |
+| 4 | Allowed-tools ↔ body instructions | PASS\|FAIL | capability keyword grep |
+| 5 | Placeholder resolution | PASS\|FAIL | `[PLACEHOLDER]` token scan |
+| 6 | Model ↔ complexity alignment | PASS\|FAIL | line count + subagent heuristic |
+| 7 | Architectural + paradigm vocabulary scan (forms 4+5) | PASS\|FAIL | unguarded-match list |
+| 8 | Reference file coverage check (stack-dependent only) | PASS\|FAIL | check ID match across files |
+
+***** STOP - Phase 1 → Phase 2 gate. Phase 2 entry requires 100% PASS in the table above. Reviewer judgment cannot override a FAIL row. *****
 
 ### Phase 2 - Internal analysis + walkthrough
 
@@ -232,11 +249,11 @@ Grouped by gravity. 2.A/2.B/2.C autonomous; 2.D interactive; 2.E targeted on hig
 
 ***** STOP - cross-tier diff approval. Wait for execution keyword before Phase 2.E or Phase 3. *****
 
-#### 2.E - Behavioral fixtures *(D1 - targeted, 6 skills only)*
+#### 2.E - Behavioral fixtures *(D1 + P3.2 - targeted, 11 stack-dependent skills)*
 
-**Applies to**: ui-audit, visual-audit, ux-audit, responsive-audit, accessibility-audit, security-audit.
-**Rationale**: these skills have the highest false-positive / behavioral-drift risk (browser-based, pattern-heavy, subjective).
-**Skipped for**: all other 11 skills (document-audit sufficient).
+**Applies to**: ui-audit, visual-audit, accessibility-audit, responsive-audit, ux-audit, security-audit, api-design, migration-audit, perf-audit, test-audit, skill-db. Canonical list in `SKILLS_INVENTORY.md § Behavioral fixture targets`.
+**Rationale**: these 11 skills are stack-dependent — their checks vary by stack (web/native/CLI), depend on stack-conditional dispatch, or run live verification whose output differs by dialect/runtime. Textual correctness alone cannot catch known defect classes (false-positive on system colors, dialect-specific SQL, parser-format mismatch, viewport behavior).
+**Skipped for**: the other 6 skills (arch-audit, commit, context-review, dependency-scan, simplify, skill-dev) which are stack-agnostic — textual review is sufficient.
 
 **Procedure**:
 1. Define fixture pack per skill:
@@ -336,19 +353,43 @@ Same scrutiny as Phase 2 findings. **Emerging principle capture (O4)**: if a Pha
 
 **Fail handling**: if drift detected and unresolvable (calibration set itself ambiguous), pause cycle, update P5, user decides alignment direction.
 
+### Phase 10 - Final mechanical sweep *(new P3.3, cycle closure, portfolio-level)*
+
+**When**: after Phase 6 GO on the last skill of the cycle, before declaring cycle CLOSED per `## Review closing criterion`.
+**Executor**: Claude (mechanical-only, no MITL, no LLM jury, no walkthrough).
+**Input**: final-state `REVIEW_FRAMEWORK.md` + final-state `SPEC_SNAPSHOT.md` (authoritative reference at cycle close) + all 17 reviewed skills on disk.
+
+**Rationale (CC6)**: pipeline hardening commits (e.g. P1.1, P1.2, P1.3, P2, P3.1 of this same cycle) land progressively during the cycle. Skills reviewed early in the cycle were calibrated against an earlier pipeline version. Without this sweep, those skills retain residual drift against the final pipeline definition that ships with the release — the drift is invisible at midpoint (Phase 9 only scores the first 3 skills) and accumulates across cycles.
+
+**Procedure**:
+1. Read final `REVIEW_FRAMEWORK.md` and `SPEC_SNAPSHOT.md` as authoritative — these are the version that ships, not the version any individual skill was originally reviewed against.
+2. For each of the 17 reviewed skills, re-run **Phase 1 only** (the 8-step mechanical preflight). Do not re-run Phase 2 (walkthrough), Phase 3 (fixes), Phase 4 (LLM jury), or Phase 9 (drift). This sweep is preflight-only.
+3. Emit one consolidated report at `outputs/phase10-drift-sweep-<YYYY-MM-DD>.md` with a 17 × 8 PASS\|FAIL grid (skills × Phase 1 steps).
+4. **Any FAIL row → open a follow-up review item for next cycle** (e.g. record in `MEMORY.md` or roadmap backlog). Do NOT block current cycle closeout. Do NOT auto-fix. Do NOT escalate severity from the original review.
+
+**Output**: drift-sweep report + 0 or more follow-up items for next cycle.
+
+**Why preflight-only (not full Phase 1-6 re-run)**:
+- Phase 2 walkthrough and Phase 3 fixes are MITL — re-running on 17 skills would cost the same as a full second cycle.
+- Phase 1 mechanical steps catch the most common drift modes (frontmatter syntax updates, line-budget changes, registry/inventory drift, allowed-tools spec changes, placeholder grammar).
+- Anything Phase 1 cannot catch (semantic / behavioral drift) goes into the next cycle's normal Phase 2-3 flow — the follow-up item ensures it isn't lost.
+
+**Fail handling**: this phase cannot itself fail. A FAIL row is data, not a blocker. The cycle still CLOSES; the follow-up item carries the drift into the next cycle as input.
+
 ---
 
 ## Interactive decision points (man-in-the-loop)
 
 1. **Post-pre-work**: confirm P1, P2, P3, P4, P5 sequentially.
-2. **Phase 2.D #13**: per Anthropic opportunity, apply/roadmap/ignore.
-3. **Phase 2.D #14**: section-by-section walkthrough.
-4. **Phase 2.D #15 (C6)**: cross-tier diff approval (multi-tier skills only).
-5. **Phase 3 step 2**: confirm findings to apply before fixes.
-6. **Phase 3 → Phase 4 STOP (C7)**: approve fix diff before external LLMs.
-7. **Phase 5 confirmation**: confirm LLM finding fixes.
-8. **Phase 6 GO**: explicit authorization to proceed.
-9. **Phase 9 (D2)**: drift check resolution if drift detected.
+2. **Phase 1 → Phase 2 gate (P3.1)**: confirm 100% PASS on the 8-step mechanical table before Phase 2 starts. A FAIL row cannot be waived.
+3. **Phase 2.D #13**: per Anthropic opportunity, apply/roadmap/ignore.
+4. **Phase 2.D #14**: section-by-section walkthrough.
+5. **Phase 2.D #15 (C6)**: cross-tier diff approval (multi-tier skills only).
+6. **Phase 3 step 2**: confirm findings to apply before fixes.
+7. **Phase 3 → Phase 4 STOP (C7)**: approve fix diff before external LLMs.
+8. **Phase 5 confirmation**: confirm LLM finding fixes.
+9. **Phase 6 GO**: explicit authorization to proceed.
+10. **Phase 9 (D2)**: drift check resolution if drift detected.
 
 All other steps autonomous once corresponding gate is open.
 
@@ -361,7 +402,7 @@ Each skill review produces:
 - Decision log for opportunities (apply/roadmap/ignore with rationale).
 - Updated SKILL.md.
 - Updated integration test count.
-- **If in 6-skill fixture set (D1)**: fixture pack + expected/actual outputs.
+- **If in 11-skill stack-dependent fixture set (D1 + P3.2)**: fixture pack + expected/actual outputs.
 - Optional: roadmap entries in MEMORY.md.
 - **If emerging principle (O4)**: auto-memory feedback entry + framework amendment.
 
@@ -380,9 +421,10 @@ Cycle CLOSED only when ALL hold:
 5. Integration tests green on final state.
 6. Release note summarizing the cycle drafted (blocks affected, principles captured, severity mapping changes, behavioral fixture results).
 7. **Phase 9 midpoint drift check (D2)** executed and resolved.
-8. **All behavioral fixtures on 6-skill target (D1)** green.
+8. **All behavioral fixtures on 11-skill stack-dependent target (D1 + P3.2)** green.
+9. **Phase 10 final mechanical sweep (P3.3)** executed; the 17 × 8 drift-sweep report exists at `outputs/phase10-drift-sweep-<date>.md`. FAIL rows do NOT block closure but MUST be logged as follow-up items for the next cycle (the sweep itself is not allowed to be silently skipped).
 
-Until all eight hold, cycle OPEN. No version bump claiming "skills quality-reviewed" can ship.
+Until all nine hold, cycle OPEN. No version bump claiming "skills quality-reviewed" can ship.
 
 ---
 

--- a/packages/cli/templates/tier-m/.claude/skills/skill-review/SKILL.md
+++ b/packages/cli/templates/tier-m/.claude/skills/skill-review/SKILL.md
@@ -10,7 +10,7 @@ allowed-tools: Read Glob Grep Bash
 
 You are a skill-quality reviewer running the framework v1.2 pipeline in **lite mode** (Tier M). Your job: orchestrate a focused review for small portfolios, enforce STOP gates, keep findings rubric-anchored. You produce findings - you do not silently fix. Fixes happen in Phase 3 after explicit user Go.
 
-**Lite mode vs full mode**: Tier M skips Phase 4 (external LLM review) and Phase 9 (midpoint drift check) because both add overhead that is not justified for portfolios under 6 skills. If your portfolio exceeds 5 skills, upgrade to Tier L and use the full-mode variant.
+**Lite mode vs full mode**: Tier M skips Phase 4 (external LLM review), Phase 9 (midpoint drift check), and Phase 10 (final mechanical sweep) because all three add overhead that is not justified for portfolios under 6 skills. If your portfolio exceeds 5 skills, upgrade to Tier L and use the full-mode variant.
 
 ## Arguments
 

--- a/packages/cli/templates/tier-m/.claude/skills/skill-review/SKILLS_INVENTORY.md
+++ b/packages/cli/templates/tier-m/.claude/skills/skill-review/SKILLS_INVENTORY.md
@@ -99,18 +99,23 @@ Skills with 2 or 3 tier variants. Review approach per framework v1.2 Phase 2.B: 
 
 ---
 
-## Behavioral fixture targets (per D1: targeted)
+## Behavioral fixture targets (per D1 + P3.2)
 
-Framework v1.2 D1 decision: T2.1 behavioral fixtures applied to 6 UI/security skills where textual correctness is insufficient to catch known defect classes.
+Framework v1.2 D1 + P3.2 (cross-LLM synthesis 2026-04-29) decision: T2.1 behavioral fixtures applied to **11 stack-dependent skills** where textual correctness is insufficient to catch known defect classes. P3.2 expands the original 6-skill D1 set with 5 stack-dependent skills previously excluded (perf-audit, responsive-audit, test-audit, ux-audit, skill-db) — same rationale, same procedure.
 
-| Target skill | Rationale |
-|---|---|
-| ui-audit | stack-specific literals (e.g. system colors flagged as hardcoded) prove literal-correctness misses stack-sensitive defects |
-| visual-audit | subjective scoring (10 aesthetic dimensions) prone to domain-emotion labeling |
-| accessibility-audit | axe-core rule interpretation is judgment-heavy; false positives on hidden elements |
-| security-audit | false-negative risk highest (missed invariant violation) - hard invariants need fixture confirmation |
-| api-design | invocation context sensitivity (runs on routes that may not exist in all stacks) |
-| migration-audit | destructive-op severity depends on deployment model; fixtures pin expected labels |
+| Target skill | Rationale | Source |
+|---|---|---|
+| ui-audit | stack-specific literals (e.g. system colors flagged as hardcoded) prove literal-correctness misses stack-sensitive defects | D1 |
+| visual-audit | subjective scoring (10 aesthetic dimensions) prone to domain-emotion labeling | D1 |
+| accessibility-audit | axe-core rule interpretation is judgment-heavy; false positives on hidden elements | D1 |
+| responsive-audit | breakpoint behavior is browser-specific; fixtures pin expected viewport-handling at 375/768/1024 | P3.2 |
+| ux-audit | Nielsen heuristics interpretation is judgment-heavy; fixtures anchor task-completion + cognitive-load measurements | P3.2 |
+| security-audit | false-negative risk highest (missed invariant violation) - hard invariants need fixture confirmation | D1 |
+| api-design | invocation context sensitivity (runs on routes that may not exist in all stacks) | D1 |
+| migration-audit | destructive-op severity depends on deployment model; fixtures pin expected labels | D1 |
+| perf-audit | mode dispatch (web bundle / native I/O) is stack-conditional; fixtures validate each mode path | P3.2 |
+| test-audit | coverage parser auto-detects lcov/Istanbul/Cobertura/go/tarpaulin/xcresult — fixtures validate each parser path | P3.2 |
+| skill-db | live SQL verification with dialect-specific queries (Postgres / SQLite / MongoDB); fixtures pin expected reports per dialect | P3.2 |
 
 Per skill: 3 representative cases + 2 adversarial + 1 contamination probe + 1 severity-calibration case.
 
@@ -120,17 +125,17 @@ Per skill: 3 representative cases + 2 adversarial + 1 contamination probe + 1 se
 
 Framework v1.2 recommends the following sequence. Rationale: start with the skill that produced the motivating defect (ui-audit, Color.red), cross-tier families reviewed together, single-tier last.
 
-1. **ui-audit** (M + L) - motivating defect, behavioral fixtures required
-2. **visual-audit** (M + L) - behavioral fixtures required
-3. **accessibility-audit** (M + L) - behavioral fixtures required
-4. **responsive-audit** (M + L) - UI family closure
-5. **ux-audit** (M + L) - UI family closure
-6. **security-audit** (S + M + L) - behavioral fixtures required
-7. **api-design** (M + L) - behavioral fixtures required
-8. **migration-audit** (M + L) - behavioral fixtures required
-9. **skill-db** (M + L) - **Phase 9 midpoint drift check triggers after this skill**
-10. **test-audit** (M + L)
-11. **perf-audit** (S + M + L)
+1. **ui-audit** (M + L) - motivating defect, behavioral fixtures required (D1)
+2. **visual-audit** (M + L) - behavioral fixtures required (D1)
+3. **accessibility-audit** (M + L) - behavioral fixtures required (D1)
+4. **responsive-audit** (M + L) - behavioral fixtures required (P3.2)
+5. **ux-audit** (M + L) - behavioral fixtures required (P3.2)
+6. **security-audit** (S + M + L) - behavioral fixtures required (D1)
+7. **api-design** (M + L) - behavioral fixtures required (D1)
+8. **migration-audit** (M + L) - behavioral fixtures required (D1)
+9. **skill-db** (M + L) - behavioral fixtures required (P3.2); **Phase 9 midpoint drift check triggers after this skill**
+10. **test-audit** (M + L) - behavioral fixtures required (P3.2)
+11. **perf-audit** (S + M + L) - behavioral fixtures required (P3.2)
 12. **arch-audit** (S + M + L) - **freeze cutoff: after this skill, only Critical principles enter current cycle**
 13. **skill-dev** (S + M + L)
 14. **dependency-scan** (M + L)


### PR DESCRIPTION
## Summary

- Closes Q3 #10e (issue #132): skill-review pipeline P3 process robustness
- Three sub-tracks shipped from the cross-LLM meta-review of the pipeline (`docs/reviews/2026-04-29-pipeline-meta/synthesis.md`):
  - **P3.1 (CC5)** — mechanical Phase 1 → Phase 2 gate: 8-step PASS|FAIL table, no judgment override
  - **P3.2 (CC7)** — behavioral fixture targets expanded from 6 to 11 stack-dependent skills
  - **P3.3 (CC6)** — Phase 10 final mechanical sweep at cycle closure
- Version bump to v1.28.0

## Files changed

- **Templates** (6, strict parity tier-M ↔ tier-L): `REVIEW_FRAMEWORK.md`, `SKILLS_INVENTORY.md`, `SKILL.md`
- **Docs** (3): `CHANGELOG.md`, `README.md`, `docs/operational-guide.md`
- **Manifest** (1): `packages/cli/package.json` → 1.28.0

## Test plan

- [x] Integration tests: 1132/1132 pass (`npm test` in `packages/cli/`)
- [x] Unit tests: 554/554 pass (`npm run test:unit`)
- [x] Tier-M ↔ tier-L parity: `diff` empty on `REVIEW_FRAMEWORK.md` and `SKILLS_INVENTORY.md`
- [ ] CI green on PR (Lint, Unit 22+24, Integration 22+24, Verify CLI 22+24, Drift tracker, CodeQL Actions + JS/TS)

## Acceptance criteria (from #132)

- [x] **CC5** — Stage A→B mechanical gate. Mapped to the shipped `Phase 1 → Phase 2` boundary; the 8-step PASS|FAIL table replaces the prior informal "Critical findings block Phase 2" guidance.
- [x] **CC7** — `SKILLS_INVENTORY § Behavioral fixture targets` now lists 11 skills. The pre-existing internal mismatch between `REVIEW_FRAMEWORK.md` (which listed a different set of 6) and the inventory is resolved too: the canonical list lives in the inventory, referenced elsewhere.
- [x] **CC6** — "Final mechanical sweep" added as Phase 10 (post-Phase 9 midpoint). Mechanical-only, no MITL, no LLM jury; FAIL rows log follow-ups for the next cycle and do not block current closeout.

## Vocabulary note

The synthesis used Stage A/B, Phase 1b, C1-C14, MITL stop #1 from the meta-review prompt bundle. The shipped framework keeps its existing Phase 1/2/.../9/10 and C1-C8 vocabulary — gate and fixture-set changes map to the shipped names rather than being imported wholesale. No double-vocabulary debt introduced.

## Risk

Low. All changes are markdown templates and docs; no JS source touched. Test suite green (1132 + 554). Strict tier-M ↔ tier-L parity holds on the two canonical normative files. Phase 10 is opt-in for full-mode (tier-L) and explicitly skipped in lite-mode (tier-M) alongside the existing Phase 4 and Phase 9 skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)