### PR TITLE
feat(vscode): P2 — status-bar health (doctor + arch-audit staleness) (#95)

### DIFF
--- a/packages/vscode-extension/esbuild.js
+++ b/packages/vscode-extension/esbuild.js
@@ -30,16 +30,25 @@ async function main() {
     outfile: 'dist/cdkBackend.js',
   });
 
+  // Pure health/display logic, also vscode-free and emitted standalone for tests.
+  const health = await esbuild.context({
+    ...baseOptions,
+    entryPoints: ['src/health.ts'],
+    outfile: 'dist/health.js',
+  });
+
   if (watch) {
-    await Promise.all([extension.watch(), backend.watch()]);
+    await Promise.all([extension.watch(), backend.watch(), health.watch()]);
     console.log('[esbuild] watching…');
     return;
   }
 
   await extension.rebuild();
   await backend.rebuild();
+  await health.rebuild();
   await extension.dispose();
   await backend.dispose();
+  await health.dispose();
   console.log('[esbuild] build complete');
 }
 

--- a/packages/vscode-extension/src/cdkBackend.ts
+++ b/packages/vscode-extension/src/cdkBackend.ts
@@ -48,6 +48,15 @@ export interface RuleInfo {
   path: string;
 }
 
+export interface ArchAuditStatus {
+  /** False when the `.claude/session/last-arch-audit` record is absent. */
+  everRan: boolean;
+  /** Unix epoch seconds of the last run, or null when absent/unparseable. */
+  lastRunUnix: number | null;
+  /** ISO timestamp of the last run, or null. */
+  lastRunIso: string | null;
+}
+
 export interface ExecResult {
   stdout: string;
   stderr: string;
@@ -181,6 +190,33 @@ export class CdkBackend {
       });
     }
     return rules.sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  /**
+   * Reads the timestamp of the last `arch-audit` skill run from
+   * `.claude/session/last-arch-audit` (a Unix epoch in seconds), mirroring the
+   * CDK MCP server's parser. Never throws — a missing or unreadable record
+   * reports `everRan: false` so the status bar can degrade gracefully.
+   */
+  async getArchAuditStatus(): Promise<ArchAuditStatus> {
+    const file = join(this.projectRoot, '.claude', 'session', 'last-arch-audit');
+    if (!existsSync(file)) {
+      return { everRan: false, lastRunUnix: null, lastRunIso: null };
+    }
+    try {
+      const raw = (await readFile(file, 'utf8')).trim();
+      const epoch = Number.parseInt(raw, 10);
+      if (!Number.isFinite(epoch)) {
+        return { everRan: true, lastRunUnix: null, lastRunIso: null };
+      }
+      return {
+        everRan: true,
+        lastRunUnix: epoch,
+        lastRunIso: new Date(epoch * 1000).toISOString(),
+      };
+    } catch {
+      return { everRan: false, lastRunUnix: null, lastRunIso: null };
+    }
   }
 }
 

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -1,25 +1,64 @@
 import * as vscode from 'vscode';
 import { CdkBackend, CdkBackendError } from './cdkBackend';
 import { GovernanceTreeProvider } from './governanceTree';
+import { CdkStatusBar } from './statusBar';
 
 export function activate(context: vscode.ExtensionContext): void {
   const output = vscode.window.createOutputChannel('Claude Dev Kit');
   context.subscriptions.push(output);
 
   const treeProvider = new GovernanceTreeProvider(() => createBackend());
+  const statusBar = new CdkStatusBar(() => createBackend());
+
+  // Coalesces a burst of file-watcher events (e.g. a git checkout touching
+  // many `.claude/` files) into a single refresh of both surfaces.
+  let debounce: ReturnType<typeof setTimeout> | undefined;
+  const refreshAll = (): void => {
+    if (debounce) {
+      clearTimeout(debounce);
+    }
+    debounce = setTimeout(() => {
+      treeProvider.refresh();
+      void statusBar.refresh();
+    }, 300);
+  };
+
+  // Watch only the inputs the tree and doctor actually consume. Deliberately
+  // NOT the whole `.claude/**` tree: `doctor` is read-only so there is no
+  // self-trigger loop, but `.claude/session/` churns constantly during active
+  // Claude Code use and would respawn `doctor` on every session write — so the
+  // arch-audit stamp is the only session file watched.
+  for (const glob of [
+    '**/.claude/skills/**',
+    '**/.claude/rules/**',
+    '**/.claude/settings.json',
+    '**/.claude/session/last-arch-audit',
+    '**/CLAUDE.md',
+  ]) {
+    const watcher = vscode.workspace.createFileSystemWatcher(glob);
+    watcher.onDidCreate(refreshAll);
+    watcher.onDidChange(refreshAll);
+    watcher.onDidDelete(refreshAll);
+    context.subscriptions.push(watcher);
+  }
+
   context.subscriptions.push(
     treeProvider,
+    statusBar,
     vscode.window.registerTreeDataProvider('cdk.governance', treeProvider),
-    vscode.commands.registerCommand('cdk.refreshGovernance', () => treeProvider.refresh()),
-    vscode.commands.registerCommand('cdk.showDoctorReport', () => runDoctorReport(output)),
+    vscode.commands.registerCommand('cdk.refreshGovernance', () => {
+      treeProvider.refresh();
+      void statusBar.refresh();
+    }),
+    vscode.commands.registerCommand('cdk.showDoctorReport', () => runDoctorReport(output, statusBar)),
+    vscode.workspace.onDidChangeWorkspaceFolders(() => {
+      treeProvider.refresh();
+      void statusBar.refresh();
+    }),
+    { dispose: () => debounce && clearTimeout(debounce) },
   );
 
-  // Keep the tree in sync when skills or rules change on disk.
-  const watcher = vscode.workspace.createFileSystemWatcher('**/.claude/{skills,rules}/**');
-  watcher.onDidCreate(() => treeProvider.refresh());
-  watcher.onDidChange(() => treeProvider.refresh());
-  watcher.onDidDelete(() => treeProvider.refresh());
-  context.subscriptions.push(watcher);
+  void statusBar.refresh();
 }
 
 export function deactivate(): void {
@@ -36,7 +75,7 @@ function createBackend(): CdkBackend | undefined {
   return new CdkBackend({ projectRoot, cliPath });
 }
 
-async function runDoctorReport(output: vscode.OutputChannel): Promise<void> {
+async function runDoctorReport(output: vscode.OutputChannel, statusBar: CdkStatusBar): Promise<void> {
   const backend = createBackend();
   if (!backend) {
     void vscode.window.showWarningMessage('Claude Dev Kit: open a workspace folder first.');
@@ -64,6 +103,9 @@ async function runDoctorReport(output: vscode.OutputChannel): Promise<void> {
   } catch (error) {
     const message = error instanceof CdkBackendError ? error.message : String(error);
     void vscode.window.showErrorMessage(`Claude Dev Kit: ${message}`);
+  } finally {
+    // Reflect the freshly-run report (or a now-visible failure) in the bar.
+    void statusBar.refresh();
   }
 }
 

--- a/packages/vscode-extension/src/health.ts
+++ b/packages/vscode-extension/src/health.ts
@@ -1,0 +1,93 @@
+import type { ArchAuditStatus, DoctorSummary } from './cdkBackend';
+
+/** Weekly cadence: arch-audit is considered stale past this many days. */
+export const ARCH_AUDIT_STALE_DAYS = 7;
+
+export type HealthSeverity = 'ok' | 'warning' | 'error';
+
+export interface HealthDisplay {
+  severity: HealthSeverity;
+  /** Status-bar label; may embed `$(codicon)` tokens. */
+  text: string;
+  /** Markdown tooltip body. */
+  tooltip: string;
+}
+
+export interface HealthInput {
+  summary: DoctorSummary;
+  archAudit: ArchAuditStatus;
+  /** Current time as Unix epoch seconds. */
+  nowUnix: number;
+  staleDays?: number;
+}
+
+/** Days since the last arch-audit run, or null when it never ran / is unparseable. */
+export function archAuditAgeDays(archAudit: ArchAuditStatus, nowUnix: number): number | null {
+  if (!archAudit.everRan || archAudit.lastRunUnix == null) {
+    return null;
+  }
+  return (nowUnix - archAudit.lastRunUnix) / 86400;
+}
+
+/** Human-readable arch-audit line for tooltips. */
+export function describeArchAudit(
+  archAudit: ArchAuditStatus,
+  nowUnix: number,
+  staleDays = ARCH_AUDIT_STALE_DAYS,
+): string {
+  if (!archAudit.everRan) {
+    return 'never run';
+  }
+  const age = archAuditAgeDays(archAudit, nowUnix);
+  if (age == null) {
+    return 'recorded, but the timestamp is unparseable';
+  }
+  const rounded = Math.floor(age);
+  const when = rounded <= 0 ? 'today' : `${rounded}d ago`;
+  return age > staleDays ? `last run ${when} — stale (>${staleDays}d)` : `last run ${when}`;
+}
+
+/**
+ * Derives the status-bar display from the doctor summary and arch-audit
+ * staleness. Pure (no `vscode`, no clock) so it is fully unit-testable:
+ * failures dominate, then warnings; a *lapsed* arch-audit cadence
+ * (ran before, now stale) bumps an otherwise-healthy state to a warning,
+ * while a never-run arch-audit stays informational.
+ */
+export function evaluateHealth({
+  summary,
+  archAudit,
+  nowUnix,
+  staleDays = ARCH_AUDIT_STALE_DAYS,
+}: HealthInput): HealthDisplay {
+  const { passed, warned, failed, skipped } = summary;
+  const total = passed + warned + failed + skipped;
+
+  const age = archAuditAgeDays(archAudit, nowUnix);
+  const archStale = age != null && age > staleDays;
+
+  let severity: HealthSeverity;
+  let text: string;
+  if (failed > 0) {
+    severity = 'error';
+    text = `$(error) CDK ${failed}✗`;
+  } else if (warned > 0 || archStale) {
+    severity = 'warning';
+    text = warned > 0 ? `$(warning) CDK ${warned}⚠` : '$(warning) CDK';
+  } else {
+    severity = 'ok';
+    text = '$(check) CDK';
+  }
+
+  const tooltip = [
+    '**Claude Dev Kit — health**',
+    '',
+    `Doctor: ${passed}/${total} passed · ${failed} failed · ${warned} warnings · ${skipped} skipped`,
+    '',
+    `Arch-audit: ${describeArchAudit(archAudit, nowUnix, staleDays)}`,
+    '',
+    'Click to run the doctor report.',
+  ].join('\n');
+
+  return { severity, text, tooltip };
+}

--- a/packages/vscode-extension/src/statusBar.ts
+++ b/packages/vscode-extension/src/statusBar.ts
@@ -1,0 +1,96 @@
+import * as vscode from 'vscode';
+import { CdkBackend, CdkBackendError, type ArchAuditStatus } from './cdkBackend';
+import { ARCH_AUDIT_STALE_DAYS, describeArchAudit, evaluateHealth, type HealthSeverity } from './health';
+
+const BACKGROUND: Record<HealthSeverity, vscode.ThemeColor | undefined> = {
+  error: new vscode.ThemeColor('statusBarItem.errorBackground'),
+  warning: new vscode.ThemeColor('statusBarItem.warningBackground'),
+  ok: undefined,
+};
+
+/**
+ * Owns a single status-bar item summarising project health: the `doctor`
+ * pass/fail counts plus arch-audit staleness. Clicking it runs the doctor
+ * report. Backend access is deferred through a factory so the item reflects
+ * the current workspace folder and `cdk.cliPath` setting on every refresh.
+ */
+export class CdkStatusBar {
+  private readonly item: vscode.StatusBarItem;
+  private refreshing = false;
+  private pending = false;
+
+  constructor(private readonly resolveBackend: () => CdkBackend | undefined) {
+    this.item = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
+    this.item.name = 'Claude Dev Kit Health';
+    this.item.command = 'cdk.showDoctorReport';
+  }
+
+  dispose(): void {
+    this.item.dispose();
+  }
+
+  /**
+   * Re-evaluates and re-renders the item. Guards against overlapping runs:
+   * a refresh requested while one is in flight is coalesced into a single
+   * trailing run, so a burst of file-watcher events triggers `doctor` once.
+   */
+  async refresh(): Promise<void> {
+    if (this.refreshing) {
+      this.pending = true;
+      return;
+    }
+    this.refreshing = true;
+    try {
+      await this.render();
+    } finally {
+      this.refreshing = false;
+      if (this.pending) {
+        this.pending = false;
+        void this.refresh();
+      }
+    }
+  }
+
+  private async render(): Promise<void> {
+    const backend = this.resolveBackend();
+    if (!backend) {
+      this.item.hide();
+      return;
+    }
+
+    const nowUnix = Math.floor(Date.now() / 1000);
+    const archAudit = await backend.getArchAuditStatus();
+
+    let summary;
+    try {
+      ({ summary } = await backend.getDoctorReport());
+    } catch (error) {
+      this.renderUnavailable(error, archAudit, nowUnix);
+      return;
+    }
+
+    const display = evaluateHealth({ summary, archAudit, nowUnix });
+    this.item.text = display.text;
+    this.item.tooltip = new vscode.MarkdownString(display.tooltip);
+    this.item.backgroundColor = BACKGROUND[display.severity];
+    this.item.show();
+  }
+
+  private renderUnavailable(error: unknown, archAudit: ArchAuditStatus, nowUnix: number): void {
+    const message = error instanceof CdkBackendError ? error.message : String(error);
+    this.item.text = '$(circle-slash) CDK';
+    this.item.backgroundColor = undefined;
+    this.item.tooltip = new vscode.MarkdownString(
+      [
+        '**Claude Dev Kit — health**',
+        '',
+        `Doctor unavailable: ${message}`,
+        '',
+        'Set `cdk.cliPath` to your claude-dev-kit CLI, or install it on PATH.',
+        '',
+        `Arch-audit: ${describeArchAudit(archAudit, nowUnix, ARCH_AUDIT_STALE_DAYS)}`,
+      ].join('\n'),
+    );
+    this.item.show();
+  }
+}

--- a/packages/vscode-extension/test/archAuditStatus.test.js
+++ b/packages/vscode-extension/test/archAuditStatus.test.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { CdkBackend } = require('../dist/cdkBackend.js');
+
+function fixtureWith(record) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk-arch-'));
+  if (record !== undefined) {
+    const file = path.join(root, '.claude', 'session', 'last-arch-audit');
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, record);
+  }
+  return root;
+}
+
+test('getArchAuditStatus parses a valid epoch record', async () => {
+  const epoch = 1_700_000_000;
+  const root = fixtureWith(`${epoch}\n`);
+  try {
+    const status = await new CdkBackend({ projectRoot: root }).getArchAuditStatus();
+    assert.equal(status.everRan, true);
+    assert.equal(status.lastRunUnix, epoch);
+    assert.equal(status.lastRunIso, new Date(epoch * 1000).toISOString());
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('getArchAuditStatus reports everRan: false when the record is absent', async () => {
+  const root = fixtureWith(undefined);
+  try {
+    const status = await new CdkBackend({ projectRoot: root }).getArchAuditStatus();
+    assert.deepEqual(status, { everRan: false, lastRunUnix: null, lastRunIso: null });
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('getArchAuditStatus marks an unparseable record as run-but-unknown', async () => {
+  const root = fixtureWith('not-a-number');
+  try {
+    const status = await new CdkBackend({ projectRoot: root }).getArchAuditStatus();
+    assert.deepEqual(status, { everRan: true, lastRunUnix: null, lastRunIso: null });
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/packages/vscode-extension/test/health.test.js
+++ b/packages/vscode-extension/test/health.test.js
@@ -1,0 +1,105 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  ARCH_AUDIT_STALE_DAYS,
+  archAuditAgeDays,
+  describeArchAudit,
+  evaluateHealth,
+} = require('../dist/health.js');
+
+const NOW = 1_700_000_000;
+const DAY = 86_400;
+const ranDaysAgo = (days) => ({
+  everRan: true,
+  lastRunUnix: NOW - days * DAY,
+  lastRunIso: new Date((NOW - days * DAY) * 1000).toISOString(),
+});
+const NEVER = { everRan: false, lastRunUnix: null, lastRunIso: null };
+const summary = (s) => ({ passed: 0, warned: 0, failed: 0, skipped: 0, ...s });
+
+test('evaluateHealth: failures dominate over warnings', () => {
+  const d = evaluateHealth({
+    summary: summary({ passed: 10, warned: 4, failed: 2 }),
+    archAudit: NEVER,
+    nowUnix: NOW,
+  });
+  assert.equal(d.severity, 'error');
+  assert.match(d.text, /2✗/);
+});
+
+test('evaluateHealth: warnings without failures are a warning', () => {
+  const d = evaluateHealth({
+    summary: summary({ passed: 10, warned: 3 }),
+    archAudit: NEVER,
+    nowUnix: NOW,
+  });
+  assert.equal(d.severity, 'warning');
+  assert.match(d.text, /3⚠/);
+});
+
+test('evaluateHealth: all green with no arch-audit is ok', () => {
+  const d = evaluateHealth({ summary: summary({ passed: 12 }), archAudit: NEVER, nowUnix: NOW });
+  assert.equal(d.severity, 'ok');
+  assert.equal(d.text, '$(check) CDK');
+});
+
+test('evaluateHealth: a lapsed arch-audit cadence bumps a clean state to warning', () => {
+  const d = evaluateHealth({
+    summary: summary({ passed: 12 }),
+    archAudit: ranDaysAgo(10),
+    nowUnix: NOW,
+  });
+  assert.equal(d.severity, 'warning');
+  // No doctor warnings, so the count glyph is omitted.
+  assert.equal(d.text, '$(warning) CDK');
+});
+
+test('evaluateHealth: a recent arch-audit run does not bump severity', () => {
+  const d = evaluateHealth({
+    summary: summary({ passed: 12 }),
+    archAudit: ranDaysAgo(3),
+    nowUnix: NOW,
+  });
+  assert.equal(d.severity, 'ok');
+});
+
+test('evaluateHealth: a never-run arch-audit stays informational (no bump)', () => {
+  const d = evaluateHealth({ summary: summary({ passed: 12 }), archAudit: NEVER, nowUnix: NOW });
+  assert.equal(d.severity, 'ok');
+  assert.match(d.tooltip, /Arch-audit: never run/);
+});
+
+test('evaluateHealth: tooltip carries the full doctor breakdown', () => {
+  const d = evaluateHealth({
+    summary: summary({ passed: 6, warned: 3, failed: 3, skipped: 17 }),
+    archAudit: NEVER,
+    nowUnix: NOW,
+  });
+  assert.match(d.tooltip, /6\/29 passed · 3 failed · 3 warnings · 17 skipped/);
+});
+
+test('archAuditAgeDays: null when never run, computed otherwise', () => {
+  assert.equal(archAuditAgeDays(NEVER, NOW), null);
+  assert.equal(archAuditAgeDays(ranDaysAgo(5), NOW), 5);
+});
+
+test('describeArchAudit: never run', () => {
+  assert.equal(describeArchAudit(NEVER, NOW), 'never run');
+});
+
+test('describeArchAudit: fresh run reads "Nd ago" without a stale marker', () => {
+  const line = describeArchAudit(ranDaysAgo(3), NOW);
+  assert.equal(line, 'last run 3d ago');
+});
+
+test('describeArchAudit: stale run past the threshold is flagged', () => {
+  const line = describeArchAudit(ranDaysAgo(10), NOW);
+  assert.match(line, new RegExp(`stale \\(>${ARCH_AUDIT_STALE_DAYS}d\\)`));
+});
+
+test('describeArchAudit: unparseable record is reported, not crashed on', () => {
+  const line = describeArchAudit({ everRan: true, lastRunUnix: null, lastRunIso: null }, NOW);
+  assert.match(line, /unparseable/);
+});


### PR DESCRIPTION
## P2 — Status-bar health

Third phase of the VS Code extension (#95). Adds a single status-bar item that summarises project health from two sources and turns the existing doctor command into a one-click action.

### What it does
- **Doctor health**: shows the `doctor --report` outcome — `$(error) CDK n✗` (red) when checks fail, `$(warning) CDK m⚠` (yellow) when only warnings remain, `$(check) CDK` when clean.
- **Arch-audit staleness**: reads `.claude/session/last-arch-audit` (the same epoch record the MCP server uses). A *lapsed* cadence (ran before, now older than 7 days) bumps an otherwise-clean state to a warning; a never-run audit stays informational in the tooltip only.
- **Click** runs the doctor report (reuses `cdk.showDoctorReport`); the tooltip carries the full pass/fail/warn/skip breakdown plus the arch-audit line.
- **Graceful degrade**: when the CLI can't be reached the item shows `$(circle-slash) CDK` and points the user at `cdk.cliPath`, with no error popup — arch-audit staleness still renders from disk.

### Design
- `src/health.ts` holds the display logic as a pure function (no `vscode`, no clock), so severity and tooltip are fully unit-testable.
- `src/statusBar.ts` renders it and guards against overlapping refreshes (a burst of file events coalesces into one `doctor` run).
- The file watcher is scoped to the inputs the tree and doctor actually read — deliberately not the whole `.claude/**` tree, so active Claude Code session churn doesn't respawn `doctor`.

### Verification
- 23/23 unit tests, typecheck clean, builds on esbuild 0.28.1.
- **Empirical F5 gate passed** (Extension Development Host, staff-manager): degraded state with the CLI unresolved → set `cdk.cliPath` → warning state `CDK 8⚠` with the matching tooltip → click runs the doctor report successfully. The degraded→healthy transition is the path unit tests can't reach.
- The stale-arch-audit severity bump is unit-covered but not visually isolable on staff-manager (already yellow from 8 warnings) — logged skip, not staged.

### Notes
- The top-level README and operational-guide still don't mention the extension; that's deferred to P5 (packaging/marketplace), since advertising an unpublished extension now would be premature.
- CI does not exercise the extension yet — its CI job lands in P5. The empirical F5 above is the gate for this PR.

Draft until F5 sign-off; sign-off obtained, marking ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
