### PR TITLE
ci(github): enable workflow_dispatch for CodeQL manual runs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,6 +18,7 @@ on:
     branches: [ "main" ]
   schedule:
     - cron: '21 20 * * 0'
+  workflow_dispatch:
 
 # Top-level default: read-only. The `analyze` job below scopes up
 # `security-events: write` for SARIF upload, per principle of least privilege.


### PR DESCRIPTION
## Summary

Adds `workflow_dispatch:` to the `on:` triggers in `.github/workflows/codeql.yml`, mirroring PR #178 for `scorecard.yml`.

## Why

After a fix that affects code-scanning alerts lands on main, the current options are:
- Wait up to a week for the weekly cron (`21 20 * * 0`)
- Open a dummy push to re-trigger the `push` event

With `workflow_dispatch:` enabled, `gh workflow run codeql.yml --ref main` re-scans on demand.

## Immediate use

Will trigger a manual run after merge to close code-scanning alert **#30** (`actions/unpinned-tag` on `ossf/scorecard-action`) — already fixed by PR #188 in code but stale in CodeQL state because the post-merge `push` event didn't re-trigger the workflow.

## Test plan

- [x] YAML lint mentally: `workflow_dispatch:` is a valid top-level trigger
- [ ] CI green on this PR
- [ ] Post-merge: `gh workflow run codeql.yml --ref main` produces a new run

🤖 Generated with [Claude Code](https://claude.com/claude-code)