### PR TITLE
ci(github): npm publish workflow via Trusted Publisher OIDC + provenance

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,32 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: npm-publish
+    defaults:
+      run:
+        working-directory: packages/cli
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - run: npm ci
+
+      - run: npm test
+
+      - name: Publish with provenance
+        run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary
- Nuovo workflow `.github/workflows/npm-publish.yml`: pubblica `mg-claude-dev-kit` su npm con `--provenance --access public`. Trigger su `release: published` (raccomandato) + `workflow_dispatch` come fallback manuale.
- Auth via **npm Trusted Publisher (OIDC)**: nessun `NPM_TOKEN` da gestire, nessun secret long-lived.
- Workflow scoped all'environment `npm-publish` (creato in parallelo, deployment branch policy: protected branches).
- Run prima di pubblicare: `npm ci` + `npm test`.

## ⚠️ Setup esterno richiesto prima del primo publish
Per far funzionare il workflow, configura il Trusted Publisher su npmjs.com:
1. Vai su https://www.npmjs.com/package/mg-claude-dev-kit/access
2. Sezione **Trusted publishers** → Add → GitHub Actions
3. Compila:
   - Owner: `marcoguillermaz`
   - Repository: `claude-dev-kit`
   - Workflow filename: `npm-publish.yml`
   - Environment: `npm-publish`
4. Save.

Senza questo step il publish fallirà con `ENEEDAUTH`.

## Disallineamento versione attuale
`packages/cli/package.json` è a `1.28.0`, npm registry è fermo a `1.27.0` (publish manuale saltato). Dopo il merge e il setup del Trusted Publisher puoi scegliere:
- `workflow_dispatch` per pubblicare `1.28.0` retroattivamente, oppure
- bump a `1.29.0` + GitHub Release: il workflow parte da solo.

## Test plan
- [ ] CI verde sui 5 required checks (il publish job NON parte su PR, solo su release/dispatch).
- [ ] Dopo merge + setup Trusted Publisher, `workflow_dispatch` pubblica con successo e npmjs mostra "Provenance" verificata sulla pagina del package.
- [ ] L'environment `npm-publish` registra il deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)