### PR TITLE
ci: bump actions/checkout + setup-node to v6 (Node 20 deprecation)

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v5
         # Commonly enabled options, see https://github.com/actions/dependency-review-action#configuration-options for all available options.

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,9 +17,9 @@ jobs:
       run:
         working-directory: packages/cli
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -21,7 +21,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` e `actions/setup-node` da `v4` a `v6` in `npm-publish.yml`, `dependency-review.yml`, `scorecard.yml`.
- Allinea questi tre workflow al resto del repo, già su `v6`.
- Anticipa la deprecation di Node 20 in GitHub Actions (force su Node 24 dal 16 giugno 2026, rimozione runner il 16 settembre 2026).

## Test plan
- [ ] CI verde sulla PR su tutti i check (ci, claude-dev-kit-verify, dependency-review, codeql, scorecard).
- [ ] Nessun warning "Node.js 20 actions are deprecated" nei log dei 3 workflow toccati al prossimo run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)