### PR TITLE
docs: sync README version stamps to v1.29.2 (CDK-C19 follow-up to #197)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - **`docs/operational-guide.md`** version header and footer synced from `1.28.0` to `1.29.2` to match `packages/cli/package.json` (closes the arch-audit CDK-C19 version-triple drift). The MCP read-only posture note now reads "unchanged through v1.29.2". Added a maintainer comment flagging the file size (~1490 lines, ~2.5x the ~600-line soft threshold from arch-audit P5) and a future progressive-disclosure split as a tracked task.
 - **`docs/reviews/anthropic-spec-deviations.md`** last-reviewed date refreshed to 2026-06-10 with an arch-audit re-review note: documented deviations still hold, source URLs still resolve, and the current model tier (`claude-opus-4-8`, plus `claude-fable-5` GA from 2026-06-09) is recorded for awareness.
+- **`README.md`** stale `v1.28.0` stamps synced to `v1.29.2`: the MCP read-only posture line and the "Current" release blurb, which now headlines the v1.29.x cross-LLM rubric automation. The arch-audit CDK-C19 version-triple check did not cover the README, so this drift slipped past the prior round; the local audit check has been extended to include it.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Read-only tools exposed:
 | `cdk_package_meta`      | CDK package name, version, CLI path, cwd                                                                                                                         |
 | `cdk_pr_review`         | reads existing `/pr-review` skill comments on a GitHub PR (verdict, severity counts). Read-only — to generate a fresh review, invoke the `/pr-review` CDK skill. |
 
-The server resolves the project root from `$CDK_PROJECT_ROOT` if set, otherwise from `process.cwd()`. v1.17.0 launched read-only by design; that posture is unchanged through v1.28.0.
+The server resolves the project root from `$CDK_PROJECT_ROOT` if set, otherwise from `process.cwd()`. v1.17.0 launched read-only by design; that posture is unchanged through v1.29.2.
 
 ---
 
@@ -251,7 +251,7 @@ A separate **template-coverage** layer (under `packages/cli/test/template-covera
 
 See [GitHub Milestones](https://github.com/marcoguillermaz/claude-dev-kit/milestones) for the 12-month plan.
 
-**Current**: v1.28.0 closes Q3 #10e (skill-review pipeline P3 process robustness). Three gaps surfaced by the cross-LLM meta-review are now closed: a Phase 1 → Phase 2 gate that no longer yields to maintainer judgment, behavioral-fixture coverage up from 6 to 11 stack-dependent skills, and a Phase 10 mechanical sweep at cycle closure that catches drift on early-cycle skills against the final pipeline version. Carried forward: v1.27.0's Context Builder v1.1 cycle (schema-validated `CONTEXT.md` driving non-interactive scaffolding across all four tiers), v1.22.0's `/skill-dev` v2 hotspot step (churn × debt), v1.21.0's PreToolUse runtime enforcement, and v1.20.0's MCP-aware audit skills pinned to `mcp-nvd` and `package-registry-mcp`.
+**Current**: v1.29.2 lands the cross-LLM rubric automation for the Context Builder (shipped in v1.29.0, closing v1.1 P5): SHOULD-PASS scoring of `CONTEXT.md` now runs as a single maintainer command against the locked jury, with v1.29.1 fixing the npm-publish lockfile and v1.29.2 dropping the deprecated `temperature` param that 400'd on Opus. Carried forward: v1.28.0's skill-review pipeline P3 robustness (Phase 1→2 gate, behavioral-fixture coverage 6→11 skills, Phase 10 closure sweep), v1.27.0's Context Builder v1.1 cycle (schema-validated `CONTEXT.md` driving non-interactive scaffolding across all four tiers), v1.22.0's `/skill-dev` v2 hotspot step (churn × debt), v1.21.0's PreToolUse runtime enforcement, and v1.20.0's MCP-aware audit skills pinned to `mcp-nvd` and `package-registry-mcp`.
 
 **Next**: `/arch-audit` MCP-aware once the upstream Anthropic spec MCP server lands. `/privacy-audit` re-eval (Issue #97 sub-track 3) when AST tracing matures or demand signal materializes. Q2 #3 VitePress docs site (ICE 432) stays on hold.
 


### PR DESCRIPTION
## What this does

Follow-up to #197. Syncs two stale `v1.28.0` stamps in `README.md` to `v1.29.2`, closing a gap the arch-audit's CDK-C19 check missed.

## Why a follow-up

The arch-audit defines the version triple as `package.json` + `CHANGELOG` + `operational-guide` and does not look at the README. #197 fixed the triple, but the README still had `v1.28.0` in two places — the drift made it through the round unnoticed.

## Changes

- `README.md:192` — MCP read-only posture line: "unchanged through v1.28.0" updated to `v1.29.2` (parallel to the `operational-guide.md` line already fixed in #197).
- `README.md:254` — the "Current" release blurb, two patches stale, rewritten to headline the v1.29.x line: the cross-LLM rubric automation from v1.29.0 (closing Context Builder v1.1 P5), with the v1.29.1 npm-publish lockfile fix and the v1.29.2 `temperature` 400 fix. The v1.28.0 skill-review P3 work moves into "carried forward".
- `CHANGELOG.md` — a `### Docs` bullet under `[Unreleased]` recording the sync and the CDK-C19 scope gap.

## Out of band

The local arch-audit skill (`.claude/skills/arch-audit/SKILL.md`, gitignored) had its CDK-C19 check extended to grep the README's version stamps, so this drift gets caught automatically next round. Not in this PR — it lives outside the repo.

## CI / risk

`v1.29.2` is the current GitHub release (Latest, 2026-05-20), so the stamps point at a real version. Prettier/ESLint are scoped to `packages/cli`; the README and CHANGELOG are untouched by lint. Docs only, no behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
