### PR TITLE
fix(scripts): remove deprecated temperature param for Opus 4.7 (v1.29.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.29.2] — 2026-05-20
+
+### Fixed
+
+- **`anthropicCall` in cross-LLM scripts** no longer sends `temperature`. The first live smoke test of `scripts/cross-llm-rubric.mjs` against an Anthropic key surfaced a 400 from Opus 4.7: `temperature is deprecated for this model`. Sonnet was unaffected but the locked jury requires all three providers to respond. Removed `temperature: 0.2` from `anthropicCall` in both `scripts/cross-llm-rubric.mjs` and `scripts/external-review.mjs`; the API default is fine for review-style judgment tasks. Smoke test path now reaches the parsing stage on Opus too.
+
+### Notes
+
+- Discovered during the live smoke of the rubric after v1.29.0 / v1.29.1 shipped (unit tests mock the provider call and so couldn't catch a real-world API change).
+- npm publish still pending, tracked separately in #181 (OIDC trusted-publisher registration required on npmjs.com).
+
+---
+
 ## [1.29.1] — 2026-05-20
 
 ### Fixed

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mg-claude-dev-kit",
-  "version": "1.29.1",
+  "version": "1.29.2",
   "description": "Scaffold for legible, reviewable AI-assisted development",
   "type": "module",
   "bin": {

--- a/scripts/cross-llm-rubric.mjs
+++ b/scripts/cross-llm-rubric.mjs
@@ -146,7 +146,10 @@ export function detectMode(content) {
   }
   const modeMatch = m[1].match(/^\s*mode:\s*['"]?([a-z-]+)['"]?\s*$/m);
   if (!modeMatch) {
-    throw makeError("BAD_CONTEXT", "CONTEXT.md frontmatter missing project.mode");
+    throw makeError(
+      "BAD_CONTEXT",
+      "CONTEXT.md frontmatter missing project.mode",
+    );
   }
   return modeMatch[1];
 }
@@ -167,11 +170,20 @@ export function renderCriteriaList(criteria) {
     .join("\n");
 }
 
-export function fillTemplate({ template, mode, repoSummary, contextMd, criteria }) {
+export function fillTemplate({
+  template,
+  mode,
+  repoSummary,
+  contextMd,
+  criteria,
+}) {
   const criteriaList = renderCriteriaList(criteria);
   return template
     .replace(/\{MODE\}/g, mode)
-    .replace(/\{REPO_SUMMARY\}/g, repoSummary || "(greenfield — no repo summary)")
+    .replace(
+      /\{REPO_SUMMARY\}/g,
+      repoSummary || "(greenfield — no repo summary)",
+    )
     .replace(/\{CONTEXT_MD_CONTENT\}/g, contextMd)
     .replace(/\{CRITERIA_LIST\}/g, criteriaList);
 }
@@ -179,6 +191,10 @@ export function fillTemplate({ template, mode, repoSummary, contextMd, criteria 
 // ---- providers -------------------------------------------------------------
 
 async function anthropicCall({ apiKey, model, system, user }) {
+  // Note: `temperature` is omitted. Newer Anthropic models (Opus 4.7+)
+  // reject `temperature` with a 400 `invalid_request_error`; older models
+  // accept it but the rubric task is judgment-heavy and the default
+  // sampling is fine. Smoke-tested 2026-05-20.
   const res = await fetch("https://api.anthropic.com/v1/messages", {
     method: "POST",
     headers: {
@@ -191,7 +207,6 @@ async function anthropicCall({ apiKey, model, system, user }) {
       max_tokens: 8192,
       system,
       messages: [{ role: "user", content: user }],
-      temperature: 0.2,
     }),
   });
   if (!res.ok) throw new Error(`anthropic ${res.status}: ${await res.text()}`);
@@ -306,7 +321,8 @@ export function aggregate({ criteria, providerResults }) {
   const medians = Object.values(perCriterion).map((c) => c.median);
   const allAboveTwo = medians.every((m) => m >= 2);
   const aboveTwoCount = medians.filter((m) => m >= 2).length;
-  const percentAboveTwo = medians.length === 0 ? 0 : aboveTwoCount / medians.length;
+  const percentAboveTwo =
+    medians.length === 0 ? 0 : aboveTwoCount / medians.length;
   const status = allAboveTwo && percentAboveTwo >= 0.8 ? "PASS" : "FAIL";
 
   return {
@@ -349,7 +365,9 @@ export function renderMarkdownReport({ aggregation, providerResults, meta }) {
   );
   lines.push("");
 
-  const malformed = providerResults.filter((p) => p.malformed).map((p) => p.name);
+  const malformed = providerResults
+    .filter((p) => p.malformed)
+    .map((p) => p.name);
   if (malformed.length > 0) {
     lines.push(
       `> **Warning**: malformed JSON response from: ${malformed.join(", ")} — their criteria default to score 0.`,
@@ -365,7 +383,9 @@ export function renderMarkdownReport({ aggregation, providerResults, meta }) {
 
   lines.push("## Per-provider models", "");
   for (const pr of providerResults) {
-    lines.push(`- **${pr.name}** — model: \`${pr.model}\`${pr.malformed ? " (malformed response)" : ""}`);
+    lines.push(
+      `- **${pr.name}** — model: \`${pr.model}\`${pr.malformed ? " (malformed response)" : ""}`,
+    );
   }
   lines.push("");
 
@@ -488,7 +508,9 @@ async function main() {
   const failed = settled.filter((s) => s.status === "rejected");
   if (failed.length > 0) {
     for (const f of failed) {
-      process.stderr.write(`provider error: ${f.reason?.message ?? f.reason}\n`);
+      process.stderr.write(
+        `provider error: ${f.reason?.message ?? f.reason}\n`,
+      );
     }
     process.exit(1);
   }
@@ -563,7 +585,14 @@ function makeError(code, message) {
 
 function exitErr(err) {
   process.stderr.write(`cross-llm-rubric: ${err.message}\n`);
-  process.exit(err.code === "MISSING_KEYS" || err.code === "BAD_ARGS" || err.code === "BAD_CONTEXT" || err.code === "BAD_TEMPLATE" ? 2 : 1);
+  process.exit(
+    err.code === "MISSING_KEYS" ||
+      err.code === "BAD_ARGS" ||
+      err.code === "BAD_CONTEXT" ||
+      err.code === "BAD_TEMPLATE"
+      ? 2
+      : 1,
+  );
 }
 
 const isMain = import.meta.url === `file://${process.argv[1]}`;

--- a/scripts/external-review.mjs
+++ b/scripts/external-review.mjs
@@ -241,6 +241,8 @@ const PROVIDERS = [
 ];
 
 async function anthropicCall({ apiKey, model, system, user }) {
+  // Note: `temperature` is omitted because Opus 4.7+ rejects it with a 400.
+  // Older Anthropic models accept it but defaulting is fine for review work.
   const res = await fetch("https://api.anthropic.com/v1/messages", {
     method: "POST",
     headers: {
@@ -253,7 +255,6 @@ async function anthropicCall({ apiKey, model, system, user }) {
       max_tokens: 8192,
       system,
       messages: [{ role: "user", content: user }],
-      temperature: 0.2,
     }),
   });
   if (!res.ok) throw new Error(`anthropic ${res.status}: ${await res.text()}`);


### PR DESCRIPTION
## Summary

- Live smoke test of `scripts/cross-llm-rubric.mjs` on 2026-05-20 returned a 400 from Opus 4.7: `temperature is deprecated for this model`. Sonnet was unaffected but the locked jury requires all three providers to respond.
- Patch removes `temperature: 0.2` from `anthropicCall` in both `scripts/cross-llm-rubric.mjs` and `scripts/external-review.mjs`. API default sampling is fine for review-style judgment tasks.

## Test plan

- [x] Unit tests still pass (585 / 585 — provider call is mocked, so this fix is invisible to them)
- [x] `npm run format:check` clean
- [x] Code review: 2 nearly identical edits, only the `body` payload changes
- [ ] Live re-smoke after merge: requires `ANTHROPIC_API_KEY` and a non-exhausted `GEMINI_API_KEY` (current key is at free-tier quota — out of scope for this PR)

## Context

This is the third v1.29.x patch in a row:

- v1.29.0 (#179): ship the rubric (mergiato, GitHub release tag created)
- v1.29.1 (#180): fix npm publish workflow lockfile (mergiato, GitHub release tag created)
- v1.29.2 (this PR): fix temperature param surfaced by the first live smoke test

npm publish still blocked on OIDC trusted-publisher registration — tracked in #181.

🤖 Generated with [Claude Code](https://claude.com/claude-code)