### PR TITLE
chore(ci): pin ossf/scorecard-action to commit SHA (Option C)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -26,7 +26,10 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2.4.3
+        # Pinned to commit SHA per supply-chain hardening (Option C: only 3rd-party
+        # actions pinned; GitHub-owned actions/* + github/* trust semver).
+        # To bump: resolve new SHA via `gh api repos/ossf/scorecard-action/git/refs/tags/<vX.Y.Z>`.
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Summary

Pins the only 3rd-party action in the repo to a 40-char commit SHA, per Option C of the security review:

- `ossf/scorecard-action@v2.4.3` → `ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3`

All other actions are GitHub-owned (`actions/*`, `github/*`) and intentionally remain on semver tags — the Pinned-Dependencies alerts for those (#34–#62) will be dismissed as an accepted-risk policy decision rather than fixed.

## Closes

- CodeQL alert **#30** (`actions/unpinned-tag` — Unpinned 3rd party Action 'Scorecard supply-chain security')
- Reduces 1 Scorecard `Pinned-Dependencies` warning

## Verification

- Resolved the v2.4.3 annotated tag via `gh api repos/ossf/scorecard-action/git/refs/tags/v2.4.3` then dereferenced the tag object → commit SHA `4eaacf0543bb3f2c246792bd56e8cdeffafb205a`
- Added an inline maintenance comment with the bump command for future version updates

## Test plan

- [x] Workflow syntax: the `uses:` line parses correctly (SHA-pinning is supported syntax)
- [ ] CI green on this PR
- [ ] Scorecard re-run (weekly schedule) clears alert #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)