### PR TITLE
ci(github): enable workflow_dispatch for Scorecard manual runs

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -6,6 +6,7 @@ on:
     - cron: "0 5 * * 1"
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions: read-all
 


### PR DESCRIPTION
## Summary
- Aggiunge `workflow_dispatch:` ai trigger del workflow `scorecard.yml`.
- Sblocca l'esecuzione manuale via `gh workflow run scorecard.yml` o dall'UI Actions.

## Perché
Il primo run di Scorecard non è mai partito automaticamente: i merge auto-merge usano `GITHUB_TOKEN`, che per design non triggera workflow `on: push`. Risultato: badge "invalid repo path" sul README, viewer "not found".

Con `workflow_dispatch` possiamo:
1. Triggerare manualmente subito dopo il merge per generare il primo report.
2. Riusare il trigger manuale ogni volta che serve forzare un refresh fuori dal cron settimanale.

## Test plan
- [ ] CI verde sui 5 required checks.
- [ ] Dopo merge, `gh workflow run scorecard.yml` (oppure UI Actions) avvia un run.
- [ ] Il run completa con success, carica SARIF in Security → Code scanning.
- [ ] Entro ~10 minuti il viewer su securityscorecards.dev mostra il report.
- [ ] Il badge nel README mostra il punteggio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)