### PR TITLE
feat(scripts): v1.29.0 — cross-LLM rubric automation (v1.1 P5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ scripts/*
 !scripts/lint-templates.mjs
 !scripts/external-review.mjs
 !scripts/external-review-bundle.mjs
+!scripts/cross-llm-rubric.mjs
 
 # Internal project management (not product docs)
 FIRST_SESSION.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,31 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.29.0] — 2026-05-20
+
+### Added
+
+- **Cross-LLM rubric automation for Context Builder** (closes v1.1 P5 from the reopened roadmap). The SHOULD PASS scoring on `CONTEXT.md` (locked 2026-05-07, run manually during the v1.0 pilot on 2026-05-11) now runs as a single command. Maintainer-side gate, not an end-user feature.
+  - `scripts/cross-llm-rubric.mjs` — fans out to the locked jury (`claude-opus-4-7` + `claude-sonnet-4-6` + `gemini-2.5-pro`), parses each response as JSON, aggregates per-criterion medians, applies the threshold (all medians ≥ 2 AND ≥ 80 % of criteria with median ≥ 2), writes `report.json` + `report.md` + raw responses.
+  - **Hard-fail policy.** Missing `ANTHROPIC_API_KEY` or `GEMINI_API_KEY` → exit 2 (config error, no models called). Any provider runtime error (network, 5xx, abort) → exit 1. Malformed JSON from one model does not abort the run: that model's missing criteria score 0 and the report flags `malformed: true`.
+  - **Provider extension.** `scripts/external-review.mjs` gains two Anthropic entries (`anthropic-opus` and `anthropic-sonnet`) so the locked jury can be invoked from there as well.
+  - **Calibration note.** The criteria were locked against schema v1 when only tier 0 / S were supported. v1.27.0 (2026-05-14) added tier M / L; A6 ("tier plausible") may discriminate less on M / L outputs and Q2 / Q3 do not yet reward acknowledgment of M / L feature flags. Re-calibrate the prompt template if M / L outputs become a routine target.
+
+### Changed
+
+- `packages/cli/test/cross-llm-rubric/prompt-template.md` — introduces a `{CRITERIA_LIST}` placeholder. The applicable criteria are now selected in code from `frontmatter.project.mode` (3 for greenfield, 12 for in-place / from-context) and injected into the prompt as an explicit list, rather than relying on the model to honor a "skip for greenfield" instruction.
+- `packages/cli/test/cross-llm-rubric/README.md` — rewritten for the automated flow; the manual pilot procedure is kept as a historical appendix.
+- `docs/operational-guide.md` — adds section 15d covering the rubric script, next to the existing template-coverage gates (15c).
+- `docs/reviews/context-builder-pilot-v1.md` — the automated script now resolves the pre-ship checklist item on locked-jury re-run.
+
+### Notes
+
+- 585/585 unit tests pass (+31 new tests for parsing, aggregation, threshold, and markdown rendering, all with mocked providers; no live LLM calls).
+- Maintainer-only surface: no new public CLI command, no new dependency in the user-installed package.
+- Closes v1.1 P5; P6 (stack adaptation post-scaffold) and P4 (persona-distribution telemetry, gated on ~1 month of adoption) remain open.
+
+---
+
 ## [1.28.0] — 2026-05-15
 
 ### Added

--- a/docs/operational-guide.md
+++ b/docs/operational-guide.md
@@ -25,6 +25,7 @@
 15. [Maintaining the scaffold](#15-maintaining-the-scaffold)
     15b. [Anthropic drift tracking](#15b-anthropic-drift-tracking)
     15c. [Template coverage tests (maintainer-only)](#15c-template-coverage-tests-maintainer-only)
+    15d. [Cross-LLM rubric for Context Builder (maintainer-only)](#15d-cross-llm-rubric-for-context-builder-maintainer-only)
 16. [Frequently asked questions](#16-frequently-asked-questions)
 
 ---
@@ -1371,6 +1372,27 @@ Pass `--json` to any of them for machine-readable output. Exit code is non-zero 
 The concept registry consumed by `cross-tier-lint.mjs` lives in `packages/cli/test/template-coverage/cross-tier-concepts.json`. When adding a new phase or normative paragraph that must remain aligned across tiers, update the registry before changing the templates. The lint will flag the mismatch until both sides agree.
 
 Strategy, cost-benefit, and the explicit decision on deferred approaches (LLM-based semantic eval, behavioral fixture testing): [docs/architecture/test-coverage-strategy.md](architecture/test-coverage-strategy.md).
+
+---
+
+## 15d. Cross-LLM rubric for Context Builder (maintainer-only)
+
+The Context Builder produces `CONTEXT.md` files that feed the rest of the scaffold. A deterministic schema validator covers structural correctness (16 MUST PASS criteria), but semantic quality (whether the description reflects reality, whether `tier.rationale` is non-tautological, whether inferred source files actually exist) requires human-level judgment. The cross-LLM rubric automates that judgment by asking three independent models to score each criterion 0-3, then aggregating by median.
+
+```bash
+node scripts/cross-llm-rubric.mjs \
+  --context path/to/CONTEXT.md \
+  --out path/to/output-dir/ \
+  [--repo-summary path/to/repo-summary.md]
+```
+
+Output: `report.json` (machine-readable), `report.md` (human-readable table), and `raw-<provider>.txt` for each model.
+
+The locked jury is `claude-opus-4-7` + `claude-sonnet-4-6` + `gemini-2.5-pro`. PASS requires all medians ≥ 2 **and** ≥ 80 % of criteria with median ≥ 2. The script hard-fails (exit 2) if `ANTHROPIC_API_KEY` or `GEMINI_API_KEY` is missing, and hard-fails at runtime (exit 1) on any provider network error; a model that responds with malformed JSON is penalised in scoring rather than crashing the run.
+
+This is a maintainer gate: run it before any release that touches `packages/cli/src/context-builder/**`, the schema, or prompt templates. End users do not run it; they get the deterministic MUST PASS via `npx mg-claude-dev-kit validate-context`.
+
+Full reference: `packages/cli/test/cross-llm-rubric/README.md`. Locked design in `memory/project_context_builder_rubric_v1.md`.
 
 ---
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mg-claude-dev-kit",
-  "version": "1.28.0",
+  "version": "1.29.0",
   "description": "Scaffold for legible, reviewable AI-assisted development",
   "type": "module",
   "bin": {

--- a/packages/cli/test/cross-llm-rubric/README.md
+++ b/packages/cli/test/cross-llm-rubric/README.md
@@ -1,44 +1,88 @@
-# Cross-LLM Rubric — Pilot Test v1 Execution
+# Cross-LLM rubric — SHOULD PASS scoring for CONTEXT.md
 
-Manual execution of the SHOULD PASS scoring against the rubric locked in
-`memory/project_context_builder_rubric_v1.md`.
+Automated execution of the rubric locked in
+`memory/project_context_builder_rubric_v1.md` (2026-05-07). Replaces the
+manual pilot procedure used at the v1.0 release.
 
-## Why manual in v1
+## When to run
 
-Lockedin scope freeze (`memory/project_context_builder_scope_v1.md`):
-automated cross-LLM scoring is deferred to v1.1. The v1 pilot is a
-one-time validation across 3 repos; manual cost ≈ 1h.
+Pre-release of any version that touches Context Builder, schema,
+prompt templates, or inference. Optional in CI on PRs that change
+`packages/cli/src/context-builder/**`.
 
-## How to run a pilot round
+This is a **maintainer-side gate**, not an end-user command. Users get
+the deterministic 16 MUST PASS via `validate-context`; the SHOULD PASS
+quality bar is the maintainer's responsibility.
 
-For each of the 3 target repos (see `memory/project_context_builder_pilot_v1.md`):
+## How to run
 
-1. Run `npx mg-claude-dev-kit context` in the repo to generate `CONTEXT.md`.
-2. Run `npx mg-claude-dev-kit doctor` (or use `validateContextFile()`) to
-   verify all 16 MUST PASS criteria are green.
-   - If any MUST fail → **REJECT**, fix and re-run.
-3. Copy the content of `CONTEXT.md` into the `{CONTEXT_MD_CONTENT}` slot of
-   `prompt-template.md`.
-4. For existing repos, prepare a `REPO_SUMMARY` (a few README excerpts +
-   `ls` tree, ~1-2 KB).
-5. Send the populated prompt to **3 models**:
-   - `claude-opus-4-7` (or latest Opus)
-   - `claude-sonnet-4-6`
-   - Gemini Pro (latest)
-6. For each criterion, take the **median** of the three scores.
-7. PASS iff:
-   - All medians ≥ 2 **AND**
-   - ≥ 80 % of applicable criteria have median ≥ 2
+```bash
+node scripts/cross-llm-rubric.mjs \
+  --context path/to/CONTEXT.md \
+  --out path/to/output-dir/ \
+  [--repo-summary path/to/repo-summary.md]
+```
 
-## Acceptance gate v1 release
+The script writes three files into `--out`:
 
-Locked: **3/3 PASS strict**.
+- `report.json` — machine-readable result (status, per-criterion median,
+  per-provider scores, malformed flags)
+- `report.md` — human-readable table
+- `raw-<provider>.txt` — raw model responses (debug)
 
-- 3/3 → release v1 GO
-- 2/3 → BLOCK, fix the failing repo
-- ≤ 1/3 → BLOCK + retrospective on schema / rubric
+### Required environment variables
 
-## Reporting
+Both must be set in `.env` at the repo root:
 
-Append per-repo results to `docs/reviews/context-builder-pilot-v1.md`
-(template provided).
+- `ANTHROPIC_API_KEY` — calls Opus + Sonnet
+- `GEMINI_API_KEY` — calls Gemini Pro
+
+Optional overrides:
+
+- `ANTHROPIC_OPUS_MODEL` (default `claude-opus-4-7`)
+- `ANTHROPIC_SONNET_MODEL` (default `claude-sonnet-4-6`)
+- `GEMINI_MODEL` (default `gemini-2.5-pro`)
+
+## Locked jury and threshold
+
+| Field               | Value                                                      |
+| ------------------- | ---------------------------------------------------------- |
+| Jury                | `claude-opus-4-7` + `claude-sonnet-4-6` + `gemini-2.5-pro` |
+| Aggregation         | Median per criterion across 3 models                       |
+| PASS                | All medians ≥ 2 **AND** ≥ 80 % of criteria with median ≥ 2 |
+| Greenfield criteria | Q1, Q2, Q3                                                 |
+| Existing criteria   | A1-A6 + Q1-Q3 + T1-T3                                      |
+
+## Hard-fail policy
+
+| Condition                                       | Exit code | Behavior                                                                             |
+| ----------------------------------------------- | --------- | ------------------------------------------------------------------------------------ |
+| Missing `ANTHROPIC_API_KEY` or `GEMINI_API_KEY` | 2         | Config error, no models called                                                       |
+| Provider runtime error (network, 5xx, abort)    | 1         | Run aborted, no report written                                                       |
+| Malformed JSON from one model                   | 0 / 1     | Run continues; that model's missing criteria score 0; report flags `malformed: true` |
+| Threshold not met                               | 1         | Report written, exit FAIL                                                            |
+| Threshold met                                   | 0         | Report written, exit PASS                                                            |
+
+Rationale: the locked jury means three models, not "up to three." A
+network failure on Opus makes the result non-equivalent to the locked
+gate, so the run fails. A model that responds with malformed JSON is a
+different failure mode: penalised in scoring, not blocking.
+
+## Calibration note
+
+The criteria were locked against schema v1 when only tier 0 / S were
+supported. v1.27.0 (2026-05-14) added tier M / L; criterion A6
+("tier plausible") may discriminate less on M / L outputs, and Q2 / Q3
+do not yet reward acknowledgment of M / L feature flags. Re-calibrate
+the prompt template if M / L outputs become a routine target. File as a
+follow-up against the rubric memo.
+
+## Historical: manual pilot procedure
+
+For reference only. The v1.0 pilot (2026-05-11, results in
+`docs/reviews/context-builder-pilot-v1.md`) was executed by hand: paste
+the populated `prompt-template.md` into three model UIs, copy scores,
+compute the median in a spreadsheet. Automation replaces this in v1.29.0.
+
+The original manual instructions are kept here to record what the design
+intended. New runs should use the automated script.

--- a/packages/cli/test/cross-llm-rubric/prompt-template.md
+++ b/packages/cli/test/cross-llm-rubric/prompt-template.md
@@ -44,9 +44,15 @@ Score only the criteria that apply (existing-only criteria are skipped for green
 {CONTEXT_MD_CONTENT}
 ```
 
-### Criteria to score
+### Criteria to score (filtered for this run)
 
-**Accuracy (existing only — skip for greenfield):**
+Score **only** the criteria below — they are pre-filtered for the mode of this `CONTEXT.md`. Return one entry per criterion id in the JSON. Omitting any criterion id is treated as score 0.
+
+{CRITERIA_LIST}
+
+Criterion reference (full set, for context):
+
+**Accuracy (existing only):**
 
 - A1: `project.name` corresponds to the real repo name
 - A2: `project.description` reflects the real purpose (not boilerplate)
@@ -61,7 +67,7 @@ Score only the criteria that apply (existing-only criteria are skipped for green
 - Q2: Body "What we are building" is coherent with the frontmatter
 - Q3: Body "Operational constraints" is specific (no boilerplate)
 
-**Inference traceability (existing only — skip for greenfield):**
+**Inference traceability (existing only):**
 
 - T1: `inference.source_files` lists files that really exist in the repo
 - T2: Confidence levels are reasonable (not all "high" without evidence)

--- a/packages/cli/test/unit/cross-llm-rubric.test.js
+++ b/packages/cli/test/unit/cross-llm-rubric.test.js
@@ -1,0 +1,326 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  GREENFIELD_CRITERIA,
+  EXISTING_CRITERIA,
+  CRITERION_LABELS,
+  parseArgs,
+  detectMode,
+  pickCriteriaForMode,
+  renderCriteriaList,
+  fillTemplate,
+  parseScores,
+  median,
+  aggregate,
+  renderMarkdownReport,
+} from '../../../../scripts/cross-llm-rubric.mjs';
+
+// ── parseArgs ─────────────────────────────────────────────────────────────
+
+describe('parseArgs', () => {
+  it('parses --context and --out', () => {
+    const a = parseArgs(['node', 'rubric.mjs', '--context', 'CONTEXT.md', '--out', 'out/']);
+    assert.equal(a.context, 'CONTEXT.md');
+    assert.equal(a.out, 'out/');
+  });
+
+  it('throws on missing --context', () => {
+    assert.throws(
+      () => parseArgs(['node', 'rubric.mjs', '--out', 'out/']),
+      /missing required --context/,
+    );
+  });
+
+  it('throws on missing --out', () => {
+    assert.throws(
+      () => parseArgs(['node', 'rubric.mjs', '--context', 'CONTEXT.md']),
+      /missing required --out/,
+    );
+  });
+
+  it('captures optional --repo-summary', () => {
+    const a = parseArgs([
+      'node',
+      'rubric.mjs',
+      '--context',
+      'CONTEXT.md',
+      '--out',
+      'out/',
+      '--repo-summary',
+      'summary.txt',
+    ]);
+    assert.equal(a['repo-summary'], 'summary.txt');
+  });
+});
+
+// ── detectMode ────────────────────────────────────────────────────────────
+
+describe('detectMode', () => {
+  it('extracts mode from valid frontmatter', () => {
+    const md = `---\nproject:\n  name: foo\n  mode: in-place\n---\nbody`;
+    assert.equal(detectMode(md), 'in-place');
+  });
+
+  it('handles quoted mode value', () => {
+    const md = `---\n  mode: 'greenfield'\n---\nbody`;
+    assert.equal(detectMode(md), 'greenfield');
+  });
+
+  it('throws when frontmatter is missing', () => {
+    assert.throws(() => detectMode('no frontmatter here'), /missing YAML frontmatter/);
+  });
+
+  it('throws when mode field is missing', () => {
+    const md = `---\nname: foo\n---\nbody`;
+    assert.throws(() => detectMode(md), /missing project\.mode/);
+  });
+});
+
+// ── pickCriteriaForMode ───────────────────────────────────────────────────
+
+describe('pickCriteriaForMode', () => {
+  it('returns 3 criteria for greenfield', () => {
+    assert.deepEqual(pickCriteriaForMode('greenfield'), GREENFIELD_CRITERIA);
+    assert.equal(pickCriteriaForMode('greenfield').length, 3);
+  });
+
+  it('returns 12 criteria for in-place', () => {
+    assert.deepEqual(pickCriteriaForMode('in-place'), EXISTING_CRITERIA);
+    assert.equal(pickCriteriaForMode('in-place').length, 12);
+  });
+
+  it('returns 12 criteria for from-context', () => {
+    assert.equal(pickCriteriaForMode('from-context').length, 12);
+  });
+
+  it('throws on unknown mode', () => {
+    assert.throws(() => pickCriteriaForMode('weird-mode'), /unknown project\.mode/);
+  });
+});
+
+// ── renderCriteriaList ────────────────────────────────────────────────────
+
+describe('renderCriteriaList', () => {
+  it('formats criteria with labels', () => {
+    const out = renderCriteriaList(['A1', 'Q1']);
+    assert.ok(out.includes(`A1: ${CRITERION_LABELS.A1}`));
+    assert.ok(out.includes(`Q1: ${CRITERION_LABELS.Q1}`));
+  });
+
+  it('emits one line per criterion', () => {
+    const out = renderCriteriaList(['A1', 'A2', 'A3']);
+    assert.equal(out.split('\n').length, 3);
+  });
+});
+
+// ── fillTemplate ──────────────────────────────────────────────────────────
+
+describe('fillTemplate', () => {
+  it('replaces all placeholders', () => {
+    const tpl = '{MODE} / {REPO_SUMMARY} / {CONTEXT_MD_CONTENT} / {CRITERIA_LIST}';
+    const out = fillTemplate({
+      template: tpl,
+      mode: 'in-place',
+      repoSummary: 'SUMMARY',
+      contextMd: 'CTX',
+      criteria: ['Q1'],
+    });
+    assert.ok(out.includes('in-place'));
+    assert.ok(out.includes('SUMMARY'));
+    assert.ok(out.includes('CTX'));
+    assert.ok(out.includes('Q1'));
+  });
+
+  it('falls back to placeholder text when repoSummary is empty', () => {
+    const tpl = '{REPO_SUMMARY}';
+    const out = fillTemplate({
+      template: tpl,
+      mode: 'greenfield',
+      repoSummary: '',
+      contextMd: '',
+      criteria: [],
+    });
+    assert.match(out, /greenfield/);
+  });
+});
+
+// ── parseScores ───────────────────────────────────────────────────────────
+
+describe('parseScores', () => {
+  const expected = ['Q1', 'Q2', 'Q3'];
+
+  it('parses raw JSON with scores wrapper', () => {
+    const raw = JSON.stringify({
+      scores: { Q1: { score: 3, comment: 'ok' }, Q2: { score: 2 }, Q3: { score: 1 } },
+    });
+    const out = parseScores(raw, expected);
+    assert.equal(out.Q1.score, 3);
+    assert.equal(out.Q1.comment, 'ok');
+    assert.equal(out.Q2.score, 2);
+    assert.equal(out.Q3.score, 1);
+  });
+
+  it('parses JSON inside ```json fence', () => {
+    const raw =
+      'Here is my scoring:\n```json\n{"scores":{"Q1":{"score":2},"Q2":{"score":3},"Q3":{"score":2}}}\n```\nDone.';
+    const out = parseScores(raw, expected);
+    assert.equal(out.Q1.score, 2);
+    assert.equal(out.Q2.score, 3);
+  });
+
+  it('parses JSON with leading prose via greedy extraction', () => {
+    const raw = 'Sure, here is my score.\n{"Q1":{"score":2},"Q2":{"score":2},"Q3":{"score":3}}\n';
+    const out = parseScores(raw, expected);
+    assert.equal(out.Q1.score, 2);
+    assert.equal(out.Q3.score, 3);
+  });
+
+  it('returns null on completely malformed input', () => {
+    assert.equal(parseScores('no json here at all', expected), null);
+    assert.equal(parseScores('', expected), null);
+    assert.equal(parseScores(null, expected), null);
+  });
+
+  it('rejects scores outside [0,3]', () => {
+    const raw = JSON.stringify({
+      scores: { Q1: { score: 5 }, Q2: { score: 2 }, Q3: { score: 3 } },
+    });
+    const out = parseScores(raw, expected);
+    assert.equal(out.Q1, undefined);
+    assert.equal(out.Q2.score, 2);
+  });
+
+  it('accepts plain numeric values (no wrapper object)', () => {
+    const raw = JSON.stringify({ scores: { Q1: 3, Q2: 2, Q3: 1 } });
+    const out = parseScores(raw, expected);
+    assert.equal(out.Q1.score, 3);
+    assert.equal(out.Q2.score, 2);
+    assert.equal(out.Q3.score, 1);
+  });
+});
+
+// ── median ────────────────────────────────────────────────────────────────
+
+describe('median', () => {
+  it('returns 0 on empty array', () => {
+    assert.equal(median([]), 0);
+  });
+
+  it('returns the middle value on odd-length arrays', () => {
+    assert.equal(median([1, 2, 3]), 2);
+    assert.equal(median([3, 1, 2]), 2);
+    assert.equal(median([1, 1, 1]), 1);
+  });
+
+  it('returns the average of middle values on even-length arrays', () => {
+    assert.equal(median([1, 3]), 2);
+    assert.equal(median([2, 3]), 2.5);
+  });
+});
+
+// ── aggregate ─────────────────────────────────────────────────────────────
+
+describe('aggregate', () => {
+  const allHigh = [
+    { name: 'opus', scores: { Q1: { score: 3 }, Q2: { score: 3 }, Q3: { score: 3 } } },
+    { name: 'sonnet', scores: { Q1: { score: 3 }, Q2: { score: 3 }, Q3: { score: 3 } } },
+    { name: 'gemini', scores: { Q1: { score: 3 }, Q2: { score: 3 }, Q3: { score: 3 } } },
+  ];
+
+  it('computes median per criterion and overall PASS when all >= 2', () => {
+    const out = aggregate({ criteria: ['Q1', 'Q2', 'Q3'], providerResults: allHigh });
+    assert.equal(out.status, 'PASS');
+    assert.equal(out.perCriterion.Q1.median, 3);
+    assert.equal(out.summary.all_above_two, true);
+    assert.equal(out.summary.percent_above_two, 100);
+  });
+
+  it('marks FAIL when one median drops below 2', () => {
+    const results = [
+      { name: 'opus', scores: { Q1: { score: 1 }, Q2: { score: 3 }, Q3: { score: 3 } } },
+      { name: 'sonnet', scores: { Q1: { score: 1 }, Q2: { score: 3 }, Q3: { score: 3 } } },
+      { name: 'gemini', scores: { Q1: { score: 2 }, Q2: { score: 3 }, Q3: { score: 3 } } },
+    ];
+    const out = aggregate({ criteria: ['Q1', 'Q2', 'Q3'], providerResults: results });
+    assert.equal(out.status, 'FAIL');
+    assert.equal(out.perCriterion.Q1.median, 1);
+    assert.equal(out.summary.all_above_two, false);
+  });
+
+  it('treats missing scores from a provider as 0', () => {
+    const results = [
+      { name: 'opus', scores: { Q1: { score: 3 }, Q2: { score: 3 }, Q3: { score: 3 } } },
+      { name: 'sonnet', scores: {} },
+      { name: 'gemini', scores: { Q1: { score: 3 }, Q2: { score: 3 }, Q3: { score: 3 } } },
+    ];
+    const out = aggregate({ criteria: ['Q1', 'Q2', 'Q3'], providerResults: results });
+    assert.equal(out.perCriterion.Q1.scores.sonnet, 0);
+    assert.equal(out.perCriterion.Q1.median, 3);
+  });
+
+  it('records per-provider scores in the per-criterion entry', () => {
+    const out = aggregate({ criteria: ['Q1'], providerResults: allHigh });
+    assert.deepEqual(out.perCriterion.Q1.scores, { opus: 3, sonnet: 3, gemini: 3 });
+  });
+});
+
+// ── renderMarkdownReport ─────────────────────────────────────────────────
+
+describe('renderMarkdownReport', () => {
+  it('produces markdown including status, table and provider models', () => {
+    const aggregation = aggregate({
+      criteria: ['Q1', 'Q2', 'Q3'],
+      providerResults: [
+        { name: 'opus', scores: { Q1: { score: 3 }, Q2: { score: 2 }, Q3: { score: 3 } } },
+        { name: 'sonnet', scores: { Q1: { score: 3 }, Q2: { score: 3 }, Q3: { score: 3 } } },
+        { name: 'gemini', scores: { Q1: { score: 2 }, Q2: { score: 2 }, Q3: { score: 3 } } },
+      ],
+    });
+    const providerResults = [
+      { name: 'opus', model: 'claude-opus-4-7', malformed: false },
+      { name: 'sonnet', model: 'claude-sonnet-4-6', malformed: false },
+      { name: 'gemini', model: 'gemini-2.5-pro', malformed: false },
+    ];
+    const md = renderMarkdownReport({
+      aggregation,
+      providerResults,
+      meta: {
+        generatedAt: '2026-05-20T00:00:00Z',
+        contextPath: '/tmp/CONTEXT.md',
+        mode: 'greenfield',
+      },
+    });
+    assert.match(md, /PASS/);
+    assert.match(md, /\| Criterion \|/);
+    assert.match(md, /claude-opus-4-7/);
+    assert.match(md, /claude-sonnet-4-6/);
+    assert.match(md, /gemini-2\.5-pro/);
+  });
+
+  it('flags malformed providers in the markdown', () => {
+    const aggregation = aggregate({
+      criteria: ['Q1'],
+      providerResults: [
+        { name: 'opus', scores: { Q1: { score: 3 } } },
+        { name: 'sonnet', scores: {} },
+        { name: 'gemini', scores: { Q1: { score: 2 } } },
+      ],
+    });
+    const providerResults = [
+      { name: 'opus', model: 'claude-opus-4-7', malformed: false },
+      { name: 'sonnet', model: 'claude-sonnet-4-6', malformed: true },
+      { name: 'gemini', model: 'gemini-2.5-pro', malformed: false },
+    ];
+    const md = renderMarkdownReport({
+      aggregation,
+      providerResults,
+      meta: {
+        generatedAt: '2026-05-20T00:00:00Z',
+        contextPath: '/tmp/CONTEXT.md',
+        mode: 'greenfield',
+      },
+    });
+    assert.match(md, /malformed JSON response from: sonnet/);
+  });
+});

--- a/scripts/cross-llm-rubric.mjs
+++ b/scripts/cross-llm-rubric.mjs
@@ -1,0 +1,575 @@
+#!/usr/bin/env node
+/**
+ * Cross-LLM rubric — automated SHOULD PASS scoring for CONTEXT.md.
+ *
+ * Locked jury (memory/project_context_builder_rubric_v1.md, 2026-05-07):
+ *   - claude-opus-4-7
+ *   - claude-sonnet-4-6
+ *   - gemini-2.5-pro
+ *
+ * Threshold (locked 2026-05-07):
+ *   - All criterion medians >= 2 AND
+ *   - >= 80% of criteria with median >= 2
+ *
+ * Hard-fail policy (locked 2026-05-20):
+ *   - Missing ANTHROPIC_API_KEY or GEMINI_API_KEY → exit 2 (config error)
+ *   - Any provider runtime error (network, 5xx, timeout, abort) → exit 1
+ *   - Malformed JSON response (parseable HTTP, unparseable body) is NOT a
+ *     runtime error: that provider's missing-keyed criteria score 0 and a
+ *     `malformed: true` flag is set in the report. The run continues.
+ *
+ * Exit codes:
+ *   0  PASS
+ *   1  FAIL (threshold not met, or provider runtime error)
+ *   2  config error (missing files, missing required API keys, bad args)
+ *
+ * Usage:
+ *   node scripts/cross-llm-rubric.mjs \
+ *     --context <path/CONTEXT.md> \
+ *     [--repo-summary <path>] \
+ *     --out <output dir>
+ *
+ * Rubric calibration note: the criteria were locked against schema v1 when
+ * only tier 0/S were supported. v1.27.0 (2026-05-14) added tier M/L; the
+ * criterion A6 ("tier plausible") may discriminate less on M/L outputs and
+ * Q2/Q3 do not yet reward acknowledgment of M/L feature flags. Re-calibrate
+ * the prompt template if M/L outputs become a routine target.
+ */
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { join, resolve, dirname, basename } from "node:path";
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..");
+const PROMPT_TEMPLATE_PATH = resolve(
+  REPO_ROOT,
+  "packages/cli/test/cross-llm-rubric/prompt-template.md",
+);
+
+export const GREENFIELD_CRITERIA = ["Q1", "Q2", "Q3"];
+export const EXISTING_CRITERIA = [
+  "A1",
+  "A2",
+  "A3",
+  "A4",
+  "A5",
+  "A6",
+  "Q1",
+  "Q2",
+  "Q3",
+  "T1",
+  "T2",
+  "T3",
+];
+
+export const CRITERION_LABELS = {
+  A1: "project.name correct",
+  A2: "project.description real",
+  A3: "stack.primary correct",
+  A4: "commands.test runs",
+  A5: "commands.dev runs",
+  A6: "tier.selected plausible",
+  Q1: "tier.rationale non-tautological",
+  Q2: "body coherent",
+  Q3: "constraints specific",
+  T1: "source_files real",
+  T2: "confidence reasonable",
+  T3: "pending reasons specific",
+};
+
+const LOCKED_JURY = [
+  {
+    name: "opus",
+    envKey: "ANTHROPIC_API_KEY",
+    modelEnv: "ANTHROPIC_OPUS_MODEL",
+    defaultModel: "claude-opus-4-7",
+    call: anthropicCall,
+  },
+  {
+    name: "sonnet",
+    envKey: "ANTHROPIC_API_KEY",
+    modelEnv: "ANTHROPIC_SONNET_MODEL",
+    defaultModel: "claude-sonnet-4-6",
+    call: anthropicCall,
+  },
+  {
+    name: "gemini",
+    envKey: "GEMINI_API_KEY",
+    modelEnv: "GEMINI_MODEL",
+    defaultModel: "gemini-2.5-pro",
+    call: geminiCall,
+  },
+];
+
+// ---- arg parsing -----------------------------------------------------------
+
+export function parseArgs(argv) {
+  const args = {};
+  for (let i = 2; i < argv.length; i += 2) {
+    const key = argv[i]?.replace(/^--/, "");
+    const val = argv[i + 1];
+    if (!key || val === undefined) {
+      throw makeError("BAD_ARGS", `bad argument near: ${argv[i]}`);
+    }
+    args[key] = val;
+  }
+  for (const required of ["context", "out"]) {
+    if (!args[required]) {
+      throw makeError("BAD_ARGS", `missing required --${required}`);
+    }
+  }
+  return args;
+}
+
+// ---- .env loader (no dependency) ------------------------------------------
+
+async function loadEnv(cwd) {
+  const envPath = join(cwd, ".env");
+  if (!existsSync(envPath)) return;
+  const raw = await readFile(envPath, "utf8");
+  for (const line of raw.split("\n")) {
+    const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*?)\s*$/);
+    if (!m) continue;
+    const [, key, rawVal] = m;
+    if (process.env[key]) continue;
+    process.env[key] = rawVal.replace(/^["']|["']$/g, "");
+  }
+}
+
+// ---- frontmatter / mode detection -----------------------------------------
+
+export function detectMode(content) {
+  const m = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!m) {
+    throw makeError("BAD_CONTEXT", "CONTEXT.md missing YAML frontmatter");
+  }
+  const modeMatch = m[1].match(/^\s*mode:\s*['"]?([a-z-]+)['"]?\s*$/m);
+  if (!modeMatch) {
+    throw makeError("BAD_CONTEXT", "CONTEXT.md frontmatter missing project.mode");
+  }
+  return modeMatch[1];
+}
+
+export function pickCriteriaForMode(mode) {
+  if (mode === "greenfield") return GREENFIELD_CRITERIA.slice();
+  if (mode === "in-place" || mode === "from-context") {
+    return EXISTING_CRITERIA.slice();
+  }
+  throw makeError("BAD_CONTEXT", `unknown project.mode: ${mode}`);
+}
+
+// ---- prompt assembly -------------------------------------------------------
+
+export function renderCriteriaList(criteria) {
+  return criteria
+    .map((c) => `- ${c}: ${CRITERION_LABELS[c] ?? "(no label)"}`)
+    .join("\n");
+}
+
+export function fillTemplate({ template, mode, repoSummary, contextMd, criteria }) {
+  const criteriaList = renderCriteriaList(criteria);
+  return template
+    .replace(/\{MODE\}/g, mode)
+    .replace(/\{REPO_SUMMARY\}/g, repoSummary || "(greenfield — no repo summary)")
+    .replace(/\{CONTEXT_MD_CONTENT\}/g, contextMd)
+    .replace(/\{CRITERIA_LIST\}/g, criteriaList);
+}
+
+// ---- providers -------------------------------------------------------------
+
+async function anthropicCall({ apiKey, model, system, user }) {
+  const res = await fetch("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01",
+    },
+    body: JSON.stringify({
+      model,
+      max_tokens: 8192,
+      system,
+      messages: [{ role: "user", content: user }],
+      temperature: 0.2,
+    }),
+  });
+  if (!res.ok) throw new Error(`anthropic ${res.status}: ${await res.text()}`);
+  const j = await res.json();
+  return j.content?.map((b) => b.text ?? "").join("\n") ?? "";
+}
+
+async function geminiCall({ apiKey, model, system, user }) {
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      systemInstruction: { role: "system", parts: [{ text: system }] },
+      contents: [{ role: "user", parts: [{ text: user }] }],
+      generationConfig: { temperature: 0.2, maxOutputTokens: 8192 },
+    }),
+  });
+  if (!res.ok) throw new Error(`gemini ${res.status}: ${await res.text()}`);
+  const j = await res.json();
+  return j.candidates?.[0]?.content?.parts?.map((p) => p.text).join("\n") ?? "";
+}
+
+// ---- JSON parsing (robust) -------------------------------------------------
+
+/**
+ * Extract a scores object from a raw model response.
+ *
+ * Strategy:
+ *   1. Try JSON.parse(raw)
+ *   2. Strip ```json fences, retry
+ *   3. Extract outermost {...} via greedy regex, retry
+ *   4. Return null (caller sets malformed: true, scores fall back to 0)
+ */
+export function parseScores(raw, expectedKeys) {
+  if (!raw || typeof raw !== "string") return null;
+  const candidates = [];
+
+  try {
+    candidates.push(JSON.parse(raw));
+  } catch {
+    // ignore
+  }
+
+  const fenced = raw.match(/```(?:json)?\s*([\s\S]*?)```/);
+  if (fenced) {
+    try {
+      candidates.push(JSON.parse(fenced[1]));
+    } catch {
+      // ignore
+    }
+  }
+
+  const greedy = raw.match(/\{[\s\S]*\}/);
+  if (greedy) {
+    try {
+      candidates.push(JSON.parse(greedy[0]));
+    } catch {
+      // ignore
+    }
+  }
+
+  for (const c of candidates) {
+    const scores = c?.scores ?? c;
+    if (scores && typeof scores === "object") {
+      const out = {};
+      let foundAny = false;
+      for (const k of expectedKeys) {
+        const v = scores[k];
+        const score = typeof v?.score === "number" ? v.score : Number(v);
+        if (Number.isFinite(score) && score >= 0 && score <= 3) {
+          out[k] = {
+            score,
+            comment: typeof v?.comment === "string" ? v.comment : "",
+          };
+          foundAny = true;
+        }
+      }
+      if (foundAny) return out;
+    }
+  }
+
+  return null;
+}
+
+// ---- aggregation -----------------------------------------------------------
+
+export function median(values) {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 1) return sorted[mid];
+  return (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+export function aggregate({ criteria, providerResults }) {
+  const perCriterion = {};
+  for (const c of criteria) {
+    const scores = providerResults.map((pr) => {
+      const entry = pr.scores?.[c];
+      return typeof entry?.score === "number" ? entry.score : 0;
+    });
+    perCriterion[c] = {
+      label: CRITERION_LABELS[c] ?? c,
+      scores: Object.fromEntries(
+        providerResults.map((pr, i) => [pr.name, scores[i]]),
+      ),
+      median: median(scores),
+    };
+  }
+
+  const medians = Object.values(perCriterion).map((c) => c.median);
+  const allAboveTwo = medians.every((m) => m >= 2);
+  const aboveTwoCount = medians.filter((m) => m >= 2).length;
+  const percentAboveTwo = medians.length === 0 ? 0 : aboveTwoCount / medians.length;
+  const status = allAboveTwo && percentAboveTwo >= 0.8 ? "PASS" : "FAIL";
+
+  return {
+    status,
+    perCriterion,
+    summary: {
+      total: medians.length,
+      above_two: aboveTwoCount,
+      percent_above_two: Number((percentAboveTwo * 100).toFixed(1)),
+      all_above_two: allAboveTwo,
+    },
+  };
+}
+
+// ---- report rendering ------------------------------------------------------
+
+export function renderMarkdownReport({ aggregation, providerResults, meta }) {
+  const { status, perCriterion, summary } = aggregation;
+  const providerNames = providerResults.map((p) => p.name);
+  const headerCols = ["Criterion", "Median", ...providerNames, "Label"];
+  const rows = Object.entries(perCriterion).map(([c, data]) => [
+    c,
+    String(data.median),
+    ...providerNames.map((n) => String(data.scores[n] ?? 0)),
+    data.label,
+  ]);
+
+  const lines = [];
+  lines.push(`# Cross-LLM rubric report — ${status}`);
+  lines.push("");
+  lines.push(`- Generated: ${meta.generatedAt}`);
+  lines.push(`- Context: \`${meta.contextPath}\``);
+  lines.push(`- Mode: ${meta.mode}`);
+  lines.push(`- Criteria scored: ${summary.total}`);
+  lines.push(
+    `- Threshold: all medians >= 2 AND >= 80% of criteria with median >= 2`,
+  );
+  lines.push(
+    `- Result: ${summary.above_two}/${summary.total} criteria with median >= 2 (${summary.percent_above_two}%)`,
+  );
+  lines.push("");
+
+  const malformed = providerResults.filter((p) => p.malformed).map((p) => p.name);
+  if (malformed.length > 0) {
+    lines.push(
+      `> **Warning**: malformed JSON response from: ${malformed.join(", ")} — their criteria default to score 0.`,
+    );
+    lines.push("");
+  }
+
+  lines.push("## Scores", "");
+  lines.push(`| ${headerCols.join(" | ")} |`);
+  lines.push(`| ${headerCols.map(() => "---").join(" | ")} |`);
+  for (const r of rows) lines.push(`| ${r.join(" | ")} |`);
+  lines.push("");
+
+  lines.push("## Per-provider models", "");
+  for (const pr of providerResults) {
+    lines.push(`- **${pr.name}** — model: \`${pr.model}\`${pr.malformed ? " (malformed response)" : ""}`);
+  }
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+// ---- main ------------------------------------------------------------------
+
+async function main() {
+  let args;
+  try {
+    args = parseArgs(process.argv);
+  } catch (err) {
+    return exitErr(err);
+  }
+
+  const cwd = process.cwd();
+  await loadEnv(cwd);
+
+  const contextPath = resolve(cwd, args.context);
+  if (!existsSync(contextPath)) {
+    return exitErr(makeError("BAD_ARGS", `context not found: ${contextPath}`));
+  }
+  const outDir = resolve(cwd, args.out);
+  await mkdir(outDir, { recursive: true });
+
+  const contextMd = await readFile(contextPath, "utf8");
+
+  let mode;
+  try {
+    mode = detectMode(contextMd);
+  } catch (err) {
+    return exitErr(err);
+  }
+  const criteria = pickCriteriaForMode(mode);
+
+  let repoSummary = "";
+  if (args["repo-summary"]) {
+    const rsPath = resolve(cwd, args["repo-summary"]);
+    if (!existsSync(rsPath)) {
+      return exitErr(
+        makeError("BAD_ARGS", `repo-summary not found: ${rsPath}`),
+      );
+    }
+    repoSummary = await readFile(rsPath, "utf8");
+  } else if (mode !== "greenfield") {
+    process.stdout.write(
+      `warning: --repo-summary not provided for mode "${mode}"; scoring will be less informed.\n`,
+    );
+  }
+
+  // Hard-fail config check: all three jury providers must have keys.
+  const missingKeys = LOCKED_JURY.filter((p) => !process.env[p.envKey]).map(
+    (p) => p.envKey,
+  );
+  if (missingKeys.length > 0) {
+    const uniq = [...new Set(missingKeys)];
+    return exitErr(
+      makeError(
+        "MISSING_KEYS",
+        `locked jury requires ${uniq.join(" + ")}; set them in .env`,
+      ),
+    );
+  }
+
+  const template = await readFile(PROMPT_TEMPLATE_PATH, "utf8");
+  const sysAndUser = splitSystemUser(template);
+  const filledSystem = fillTemplate({
+    template: sysAndUser.system,
+    mode,
+    repoSummary,
+    contextMd,
+    criteria,
+  });
+  const filledUser = fillTemplate({
+    template: sysAndUser.user,
+    mode,
+    repoSummary,
+    contextMd,
+    criteria,
+  });
+
+  process.stdout.write(
+    `Cross-LLM rubric: context=${basename(contextPath)} mode=${mode} criteria=${criteria.length}\n`,
+  );
+  process.stdout.write(
+    `Locked jury: ${LOCKED_JURY.map((p) => p.name).join(", ")}\n\n`,
+  );
+
+  const started = Date.now();
+  const settled = await Promise.allSettled(
+    LOCKED_JURY.map(async (p) => {
+      const model = process.env[p.modelEnv] || p.defaultModel;
+      const t0 = Date.now();
+      process.stdout.write(`[${p.name}] calling ${model}...\n`);
+      const raw = await p.call({
+        apiKey: process.env[p.envKey],
+        model,
+        system: filledSystem,
+        user: filledUser,
+      });
+      const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
+      const scores = parseScores(raw, criteria);
+      const malformed = scores === null;
+      process.stdout.write(
+        `[${p.name}] OK in ${elapsed}s${malformed ? " (malformed JSON — scoring 0)" : ""}\n`,
+      );
+      return {
+        name: p.name,
+        model,
+        elapsedSeconds: Number(elapsed),
+        scores: scores ?? {},
+        malformed,
+        raw,
+      };
+    }),
+  );
+
+  // Hard-fail at runtime: any rejected promise = provider error.
+  const failed = settled.filter((s) => s.status === "rejected");
+  if (failed.length > 0) {
+    for (const f of failed) {
+      process.stderr.write(`provider error: ${f.reason?.message ?? f.reason}\n`);
+    }
+    process.exit(1);
+  }
+
+  const providerResults = settled.map((s) => s.value);
+  const aggregation = aggregate({ criteria, providerResults });
+
+  const meta = {
+    generatedAt: new Date().toISOString(),
+    contextPath,
+    mode,
+    elapsedSeconds: Number(((Date.now() - started) / 1000).toFixed(1)),
+  };
+
+  const reportJson = {
+    schema: "cross-llm-rubric-report-v1",
+    status: aggregation.status,
+    meta,
+    summary: aggregation.summary,
+    criteria: aggregation.perCriterion,
+    providers: providerResults.map((p) => ({
+      name: p.name,
+      model: p.model,
+      elapsed_seconds: p.elapsedSeconds,
+      malformed: p.malformed,
+    })),
+  };
+
+  await writeFile(
+    join(outDir, "report.json"),
+    JSON.stringify(reportJson, null, 2),
+    "utf8",
+  );
+  await writeFile(
+    join(outDir, "report.md"),
+    renderMarkdownReport({ aggregation, providerResults, meta }),
+    "utf8",
+  );
+  for (const pr of providerResults) {
+    await writeFile(
+      join(outDir, `raw-${pr.name}.txt`),
+      `# ${pr.name} (${pr.model})\n\n${pr.raw}\n`,
+      "utf8",
+    );
+  }
+
+  process.stdout.write(
+    `\n${aggregation.status}: ${aggregation.summary.above_two}/${aggregation.summary.total} criteria median>=2 (${aggregation.summary.percent_above_two}%)\n`,
+  );
+  process.stdout.write(`Report: ${join(outDir, "report.md")}\n`);
+
+  process.exit(aggregation.status === "PASS" ? 0 : 1);
+}
+
+function splitSystemUser(template) {
+  const sys = template.match(/## SYSTEM\s*\n([\s\S]*?)(?=\n## USER)/);
+  const usr = template.match(/## USER\s*\n([\s\S]*)$/);
+  if (!sys || !usr) {
+    throw makeError(
+      "BAD_TEMPLATE",
+      "prompt-template.md must contain `## SYSTEM` and `## USER` sections",
+    );
+  }
+  return { system: sys[1].trim(), user: usr[1].trim() };
+}
+
+function makeError(code, message) {
+  const e = new Error(message);
+  e.code = code;
+  return e;
+}
+
+function exitErr(err) {
+  process.stderr.write(`cross-llm-rubric: ${err.message}\n`);
+  process.exit(err.code === "MISSING_KEYS" || err.code === "BAD_ARGS" || err.code === "BAD_CONTEXT" || err.code === "BAD_TEMPLATE" ? 2 : 1);
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  main().catch((err) => {
+    process.stderr.write(`cross-llm-rubric: unhandled: ${err?.stack ?? err}\n`);
+    process.exit(1);
+  });
+}

--- a/scripts/external-review.mjs
+++ b/scripts/external-review.mjs
@@ -21,8 +21,11 @@
  *   GEMINI_API_KEY      → gemini-2.5-pro
  *   MISTRAL_API_KEY     → mistral-large-latest
  *   PERPLEXITY_API_KEY  → sonar-pro
+ *   ANTHROPIC_API_KEY   → claude-opus-4-7    (provider name: anthropic-opus)
+ *   ANTHROPIC_API_KEY   → claude-sonnet-4-6  (provider name: anthropic-sonnet)
  *
- * Override a model id per provider with e.g. OPENAI_MODEL=gpt-5.
+ * Override a model id per provider with e.g. OPENAI_MODEL=gpt-5,
+ * ANTHROPIC_OPUS_MODEL=claude-opus-4-7, ANTHROPIC_SONNET_MODEL=claude-sonnet-4-6.
  *
  * Exit codes:
  *   0  all providers returned a response, no Critical findings
@@ -221,7 +224,42 @@ const PROVIDERS = [
       return j.choices?.[0]?.message?.content ?? "";
     },
   },
+  {
+    name: "anthropic-opus",
+    envKey: "ANTHROPIC_API_KEY",
+    modelEnv: "ANTHROPIC_OPUS_MODEL",
+    defaultModel: "claude-opus-4-7",
+    call: anthropicCall,
+  },
+  {
+    name: "anthropic-sonnet",
+    envKey: "ANTHROPIC_API_KEY",
+    modelEnv: "ANTHROPIC_SONNET_MODEL",
+    defaultModel: "claude-sonnet-4-6",
+    call: anthropicCall,
+  },
 ];
+
+async function anthropicCall({ apiKey, model, system, user }) {
+  const res = await fetch("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01",
+    },
+    body: JSON.stringify({
+      model,
+      max_tokens: 8192,
+      system,
+      messages: [{ role: "user", content: user }],
+      temperature: 0.2,
+    }),
+  });
+  if (!res.ok) throw new Error(`anthropic ${res.status}: ${await res.text()}`);
+  const j = await res.json();
+  return j.content?.map((b) => b.text ?? "").join("\n") ?? "";
+}
 
 // ---- main ------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Closes v1.1 P5 from the reopened Context Builder roadmap. The SHOULD PASS scoring locked 2026-05-07 and executed manually during the v1.0 pilot now runs as a single command.
- New `scripts/cross-llm-rubric.mjs`: hard-fail policy (missing keys → exit 2, provider runtime error → exit 1, malformed JSON → score 0 with flag), fan-out to locked jury (Opus + Sonnet + Gemini Pro), median aggregation, threshold all ≥ 2 AND ≥ 80 % ≥ 2, report.json + report.md output.
- `scripts/external-review.mjs` gains `anthropic-opus` and `anthropic-sonnet` providers so the locked jury can be invoked from the generic review runner too.
- Maintainer-only surface: no new public CLI command, no user-visible dependency.

## What's in scope (and what isn't)

- **In scope (v1.1 P5):** automation of the rubric; Anthropic provider; report rendering; unit tests; docs.
- **Calibration limitation, intentionally not addressed:** the criteria were locked when only tier 0 / S were supported. v1.27.0 (4 days ago) added tier M / L; A6 may discriminate less on M / L outputs and Q2 / Q3 do not yet reward acknowledgment of M / L feature flags. Documented in the calibration note. File as follow-up when M / L becomes a routine target.

## Test plan

- [x] `npm run test:unit` — 585 / 585 pass (+31 new for parseScores, median, aggregate, renderMarkdownReport)
- [x] `npm run format:check` — clean
- [x] `node --check scripts/cross-llm-rubric.mjs` + `node --check scripts/external-review.mjs` — syntax OK
- [ ] CI green on the PR
- [ ] Live end-to-end run (post-merge, once `ANTHROPIC_API_KEY` is set in `.env`) against a v1.0 pilot fixture to verify provider responses parse correctly. Smoke-test only; pilot-style three-repo re-run is a separate maintainer task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)