### PR TITLE
feat(vscode): P3 — diagnostics in the Problems panel (#95)

### DIFF
--- a/packages/vscode-extension/esbuild.js
+++ b/packages/vscode-extension/esbuild.js
@@ -37,8 +37,20 @@ async function main() {
     outfile: 'dist/health.js',
   });
 
+  // Pure diagnostic-spec builder + check→file map, vscode-free, standalone for tests.
+  const diagnostics = await esbuild.context({
+    ...baseOptions,
+    entryPoints: ['src/diagnostics.ts'],
+    outfile: 'dist/diagnostics.js',
+  });
+
   if (watch) {
-    await Promise.all([extension.watch(), backend.watch(), health.watch()]);
+    await Promise.all([
+      extension.watch(),
+      backend.watch(),
+      health.watch(),
+      diagnostics.watch(),
+    ]);
     console.log('[esbuild] watching…');
     return;
   }
@@ -46,9 +58,11 @@ async function main() {
   await extension.rebuild();
   await backend.rebuild();
   await health.rebuild();
+  await diagnostics.rebuild();
   await extension.dispose();
   await backend.dispose();
   await health.dispose();
+  await diagnostics.dispose();
   console.log('[esbuild] build complete');
 }
 

--- a/packages/vscode-extension/src/cdkBackend.ts
+++ b/packages/vscode-extension/src/cdkBackend.ts
@@ -57,6 +57,18 @@ export interface ArchAuditStatus {
   lastRunIso: string | null;
 }
 
+/**
+ * One combined fetch of everything the health surfaces need, so the status bar
+ * and the Problems-panel diagnostics render from a single `doctor` invocation
+ * instead of each shelling out on their own. `report` is null when `doctor`
+ * could not run (CLI unresolved), in which case `error` carries the reason.
+ */
+export interface HealthSnapshot {
+  archAudit: ArchAuditStatus;
+  report: DoctorReport | null;
+  error: string | null;
+}
+
 export interface ExecResult {
   stdout: string;
   stderr: string;
@@ -216,6 +228,22 @@ export class CdkBackend {
       };
     } catch {
       return { everRan: false, lastRunUnix: null, lastRunIso: null };
+    }
+  }
+
+  /**
+   * Fetches the arch-audit status and the doctor report in one shot for the
+   * health surfaces. `doctor` failures are captured (not thrown) so a missing
+   * CLI degrades gracefully: `report` is null and `error` holds the reason.
+   */
+  async getHealthSnapshot(): Promise<HealthSnapshot> {
+    const archAudit = await this.getArchAuditStatus();
+    try {
+      const report = await this.getDoctorReport();
+      return { archAudit, report, error: null };
+    } catch (error) {
+      const message = error instanceof CdkBackendError ? error.message : String(error);
+      return { archAudit, report: null, error: message };
     }
   }
 }

--- a/packages/vscode-extension/src/diagnostics.ts
+++ b/packages/vscode-extension/src/diagnostics.ts
@@ -1,0 +1,89 @@
+import type { ArchAuditStatus, DoctorReport } from './cdkBackend';
+import { ARCH_AUDIT_STALE_DAYS, archAuditAgeDays, describeArchAudit } from './health';
+
+/**
+ * Maps a doctor check id to the workspace-relative file it concerns, mirroring
+ * the targets in the CLI's `doctor.js`. Checks that span multiple files or no
+ * file (e.g. `claude-cli`, the multi-skill `skill-*` checks, `anthropic-files-
+ * current`) are intentionally absent — they resolve to the project hub instead.
+ *
+ * When `doctor` gains a check, an unmapped id degrades to the hub anchor (it
+ * still surfaces, just less precisely) rather than disappearing.
+ */
+export const CHECK_FILE_MAP: Record<string, string> = {
+  'claude-md': 'CLAUDE.md',
+  'claude-md-size': 'CLAUDE.md',
+  'no-secrets-claude-md': 'CLAUDE.md',
+  'claudemd-stop-hook-test-cmd-match': 'CLAUDE.md',
+  'claudemd-skills-directory-parity': 'CLAUDE.md',
+  'settings-json': '.claude/settings.json',
+  'stop-hook': '.claude/settings.json',
+  'stop-hook-placeholder': '.claude/settings.json',
+  'stop-hook-timeout': '.claude/settings.json',
+  'settings-no-placeholders': '.claude/settings.json',
+  'permissions-no-duplicates': '.claude/settings.json',
+  'team-settings-runtime-hook': '.claude/settings.json',
+  'pipeline-md': '.claude/rules/pipeline.md',
+  'pipeline-md-tier-coherence': '.claude/rules/pipeline.md',
+  'security-rules': '.claude/rules/security.md',
+  'security-md-stack-alignment': '.claude/rules/security.md',
+  'output-style-rule': '.claude/rules/output-style.md',
+  'context-review-c12': '.claude/rules/context-review.md',
+  'gitignore-env': '.gitignore',
+  codeowners: '.github/CODEOWNERS',
+  'claudemd-standards-rule': 'docs/claudemd-standards.md',
+  'pipeline-standards-rule': 'docs/pipeline-standards.md',
+  'commit-skill': '.claude/skills/commit/SKILL.md',
+  'team-settings-compliance': '.claude/team-settings.json',
+};
+
+export type DiagnosticSeverity = 'error' | 'warning';
+
+export interface DiagnosticSpec {
+  /** Workspace-relative file the diagnostic concerns, or null → project hub. */
+  relPath: string | null;
+  severity: DiagnosticSeverity;
+  message: string;
+  /** Stable identifier (the doctor check id, or `arch-audit-stale`). */
+  code: string;
+}
+
+/**
+ * Turns a doctor report (plus arch-audit staleness) into diagnostic specs.
+ * Pure: no `vscode`, no filesystem, no clock — URI resolution and existence
+ * fallback happen in the renderer. Only `fail`/`warn` checks produce specs;
+ * `pass`/`skip` are dropped. A lapsed arch-audit cadence adds one warning.
+ */
+export function buildDiagnostics(
+  report: DoctorReport,
+  archAudit: ArchAuditStatus,
+  nowUnix: number,
+  staleDays = ARCH_AUDIT_STALE_DAYS,
+): DiagnosticSpec[] {
+  const specs: DiagnosticSpec[] = [];
+
+  for (const check of report.checks) {
+    if (check.status !== 'fail' && check.status !== 'warn') {
+      continue;
+    }
+    const detail = check.fix ? ` — ${check.fix}` : '';
+    specs.push({
+      relPath: CHECK_FILE_MAP[check.id] ?? null,
+      severity: check.status === 'fail' ? 'error' : 'warning',
+      message: `${check.label}${detail}`,
+      code: check.id,
+    });
+  }
+
+  const age = archAuditAgeDays(archAudit, nowUnix);
+  if (age != null && age > staleDays) {
+    specs.push({
+      relPath: '.claude/session/last-arch-audit',
+      severity: 'warning',
+      message: `arch-audit ${describeArchAudit(archAudit, nowUnix, staleDays)} — re-run the arch-audit skill.`,
+      code: 'arch-audit-stale',
+    });
+  }
+
+  return specs;
+}

--- a/packages/vscode-extension/src/diagnosticsProvider.ts
+++ b/packages/vscode-extension/src/diagnosticsProvider.ts
@@ -1,0 +1,94 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import * as vscode from 'vscode';
+import type { HealthSnapshot } from './cdkBackend';
+import { buildDiagnostics } from './diagnostics';
+
+const SEVERITY: Record<'error' | 'warning', vscode.DiagnosticSeverity> = {
+  error: vscode.DiagnosticSeverity.Error,
+  warning: vscode.DiagnosticSeverity.Warning,
+};
+
+// Candidate hub files, in order, for diagnostics whose target is missing or
+// not tied to a single file (e.g. multi-skill checks).
+const HUB_CANDIDATES = ['.claude/settings.json', 'CLAUDE.md', '.gitignore', 'README.md'];
+
+/**
+ * Publishes doctor failures/warnings (and a stale arch-audit) to the Problems
+ * panel. Each diagnostic anchors to the file its check concerns when that file
+ * exists; otherwise it falls back to a project hub file so it stays navigable.
+ * Driven by the shared {@link HealthSnapshot} — it does not fetch.
+ */
+export class CdkDiagnostics {
+  private readonly collection: vscode.DiagnosticCollection;
+
+  constructor() {
+    this.collection = vscode.languages.createDiagnosticCollection('cdk');
+  }
+
+  dispose(): void {
+    this.collection.dispose();
+  }
+
+  clear(): void {
+    this.collection.clear();
+  }
+
+  render(root: string, snapshot: HealthSnapshot): void {
+    this.collection.clear();
+    // No report → the status bar already signals the degraded CLI; don't leave
+    // stale check diagnostics behind.
+    if (!snapshot.report) {
+      return;
+    }
+
+    const nowUnix = Math.floor(Date.now() / 1000);
+    const specs = buildDiagnostics(snapshot.report, snapshot.archAudit, nowUnix);
+    if (specs.length === 0) {
+      return;
+    }
+
+    const hub = this.resolveHub(root);
+    const byUri = new Map<string, { uri: vscode.Uri; diags: vscode.Diagnostic[] }>();
+
+    for (const spec of specs) {
+      const uri = this.resolveUri(root, spec.relPath, hub);
+      const diag = new vscode.Diagnostic(
+        new vscode.Range(0, 0, 0, 0),
+        spec.message,
+        SEVERITY[spec.severity],
+      );
+      diag.source = 'claude-dev-kit';
+      diag.code = spec.code;
+
+      const key = uri.toString();
+      const entry = byUri.get(key) ?? { uri, diags: [] };
+      entry.diags.push(diag);
+      byUri.set(key, entry);
+    }
+
+    for (const { uri, diags } of byUri.values()) {
+      this.collection.set(uri, diags);
+    }
+  }
+
+  private resolveHub(root: string): vscode.Uri {
+    for (const rel of HUB_CANDIDATES) {
+      const abs = join(root, rel);
+      if (existsSync(abs)) {
+        return vscode.Uri.file(abs);
+      }
+    }
+    return vscode.Uri.file(root);
+  }
+
+  private resolveUri(root: string, relPath: string | null, hub: vscode.Uri): vscode.Uri {
+    if (relPath) {
+      const abs = join(root, relPath);
+      if (existsSync(abs)) {
+        return vscode.Uri.file(abs);
+      }
+    }
+    return hub;
+  }
+}

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -1,26 +1,42 @@
 import * as vscode from 'vscode';
-import { CdkBackend, CdkBackendError } from './cdkBackend';
+import { CdkBackend } from './cdkBackend';
 import { GovernanceTreeProvider } from './governanceTree';
 import { CdkStatusBar } from './statusBar';
+import { CdkDiagnostics } from './diagnosticsProvider';
 
 export function activate(context: vscode.ExtensionContext): void {
   const output = vscode.window.createOutputChannel('Claude Dev Kit');
   context.subscriptions.push(output);
 
-  const treeProvider = new GovernanceTreeProvider(() => createBackend());
-  const statusBar = new CdkStatusBar(() => createBackend());
+  const treeProvider = new GovernanceTreeProvider(() => resolveBackend());
+  const statusBar = new CdkStatusBar();
+  const diagnostics = new CdkDiagnostics();
 
-  // Coalesces a burst of file-watcher events (e.g. a git checkout touching
-  // many `.claude/` files) into a single refresh of both surfaces.
+  // Refreshes every surface from a single doctor invocation: the tree reads
+  // skills/rules from disk, while the status bar and Problems-panel diagnostics
+  // share one `HealthSnapshot` instead of each shelling out to the CLI.
+  const refreshSurfaces = async (): Promise<void> => {
+    treeProvider.refresh();
+    const root = resolveProjectRoot();
+    const backend = resolveBackend();
+    if (!root || !backend) {
+      statusBar.hide();
+      diagnostics.clear();
+      return;
+    }
+    const snapshot = await backend.getHealthSnapshot();
+    statusBar.render(snapshot);
+    diagnostics.render(root, snapshot);
+  };
+
+  // Coalesces a burst of file-watcher events (e.g. a git checkout touching many
+  // `.claude/` files) into a single refresh.
   let debounce: ReturnType<typeof setTimeout> | undefined;
-  const refreshAll = (): void => {
+  const scheduleRefresh = (): void => {
     if (debounce) {
       clearTimeout(debounce);
     }
-    debounce = setTimeout(() => {
-      treeProvider.refresh();
-      void statusBar.refresh();
-    }, 300);
+    debounce = setTimeout(() => void refreshSurfaces(), 300);
   };
 
   // Watch only the inputs the tree and doctor actually consume. Deliberately
@@ -36,76 +52,79 @@ export function activate(context: vscode.ExtensionContext): void {
     '**/CLAUDE.md',
   ]) {
     const watcher = vscode.workspace.createFileSystemWatcher(glob);
-    watcher.onDidCreate(refreshAll);
-    watcher.onDidChange(refreshAll);
-    watcher.onDidDelete(refreshAll);
+    watcher.onDidCreate(scheduleRefresh);
+    watcher.onDidChange(scheduleRefresh);
+    watcher.onDidDelete(scheduleRefresh);
     context.subscriptions.push(watcher);
   }
 
   context.subscriptions.push(
     treeProvider,
     statusBar,
+    diagnostics,
     vscode.window.registerTreeDataProvider('cdk.governance', treeProvider),
-    vscode.commands.registerCommand('cdk.refreshGovernance', () => {
-      treeProvider.refresh();
-      void statusBar.refresh();
-    }),
-    vscode.commands.registerCommand('cdk.showDoctorReport', () => runDoctorReport(output, statusBar)),
-    vscode.workspace.onDidChangeWorkspaceFolders(() => {
-      treeProvider.refresh();
-      void statusBar.refresh();
-    }),
+    vscode.commands.registerCommand('cdk.refreshGovernance', () => void refreshSurfaces()),
+    vscode.commands.registerCommand('cdk.showDoctorReport', () =>
+      runDoctorReport(output, statusBar, diagnostics),
+    ),
+    vscode.workspace.onDidChangeWorkspaceFolders(() => void refreshSurfaces()),
     { dispose: () => debounce && clearTimeout(debounce) },
   );
 
-  void statusBar.refresh();
+  void refreshSurfaces();
 }
 
 export function deactivate(): void {
   // Subscriptions are disposed by VS Code via context.subscriptions.
 }
 
-function createBackend(): CdkBackend | undefined {
-  const projectRoot = resolveProjectRoot();
-  if (!projectRoot) {
+function resolveBackend(): CdkBackend | undefined {
+  const root = resolveProjectRoot();
+  if (!root) {
     return undefined;
   }
   const cliPath =
     vscode.workspace.getConfiguration('cdk').get<string>('cliPath') ?? 'claude-dev-kit';
-  return new CdkBackend({ projectRoot, cliPath });
+  return new CdkBackend({ projectRoot: root, cliPath });
 }
 
-async function runDoctorReport(output: vscode.OutputChannel, statusBar: CdkStatusBar): Promise<void> {
-  const backend = createBackend();
-  if (!backend) {
+async function runDoctorReport(
+  output: vscode.OutputChannel,
+  statusBar: CdkStatusBar,
+  diagnostics: CdkDiagnostics,
+): Promise<void> {
+  const root = resolveProjectRoot();
+  const backend = resolveBackend();
+  if (!root || !backend) {
     void vscode.window.showWarningMessage('Claude Dev Kit: open a workspace folder first.');
     return;
   }
 
-  try {
-    const report = await vscode.window.withProgress(
-      { location: vscode.ProgressLocation.Window, title: 'Claude Dev Kit: running doctor…' },
-      () => backend.getDoctorReport(),
-    );
+  const snapshot = await vscode.window.withProgress(
+    { location: vscode.ProgressLocation.Window, title: 'Claude Dev Kit: running doctor…' },
+    () => backend.getHealthSnapshot(),
+  );
 
-    output.clear();
-    output.appendLine(JSON.stringify(report, null, 2));
-    output.show(true);
+  // The click reflects the freshly-run report on every surface.
+  statusBar.render(snapshot);
+  diagnostics.render(root, snapshot);
 
-    const { passed, warned, failed, skipped } = report.summary;
-    const total = passed + warned + failed + skipped;
-    const message = `CDK doctor: ${passed}/${total} passed, ${failed} failed, ${warned} warnings.`;
-    if (failed > 0) {
-      void vscode.window.showWarningMessage(message);
-    } else {
-      void vscode.window.showInformationMessage(message);
-    }
-  } catch (error) {
-    const message = error instanceof CdkBackendError ? error.message : String(error);
-    void vscode.window.showErrorMessage(`Claude Dev Kit: ${message}`);
-  } finally {
-    // Reflect the freshly-run report (or a now-visible failure) in the bar.
-    void statusBar.refresh();
+  if (!snapshot.report) {
+    void vscode.window.showErrorMessage(`Claude Dev Kit: ${snapshot.error ?? 'doctor failed.'}`);
+    return;
+  }
+
+  output.clear();
+  output.appendLine(JSON.stringify(snapshot.report, null, 2));
+  output.show(true);
+
+  const { passed, warned, failed, skipped } = snapshot.report.summary;
+  const total = passed + warned + failed + skipped;
+  const message = `CDK doctor: ${passed}/${total} passed, ${failed} failed, ${warned} warnings.`;
+  if (failed > 0) {
+    void vscode.window.showWarningMessage(message);
+  } else {
+    void vscode.window.showInformationMessage(message);
   }
 }
 

--- a/packages/vscode-extension/src/statusBar.ts
+++ b/packages/vscode-extension/src/statusBar.ts
@@ -1,6 +1,11 @@
 import * as vscode from 'vscode';
-import { CdkBackend, CdkBackendError, type ArchAuditStatus } from './cdkBackend';
-import { ARCH_AUDIT_STALE_DAYS, describeArchAudit, evaluateHealth, type HealthSeverity } from './health';
+import type { ArchAuditStatus, HealthSnapshot } from './cdkBackend';
+import {
+  ARCH_AUDIT_STALE_DAYS,
+  describeArchAudit,
+  evaluateHealth,
+  type HealthSeverity,
+} from './health';
 
 const BACKGROUND: Record<HealthSeverity, vscode.ThemeColor | undefined> = {
   error: new vscode.ThemeColor('statusBarItem.errorBackground'),
@@ -11,15 +16,14 @@ const BACKGROUND: Record<HealthSeverity, vscode.ThemeColor | undefined> = {
 /**
  * Owns a single status-bar item summarising project health: the `doctor`
  * pass/fail counts plus arch-audit staleness. Clicking it runs the doctor
- * report. Backend access is deferred through a factory so the item reflects
- * the current workspace folder and `cdk.cliPath` setting on every refresh.
+ * report. Rendering is driven by a {@link HealthSnapshot} supplied by the
+ * extension — the bar does not fetch, so it shares one `doctor` run with the
+ * Problems-panel diagnostics.
  */
 export class CdkStatusBar {
   private readonly item: vscode.StatusBarItem;
-  private refreshing = false;
-  private pending = false;
 
-  constructor(private readonly resolveBackend: () => CdkBackend | undefined) {
+  constructor() {
     this.item = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
     this.item.name = 'Claude Dev Kit Health';
     this.item.command = 'cdk.showDoctorReport';
@@ -29,62 +33,41 @@ export class CdkStatusBar {
     this.item.dispose();
   }
 
-  /**
-   * Re-evaluates and re-renders the item. Guards against overlapping runs:
-   * a refresh requested while one is in flight is coalesced into a single
-   * trailing run, so a burst of file-watcher events triggers `doctor` once.
-   */
-  async refresh(): Promise<void> {
-    if (this.refreshing) {
-      this.pending = true;
-      return;
-    }
-    this.refreshing = true;
-    try {
-      await this.render();
-    } finally {
-      this.refreshing = false;
-      if (this.pending) {
-        this.pending = false;
-        void this.refresh();
-      }
-    }
+  /** Hides the item — used when no workspace folder is open. */
+  hide(): void {
+    this.item.hide();
   }
 
-  private async render(): Promise<void> {
-    const backend = this.resolveBackend();
-    if (!backend) {
-      this.item.hide();
-      return;
-    }
-
+  render(snapshot: HealthSnapshot): void {
     const nowUnix = Math.floor(Date.now() / 1000);
-    const archAudit = await backend.getArchAuditStatus();
-
-    let summary;
-    try {
-      ({ summary } = await backend.getDoctorReport());
-    } catch (error) {
-      this.renderUnavailable(error, archAudit, nowUnix);
+    if (!snapshot.report) {
+      this.renderUnavailable(snapshot.error, snapshot.archAudit, nowUnix);
       return;
     }
 
-    const display = evaluateHealth({ summary, archAudit, nowUnix });
+    const display = evaluateHealth({
+      summary: snapshot.report.summary,
+      archAudit: snapshot.archAudit,
+      nowUnix,
+    });
     this.item.text = display.text;
     this.item.tooltip = new vscode.MarkdownString(display.tooltip);
     this.item.backgroundColor = BACKGROUND[display.severity];
     this.item.show();
   }
 
-  private renderUnavailable(error: unknown, archAudit: ArchAuditStatus, nowUnix: number): void {
-    const message = error instanceof CdkBackendError ? error.message : String(error);
+  private renderUnavailable(
+    error: string | null,
+    archAudit: ArchAuditStatus,
+    nowUnix: number,
+  ): void {
     this.item.text = '$(circle-slash) CDK';
     this.item.backgroundColor = undefined;
     this.item.tooltip = new vscode.MarkdownString(
       [
         '**Claude Dev Kit — health**',
         '',
-        `Doctor unavailable: ${message}`,
+        `Doctor unavailable: ${error ?? 'unknown error'}`,
         '',
         'Set `cdk.cliPath` to your claude-dev-kit CLI, or install it on PATH.',
         '',

--- a/packages/vscode-extension/test/cdkBackend.test.js
+++ b/packages/vscode-extension/test/cdkBackend.test.js
@@ -81,3 +81,26 @@ test('cliPath falls back to the default when blank', async () => {
   await backend.getDoctorReport();
   assert.equal(receivedCommand, 'claude-dev-kit');
 });
+
+test('getHealthSnapshot returns the report and arch-audit status on success', async () => {
+  const backend = new CdkBackend({
+    projectRoot: '/tmp/project',
+    exec: fakeExec(JSON.stringify(SAMPLE_REPORT)),
+  });
+  const snapshot = await backend.getHealthSnapshot();
+  assert.equal(snapshot.report.summary.failed, 1);
+  assert.equal(snapshot.error, null);
+  // No `.claude/session/last-arch-audit` under /tmp/project.
+  assert.equal(snapshot.archAudit.everRan, false);
+});
+
+test('getHealthSnapshot captures a doctor failure instead of throwing', async () => {
+  const backend = new CdkBackend({
+    projectRoot: '/tmp/project',
+    exec: fakeExec('command not found: claude-dev-kit', { fail: true }),
+  });
+  const snapshot = await backend.getHealthSnapshot();
+  assert.equal(snapshot.report, null);
+  assert.match(snapshot.error, /Failed to run/);
+  assert.equal(snapshot.archAudit.everRan, false);
+});

--- a/packages/vscode-extension/test/diagnostics.test.js
+++ b/packages/vscode-extension/test/diagnostics.test.js
@@ -1,0 +1,90 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { buildDiagnostics, CHECK_FILE_MAP } = require('../dist/diagnostics.js');
+
+const NOW = 1_700_000_000;
+const DAY = 86_400;
+const NEVER = { everRan: false, lastRunUnix: null, lastRunIso: null };
+const ranDaysAgo = (days) => ({
+  everRan: true,
+  lastRunUnix: NOW - days * DAY,
+  lastRunIso: new Date((NOW - days * DAY) * 1000).toISOString(),
+});
+
+const REPORT = {
+  timestamp: '2026-06-16T00:00:00.000Z',
+  cwd: '/x',
+  summary: { passed: 1, warned: 2, failed: 1, skipped: 1 },
+  checks: [
+    { id: 'claude-cli', label: 'Claude Code CLI installed', status: 'pass', info: null },
+    {
+      id: 'settings-json',
+      label: '.claude/settings.json present',
+      status: 'fail',
+      fix: 'Run `claude-dev-kit init`.',
+    },
+    {
+      id: 'security-rules',
+      label: '.claude/rules/security.md present',
+      status: 'warn',
+      fix: 'Copy security.md from the template.',
+    },
+    { id: 'skill-md-size-budget', label: 'Skill bodies ≤ 500 lines', status: 'warn', info: 'arch-audit (652)' },
+    { id: 'claudemd-skills-directory-parity', label: 'parity', status: 'skip' },
+  ],
+};
+
+test('buildDiagnostics drops pass/skip and keeps fail/warn', () => {
+  const specs = buildDiagnostics(REPORT, NEVER, NOW);
+  const codes = specs.map((s) => s.code).sort();
+  assert.deepEqual(codes, ['security-rules', 'settings-json', 'skill-md-size-budget']);
+});
+
+test('buildDiagnostics maps fail→error, warn→warning', () => {
+  const specs = buildDiagnostics(REPORT, NEVER, NOW);
+  assert.equal(specs.find((s) => s.code === 'settings-json').severity, 'error');
+  assert.equal(specs.find((s) => s.code === 'security-rules').severity, 'warning');
+});
+
+test('buildDiagnostics resolves the check file from the map', () => {
+  const specs = buildDiagnostics(REPORT, NEVER, NOW);
+  assert.equal(specs.find((s) => s.code === 'settings-json').relPath, '.claude/settings.json');
+  assert.equal(specs.find((s) => s.code === 'security-rules').relPath, '.claude/rules/security.md');
+});
+
+test('buildDiagnostics leaves unmapped checks at relPath null (→ hub)', () => {
+  const specs = buildDiagnostics(REPORT, NEVER, NOW);
+  assert.equal(specs.find((s) => s.code === 'skill-md-size-budget').relPath, null);
+});
+
+test('buildDiagnostics folds the fix into the message', () => {
+  const specs = buildDiagnostics(REPORT, NEVER, NOW);
+  assert.match(specs.find((s) => s.code === 'settings-json').message, /Run `claude-dev-kit init`\./);
+});
+
+test('buildDiagnostics adds a stale arch-audit warning', () => {
+  const specs = buildDiagnostics(REPORT, ranDaysAgo(10), NOW);
+  const stale = specs.find((s) => s.code === 'arch-audit-stale');
+  assert.ok(stale);
+  assert.equal(stale.severity, 'warning');
+  assert.equal(stale.relPath, '.claude/session/last-arch-audit');
+});
+
+test('buildDiagnostics omits the arch-audit warning when fresh or never run', () => {
+  assert.equal(
+    buildDiagnostics(REPORT, ranDaysAgo(3), NOW).find((s) => s.code === 'arch-audit-stale'),
+    undefined,
+  );
+  assert.equal(
+    buildDiagnostics(REPORT, NEVER, NOW).find((s) => s.code === 'arch-audit-stale'),
+    undefined,
+  );
+});
+
+test('CHECK_FILE_MAP points the three CLAUDE.md checks at CLAUDE.md', () => {
+  for (const id of ['claude-md', 'claude-md-size', 'no-secrets-claude-md']) {
+    assert.equal(CHECK_FILE_MAP[id], 'CLAUDE.md');
+  }
+});


### PR DESCRIPTION
## P3 — Diagnostics in the Problems panel

Fourth phase of the VS Code extension (#95). Surfaces `doctor --report` failures and warnings (plus a stale arch-audit) as navigable entries in the Problems panel.

### What it does
- Every `fail`/`warn` doctor check becomes a diagnostic — `fail` → Error, `warn` → Warning; `pass`/`skip` produce nothing. The check's `fix` is folded into the message and the check id rides along as the diagnostic `code`, with source `claude-dev-kit`.
- Each diagnostic anchors to the file its check concerns (via a check-id → file map mirroring `doctor.js`) when that file exists; otherwise it falls back to a project hub file (`.claude/settings.json`, else `CLAUDE.md`/…) so it stays clickable. Unmapped or new checks degrade to the hub rather than vanishing.
- A lapsed arch-audit cadence (`everRan` and older than 7 days) adds one warning anchored to the stamp file. arch-audit has no machine-readable findings beyond staleness, so that's the only arch-audit signal here.

### Architecture
- `src/diagnostics.ts` is the pure builder (the check→file map + `buildDiagnostics`) — no `vscode`, no fs, no clock — so the mapping and severity logic are unit-tested. `src/diagnosticsProvider.ts` is the thin `vscode` renderer that resolves URIs (existence check + hub fallback) and populates a `DiagnosticCollection`.
- Consolidated the doctor fetch: a new `CdkBackend.getHealthSnapshot()` runs `doctor` once and the status bar **and** diagnostics render from the same snapshot. The status bar was refactored from self-fetching to `render(snapshot)`, which also removes the duplicate doctor spawn on click that P2 left behind.

### Verification
- 33/33 unit tests, typecheck clean, builds on esbuild 0.28.1.
- **Empirical F5 gate passed** (Extension Development Host, staff-manager). Held to a falsifiable count: the captured doctor report is `{passed:12, warned:8, failed:0}`, so the Problems panel (filtered to `claude-dev-kit`) must show **exactly 8 warnings, 0 errors, no arch-audit entry** — confirmed. Navigation confirmed for a hub-anchored entry (→ `settings.json`) and a file-anchored one (→ `pipeline.md`, `.github/CODEOWNERS` resolved to its own file since it exists). Degraded-clears confirmed: blanking `cdk.cliPath` and refreshing clears all 8 and returns the status bar to `$(circle-slash)`. Status bar still reads `CDK 8⚠` (no regression from the consolidation).
- The fail→Error (red) path has no failures on staff-manager — unit-covered, not chased visually.

### Notes
- The watcher covers `skills/rules/settings.json/CLAUDE.md` but not `docs/**` or `.github/CODEOWNERS`, so fixing those won't auto-clear their diagnostic until the next refresh/trigger — consistent with P2's session-churn-avoidance scope.
- Hub-anchored diagnostics stack at line 0 of the hub file; the Problems panel is the real surface.
- Top-level README and operational-guide still defer the extension to P5 (packaging/marketplace). CI does not exercise the extension yet — its CI job lands in P5; the F5 above is the gate for this PR.

Draft until F5 sign-off; sign-off obtained, marking ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
