### PR TITLE
ci(github): security baseline — Dependabot grouping + OpenSSF Scorecard

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,13 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+        update-types: ["minor", "patch"]
+      prod-minor-patch:
+        dependency-type: "production"
+        update-types: ["minor", "patch"]
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -16,3 +23,7 @@ updates:
       interval: "monthly"
     labels:
       - "dependencies"
+    groups:
+      actions:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,44 @@
+name: Scorecard supply-chain security
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "0 5 * * 1"
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Node.js >= 22](https://img.shields.io/badge/node-%3E%3D22-brightgreen.svg)](https://nodejs.org)
 [![CI](https://github.com/marcoguillermaz/claude-dev-kit/actions/workflows/ci.yml/badge.svg)](https://github.com/marcoguillermaz/claude-dev-kit/actions/workflows/ci.yml)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/marcoguillermaz/claude-dev-kit/badge)](https://securityscorecards.dev/viewer/?uri=github.com/marcoguillermaz/claude-dev-kit)
 
 > Scaffold for legible, reviewable AI-assisted development.
 > Claude generates. Your team decides.


### PR DESCRIPTION
## Summary
- `dependabot.yml`: raggruppa minor/patch in `dev-dependencies` (devDeps) e `prod-minor-patch` (prod) per `/packages/cli`, e tutte le minor/patch in `actions` per i workflow. Le major restano singole.
- Nuovo workflow `scorecard.yml`: analisi OpenSSF Scorecard schedulata (cron lunedì 05:00 UTC) + trigger su push su main e `branch_protection_rule`. Permessi minimi, upload SARIF a code-scanning, risultati pubblicati su securityscorecards.dev. Nessun PAT — alcuni check resteranno `Inconclusive`.
- README: badge Scorecard accanto a CI.

Cambiamenti correlati fuori da questa PR (già applicati):
- Private vulnerability reporting abilitato sul repo via API.

## Test plan
- [ ] CI verde su tutti i 5 required checks.
- [ ] Il workflow Scorecard parte dopo il merge su main e produce un SARIF visibile in Security → Code scanning.
- [ ] Dopo il primo run pubblicato, il badge nel README mostra un punteggio.
- [ ] Le prossime PR Dependabot sono raggruppate secondo la nuova policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)