### PR TITLE
feat(vscode): P0 — governance extension scaffold + backend (#95)

### DIFF
--- a/packages/vscode-extension/.gitignore
+++ b/packages/vscode-extension/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.vsix

--- a/packages/vscode-extension/.vscode/launch.json
+++ b/packages/vscode-extension/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+      "outFiles": ["${workspaceFolder}/dist/**/*.js"],
+      "preLaunchTask": "npm: compile"
+    }
+  ]
+}

--- a/packages/vscode-extension/.vscodeignore
+++ b/packages/vscode-extension/.vscodeignore
@@ -1,0 +1,9 @@
+.vscode/**
+src/**
+test/**
+node_modules/**
+esbuild.js
+tsconfig.json
+**/*.ts
+**/*.map
+.gitignore

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -1,0 +1,31 @@
+# Claude Dev Kit — VS Code extension
+
+Editor-native governance surfaces for [claude-dev-kit](https://github.com/marcoguillermaz/claude-dev-kit). Claude Code's native VS Code extension is chat-centric and exposes no public extension API, so governance data — doctor health, the skill/rule registry, audit findings — never reaches the editor's own surfaces. This extension fills that gap with tree views, status-bar indicators, and Problems-panel diagnostics.
+
+> **Status:** P0 scaffold. The only working command today is `Claude Dev Kit: Run Doctor Report`. Tree view, status bar, diagnostics, and codelens land in later phases.
+
+## How it works
+
+The extension shells out to your installed `claude-dev-kit` CLI (the same approach the CDK MCP server uses) and renders the results in VS Code. It runs no governance logic of its own — the CLI stays the single source of truth.
+
+## Requirements
+
+- The `claude-dev-kit` CLI on your `PATH`, or set `cdk.cliPath` to its absolute path.
+- A workspace folder that contains a `.claude/` directory.
+
+## Settings
+
+| Setting | Default | Description |
+|---|---|---|
+| `cdk.cliPath` | `claude-dev-kit` | Command used to invoke the CLI. |
+
+## Development
+
+```bash
+npm install
+npm run compile     # esbuild → dist/extension.js
+npm run typecheck   # tsc --noEmit
+npm test            # node --test on the backend
+```
+
+Press `F5` from this folder to launch an Extension Development Host with the extension loaded.

--- a/packages/vscode-extension/esbuild.js
+++ b/packages/vscode-extension/esbuild.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const esbuild = require('esbuild');
+
+const watch = process.argv.includes('--watch');
+
+const baseOptions = {
+  bundle: true,
+  format: 'cjs',
+  platform: 'node',
+  target: 'node22',
+  sourcemap: true,
+  logLevel: 'info',
+};
+
+async function main() {
+  // Extension entry. `vscode` is injected by the extension host, so it stays external.
+  const extension = await esbuild.context({
+    ...baseOptions,
+    entryPoints: ['src/extension.ts'],
+    outfile: 'dist/extension.js',
+    external: ['vscode'],
+  });
+
+  // Backend entry, emitted standalone so the node:test suite can require it.
+  // It imports no `vscode` API, which is exactly why it is unit-testable here.
+  const backend = await esbuild.context({
+    ...baseOptions,
+    entryPoints: ['src/cdkBackend.ts'],
+    outfile: 'dist/cdkBackend.js',
+  });
+
+  if (watch) {
+    await Promise.all([extension.watch(), backend.watch()]);
+    console.log('[esbuild] watching…');
+    return;
+  }
+
+  await extension.rebuild();
+  await backend.rebuild();
+  await extension.dispose();
+  await backend.dispose();
+  console.log('[esbuild] build complete');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/vscode-extension/package-lock.json
+++ b/packages/vscode-extension/package-lock.json
@@ -1,0 +1,544 @@
+{
+  "name": "claude-dev-kit-vscode",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "claude-dev-kit-vscode",
+      "version": "0.0.1",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "@types/vscode": "^1.90.0",
+        "esbuild": "^0.25.0",
+        "typescript": "^5.6.0"
+      },
+      "engines": {
+        "vscode": "^1.90.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.120.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.120.0.tgz",
+      "integrity": "sha512-feaT4Rst+FkTch5zz/ZbNCxoIvo55YU80Be2kiL7OJcod4+CUYf2lUBPdIJzozNnSEMq1VRTGrWEcCGFB3fBmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "claude-dev-kit-vscode",
+  "displayName": "Claude Dev Kit",
+  "description": "Editor-native governance surfaces for claude-dev-kit: doctor health, skill/rule registry, and audit findings inside VS Code.",
+  "version": "0.0.1",
+  "publisher": "marcoguillermaz",
+  "license": "MIT",
+  "private": true,
+  "engines": {
+    "vscode": "^1.90.0"
+  },
+  "categories": [
+    "Linters",
+    "Other"
+  ],
+  "keywords": [
+    "claude",
+    "claude code",
+    "governance",
+    "claude-dev-kit"
+  ],
+  "main": "./dist/extension.js",
+  "activationEvents": [
+    "workspaceContains:.claude/settings.json"
+  ],
+  "contributes": {
+    "commands": [
+      {
+        "command": "cdk.showDoctorReport",
+        "title": "Claude Dev Kit: Run Doctor Report"
+      }
+    ],
+    "configuration": {
+      "title": "Claude Dev Kit",
+      "properties": {
+        "cdk.cliPath": {
+          "type": "string",
+          "default": "claude-dev-kit",
+          "description": "Command used to invoke the claude-dev-kit CLI. Override with an absolute path if the CLI is not on PATH."
+        }
+      }
+    }
+  },
+  "scripts": {
+    "compile": "node esbuild.js",
+    "watch": "node esbuild.js --watch",
+    "typecheck": "tsc --noEmit",
+    "pretest": "node esbuild.js",
+    "test": "node --test \"test/**/*.test.js\""
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@types/vscode": "^1.90.0",
+    "esbuild": "^0.25.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/packages/vscode-extension/src/cdkBackend.ts
+++ b/packages/vscode-extension/src/cdkBackend.ts
@@ -1,0 +1,120 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+export type DoctorStatus = 'pass' | 'warn' | 'fail' | 'skip';
+
+export interface DoctorCheck {
+  id: string;
+  label: string;
+  status: DoctorStatus;
+  info?: string | null;
+  fix?: string;
+}
+
+export interface DoctorSummary {
+  passed: number;
+  warned: number;
+  failed: number;
+  skipped: number;
+}
+
+export interface DoctorReport {
+  timestamp: string;
+  cwd: string;
+  summary: DoctorSummary;
+  checks: DoctorCheck[];
+}
+
+export interface ExecResult {
+  stdout: string;
+  stderr: string;
+}
+
+/** Injectable command runner — the default shells out, tests pass a fake. */
+export type ExecFn = (command: string, args: string[], cwd: string) => Promise<ExecResult>;
+
+export class CdkBackendError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CdkBackendError';
+  }
+}
+
+const defaultExec: ExecFn = async (command, args, cwd) => {
+  const { stdout, stderr } = await execFileAsync(command, args, {
+    cwd,
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  return { stdout, stderr };
+};
+
+export interface CdkBackendOptions {
+  projectRoot: string;
+  cliPath?: string;
+  exec?: ExecFn;
+}
+
+/**
+ * Sources CDK governance data for the extension by shelling out to the
+ * installed `claude-dev-kit` CLI. Holds no `vscode` dependency so it can be
+ * unit-tested under `node --test`.
+ */
+export class CdkBackend {
+  private readonly projectRoot: string;
+  private readonly cliPath: string;
+  private readonly exec: ExecFn;
+
+  constructor(options: CdkBackendOptions) {
+    this.projectRoot = options.projectRoot;
+    this.cliPath =
+      options.cliPath && options.cliPath.trim() ? options.cliPath.trim() : 'claude-dev-kit';
+    this.exec = options.exec ?? defaultExec;
+  }
+
+  /**
+   * Runs `claude-dev-kit doctor --report` and returns the parsed JSON.
+   *
+   * `doctor` exits 1 when checks fail but still prints the report to stdout,
+   * so a non-zero exit is recovered as long as stdout carries JSON.
+   */
+  async getDoctorReport(): Promise<DoctorReport> {
+    let stdout: string;
+    try {
+      ({ stdout } = await this.exec(this.cliPath, ['doctor', '--report'], this.projectRoot));
+    } catch (error) {
+      const recovered = extractStdout(error);
+      if (recovered && recovered.trim().startsWith('{')) {
+        stdout = recovered;
+      } else {
+        throw new CdkBackendError(
+          `Failed to run "${this.cliPath} doctor --report": ${describeError(error)}`,
+        );
+      }
+    }
+
+    try {
+      return JSON.parse(stdout) as DoctorReport;
+    } catch {
+      throw new CdkBackendError('doctor --report did not return valid JSON.');
+    }
+  }
+}
+
+function extractStdout(error: unknown): string | undefined {
+  if (error && typeof error === 'object' && 'stdout' in error) {
+    const value = (error as { stdout?: unknown }).stdout;
+    if (typeof value === 'string') {
+      return value;
+    }
+    if (value != null) {
+      return String(value);
+    }
+  }
+  return undefined;
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -1,0 +1,55 @@
+import * as vscode from 'vscode';
+import { CdkBackend, CdkBackendError } from './cdkBackend';
+
+export function activate(context: vscode.ExtensionContext): void {
+  const output = vscode.window.createOutputChannel('Claude Dev Kit');
+  context.subscriptions.push(output);
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('cdk.showDoctorReport', () => runDoctorReport(output)),
+  );
+}
+
+export function deactivate(): void {
+  // Subscriptions are disposed by VS Code via context.subscriptions.
+}
+
+async function runDoctorReport(output: vscode.OutputChannel): Promise<void> {
+  const projectRoot = resolveProjectRoot();
+  if (!projectRoot) {
+    void vscode.window.showWarningMessage('Claude Dev Kit: open a workspace folder first.');
+    return;
+  }
+
+  const cliPath =
+    vscode.workspace.getConfiguration('cdk').get<string>('cliPath') ?? 'claude-dev-kit';
+  const backend = new CdkBackend({ projectRoot, cliPath });
+
+  try {
+    const report = await vscode.window.withProgress(
+      { location: vscode.ProgressLocation.Window, title: 'Claude Dev Kit: running doctor…' },
+      () => backend.getDoctorReport(),
+    );
+
+    output.clear();
+    output.appendLine(JSON.stringify(report, null, 2));
+    output.show(true);
+
+    const { passed, warned, failed, skipped } = report.summary;
+    const total = passed + warned + failed + skipped;
+    const message = `CDK doctor: ${passed}/${total} passed, ${failed} failed, ${warned} warnings.`;
+    if (failed > 0) {
+      void vscode.window.showWarningMessage(message);
+    } else {
+      void vscode.window.showInformationMessage(message);
+    }
+  } catch (error) {
+    const message = error instanceof CdkBackendError ? error.message : String(error);
+    void vscode.window.showErrorMessage(`Claude Dev Kit: ${message}`);
+  }
+}
+
+function resolveProjectRoot(): string | undefined {
+  const folders = vscode.workspace.workspaceFolders;
+  return folders && folders.length > 0 ? folders[0].uri.fsPath : undefined;
+}

--- a/packages/vscode-extension/test/cdkBackend.test.js
+++ b/packages/vscode-extension/test/cdkBackend.test.js
@@ -1,0 +1,83 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { CdkBackend, CdkBackendError } = require('../dist/cdkBackend.js');
+
+const SAMPLE_REPORT = {
+  timestamp: '2026-06-08T00:00:00.000Z',
+  cwd: '/tmp/project',
+  summary: { passed: 26, warned: 1, failed: 1, skipped: 0 },
+  checks: [
+    { id: 'settings-json', label: '.claude/settings.json present', status: 'pass', info: null },
+    {
+      id: 'stop-hook',
+      label: 'Stop hook configured',
+      status: 'fail',
+      info: null,
+      fix: 'Add a Stop hook to settings.json.',
+    },
+  ],
+};
+
+// Builds a fake ExecFn. When `fail` is set it rejects with an error carrying
+// `stdout`, mirroring how child_process surfaces a non-zero exit.
+function fakeExec(stdout, { fail = false } = {}) {
+  return async () => {
+    if (fail) {
+      const error = new Error('Command failed with exit code 1');
+      error.stdout = stdout;
+      throw error;
+    }
+    return { stdout, stderr: '' };
+  };
+}
+
+test('getDoctorReport parses JSON from a clean exit', async () => {
+  const backend = new CdkBackend({
+    projectRoot: '/tmp/project',
+    exec: fakeExec(JSON.stringify(SAMPLE_REPORT)),
+  });
+  const report = await backend.getDoctorReport();
+  assert.equal(report.summary.failed, 1);
+  assert.equal(report.checks.length, 2);
+});
+
+test('getDoctorReport recovers the report when doctor exits 1', async () => {
+  const backend = new CdkBackend({
+    projectRoot: '/tmp/project',
+    exec: fakeExec(JSON.stringify(SAMPLE_REPORT), { fail: true }),
+  });
+  const report = await backend.getDoctorReport();
+  assert.equal(report.summary.passed, 26);
+});
+
+test('getDoctorReport throws CdkBackendError when the CLI fails without JSON', async () => {
+  const backend = new CdkBackend({
+    projectRoot: '/tmp/project',
+    exec: fakeExec('command not found: claude-dev-kit', { fail: true }),
+  });
+  await assert.rejects(() => backend.getDoctorReport(), CdkBackendError);
+});
+
+test('getDoctorReport throws CdkBackendError on malformed JSON', async () => {
+  const backend = new CdkBackend({
+    projectRoot: '/tmp/project',
+    exec: fakeExec('{ not valid json'),
+  });
+  await assert.rejects(() => backend.getDoctorReport(), CdkBackendError);
+});
+
+test('cliPath falls back to the default when blank', async () => {
+  let receivedCommand;
+  const backend = new CdkBackend({
+    projectRoot: '/tmp/project',
+    cliPath: '   ',
+    exec: async (command) => {
+      receivedCommand = command;
+      return { stdout: JSON.stringify(SAMPLE_REPORT), stderr: '' };
+    },
+  });
+  await backend.getDoctorReport();
+  assert.equal(receivedCommand, 'claude-dev-kit');
+});

--- a/packages/vscode-extension/tsconfig.json
+++ b/packages/vscode-extension/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node", "vscode"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## What

P0 of the VS Code extension (roadmap Q3 #7, issue #95, GO full). Adds a new self-contained package `packages/vscode-extension/` with the scaffold and the data backend. No UI surfaces yet — those land in P1–P4.

Closes nothing; tracks #95.

## Why

Claude Code's native VS Code extension is chat-centric and exposes no public extension API, so CDK governance data (doctor health, skill/rule registry, audit findings) never reaches the editor's own surfaces (tree views, Problems panel, status bar). A dedicated extension is the only way to fill that structural gap. Full rationale in the decision doc referenced from the roadmap.

## What's in P0

- `src/cdkBackend.ts` — vscode-free service that shells out to the installed `claude-dev-kit` CLI (`doctor --report`), parses the JSON, and recovers the report even when doctor exits 1. The exec function is injectable, so the backend is unit-testable without a real CLI.
- `src/extension.ts` — `activate`/`deactivate` plus the `cdk.showDoctorReport` command, which runs the report and renders it in an Output channel.
- Build: TypeScript → esbuild → CJS bundle (`vscode` external). `tsc --noEmit` as the type-check gate.
- `test/cdkBackend.test.js` — 5 unit tests (clean parse, exit-1 recovery, failure paths, cliPath fallback).
- `.vscode/launch.json` for the F5 dev loop, README, ignore files.

## Backend choice

Shell-out to the CLI (not an MCP client): the `claude-dev-kit-mcp` server is itself a thin CLI wrapper, so routing the extension through MCP would be pure indirection.

## Verification

Run in `packages/vscode-extension/`:

- `npm run compile` — esbuild build OK
- `npm run typecheck` — `tsc --noEmit` clean
- `npm test` — 5/5 pass
- `npm audit --audit-level=moderate` — 0 vulnerabilities (esbuild pinned to ^0.25 to clear the dev-server advisory)

The extension host cannot be exercised in CI: activation and the command need a manual F5 / VSIX install. The first phase with a verifiable UI surface (P1 tree view) introduces an empirical sign-off gate.

## Note

The root `.gitignore` ignores `.vscode/`, so `launch.json` was force-added — it is a shared dev artifact, not personal editor settings.
