### PR TITLE
chore: integrate arch-audit 2026-06-10 hygiene findings (version triple, Opus 4.8 re-baseline, P5 note)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,15 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-(none)
+### Changed
+
+- **Cross-LLM rubric jury re-baselined to Opus 4.8.** The Opus seat in `scripts/cross-llm-rubric.mjs` moved from `claude-opus-4-7` to `claude-opus-4-8` (current Opus tier). This is a deliberate re-baseline, not stale drift: scores produced from 2026-06-10 onward are **not** directly comparable to the v1.0 CONTEXT.md pilot results scored under the 4.7 jury. The header comment records 2026-06-10 as the new scoring baseline.
+- **`scripts/external-review.mjs` default Opus model** bumped from `claude-opus-4-7` to `claude-opus-4-8` (maintainer-only cross-LLM review tool; not shipped in the scaffold payload).
+
+### Docs
+
+- **`docs/operational-guide.md`** version header and footer synced from `1.28.0` to `1.29.2` to match `packages/cli/package.json` (closes the arch-audit CDK-C19 version-triple drift). The MCP read-only posture note now reads "unchanged through v1.29.2". Added a maintainer comment flagging the file size (~1490 lines, ~2.5x the ~600-line soft threshold from arch-audit P5) and a future progressive-disclosure split as a tracked task.
+- **`docs/reviews/anthropic-spec-deviations.md`** last-reviewed date refreshed to 2026-06-10 with an arch-audit re-review note: documented deviations still hold, source URLs still resolve, and the current model tier (`claude-opus-4-8`, plus `claude-fable-5` GA from 2026-06-09) is recorded for awareness.
 
 ---
 

--- a/docs/operational-guide.md
+++ b/docs/operational-guide.md
@@ -1,8 +1,10 @@
 # claude-dev-kit - Operational Guide
 
-**Version**: 1.28.0
+**Version**: 1.29.2
 **Audience**: Builder PMs, tech leads, and senior developers using Claude Code - from first exploration to structured, reviewable delivery
 **Format**: Reference + step-by-step. Read section 1 and your target tier section first, then use the rest as a lookup.
+
+<!-- MAINTAINER NOTE (arch-audit P5, 2026-06-10): this guide is ~1490 lines, ~2.5x the ~600-line soft threshold. Navigation is mitigated by the 16-entry Table of Contents below. A progressive-disclosure split (extract sections into linked files, re-anchor the ToC, update README cross-refs) is a tracked future task; weigh it before adding large new sections here. -->
 
 ---
 
@@ -1316,7 +1318,7 @@ Wire up by adding to `.mcp.json` (project-scoped) or `~/.claude/.mcp.json` (user
 }
 ```
 
-The server resolves the project root from `$CDK_PROJECT_ROOT` if set, otherwise from the calling process's `cwd`. v1.17.0 launched read-only by design; that posture is unchanged through v1.28.0. A read-write surface remains a future-minor decision contingent on adoption signal.
+The server resolves the project root from `$CDK_PROJECT_ROOT` if set, otherwise from the calling process's `cwd`. v1.17.0 launched read-only by design; that posture is unchanged through v1.29.2. A read-write surface remains a future-minor decision contingent on adoption signal.
 
 ### Adding team-specific rules
 
@@ -1489,4 +1491,4 @@ Nine example fixtures are in `packages/cli/test/fixtures/wizard-answers/`. Copy 
 
 ---
 
-_Last updated: 2026-05-15 - v1.28.0_
+_Last updated: 2026-06-10 - v1.29.2_

--- a/scripts/cross-llm-rubric.mjs
+++ b/scripts/cross-llm-rubric.mjs
@@ -3,9 +3,15 @@
  * Cross-LLM rubric — automated SHOULD PASS scoring for CONTEXT.md.
  *
  * Locked jury (memory/project_context_builder_rubric_v1.md, 2026-05-07):
- *   - claude-opus-4-7
+ *   - claude-opus-4-8   (re-baselined 2026-06-10 from claude-opus-4-7, now superseded)
  *   - claude-sonnet-4-6
  *   - gemini-2.5-pro
+ *
+ * Re-baseline note (2026-06-10): the Opus seat was deliberately moved from
+ * claude-opus-4-7 to claude-opus-4-8 (current Opus tier). This is intentional,
+ * not stale drift. Scores produced after this date are NOT directly comparable
+ * to the v1.0 pilot results scored under the 4.7 jury — treat 2026-06-10 as a
+ * new scoring baseline.
  *
  * Threshold (locked 2026-05-07):
  *   - All criterion medians >= 2 AND
@@ -83,7 +89,7 @@ const LOCKED_JURY = [
     name: "opus",
     envKey: "ANTHROPIC_API_KEY",
     modelEnv: "ANTHROPIC_OPUS_MODEL",
-    defaultModel: "claude-opus-4-7",
+    defaultModel: "claude-opus-4-8",
     call: anthropicCall,
   },
   {

--- a/scripts/external-review.mjs
+++ b/scripts/external-review.mjs
@@ -21,11 +21,11 @@
  *   GEMINI_API_KEY      → gemini-2.5-pro
  *   MISTRAL_API_KEY     → mistral-large-latest
  *   PERPLEXITY_API_KEY  → sonar-pro
- *   ANTHROPIC_API_KEY   → claude-opus-4-7    (provider name: anthropic-opus)
+ *   ANTHROPIC_API_KEY   → claude-opus-4-8    (provider name: anthropic-opus)
  *   ANTHROPIC_API_KEY   → claude-sonnet-4-6  (provider name: anthropic-sonnet)
  *
  * Override a model id per provider with e.g. OPENAI_MODEL=gpt-5,
- * ANTHROPIC_OPUS_MODEL=claude-opus-4-7, ANTHROPIC_SONNET_MODEL=claude-sonnet-4-6.
+ * ANTHROPIC_OPUS_MODEL=claude-opus-4-8, ANTHROPIC_SONNET_MODEL=claude-sonnet-4-6.
  *
  * Exit codes:
  *   0  all providers returned a response, no Critical findings
@@ -228,7 +228,7 @@ const PROVIDERS = [
     name: "anthropic-opus",
     envKey: "ANTHROPIC_API_KEY",
     modelEnv: "ANTHROPIC_OPUS_MODEL",
-    defaultModel: "claude-opus-4-7",
+    defaultModel: "claude-opus-4-8",
     call: anthropicCall,
   },
   {


### PR DESCRIPTION
## What this does

Applies the actionable findings from the 2026-06-10 `/arch-audit` run: the four RECOMMENDATIONS plus the CDK-C19 and P5 WARNs. No version bump — `package.json` is already at 1.29.2; this is a doc/script sync.

## Changes (4 committed files)

**Version triple sync — arch-audit High / CDK-C19**
- `docs/operational-guide.md`: header and footer updated from `1.28.0` to `1.29.2` to match `packages/cli/package.json`. The audit flagged one occurrence, but there were three: the narrative MCP-posture line ("unchanged through v1.28.0") is now `v1.29.2`, and the footer date is refreshed to 2026-06-10.

**Cross-LLM Opus model — arch-audit Medium**
- `scripts/external-review.mjs`: default Opus bumped from `claude-opus-4-7` to `claude-opus-4-8` (maintainer-only tool, not in the scaffold payload).
- `scripts/cross-llm-rubric.mjs`: jury Opus seat re-baselined from `claude-opus-4-7` to `claude-opus-4-8`. This is a deliberate re-baseline, not stale drift — scores from 2026-06-10 onward are not directly comparable to the v1.0 CONTEXT.md pilot scored under the 4.7 jury. Recorded in the header comment and the CHANGELOG.

**P5 long-context WARN**
- Added a maintainer comment to `operational-guide.md` noting its size (~1490 lines, ~2.5x the ~600-line soft threshold) and flagging a future progressive-disclosure split as a tracked task. No split here — this PR stays scoped to hygiene.

## Decisions taken with the maintainer

- **Fable 5 / Mythos 5 in `custom-skills.md` — deferred.** The models are real (verified against the Anthropic announcement of 2026-06-09), but they went GA one day ago and the audit's own details on them were wrong (incorrect pricing). Revisit at the next version bump.
- **`docs/reviews/anthropic-spec-deviations.md` date refresh — applied locally only.** `docs/reviews/` is gitignored, so the refresh persists on disk but is not part of this PR.

## CI / risk

- Prettier and ESLint are scoped to `packages/cli/src` and `test/`; none of those are touched here, so there is no lint impact.
- Doc/script sync only, no behavioral change to the CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
