### PR TITLE
chore(release): v1.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,28 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [1.30.0] — 2026-06-16
+
+### Added
+
+- **VS Code extension — governance tree view (P1).** A CDK sidebar panel lists all installed skills (with tier badges) and all active governance rules from `.claude/rules/`. Clicking any entry opens the file directly in the editor. Requires the `claude-dev-kit-mcp` server running alongside the extension. (#196)
+- **VS Code extension — health monitoring and status bar (P2).** A status-bar item shows live CDK health: the `doctor` check result and the staleness of the last `arch-audit` run. The item turns amber when the audit is more than 7 days old and red when doctor reports errors. Clicking opens the CDK output channel with the full diagnostic output. (#201)
+- **VS Code extension — diagnostics in Problems panel (P3).** CDK doctor findings are now surfaced as VS Code diagnostics (errors and warnings) in the Problems panel, with file-level attribution. Findings with a resolvable file path open the relevant file on click. Refreshes automatically when the extension detects a doctor re-run. (#203)
+- **`/skill-security` — SkillSpector integration (tier S, M, L).** New audit skill that scans Claude Code skill files for 64 vulnerability patterns: prompt injection, data exfiltration, MCP tool poisoning, supply-chain attacks, and taint tracking across tool call chains. Scaffolded at tier S and above; listed in the cheatsheet for all tiers. (#202)
+
 ### Changed
 
-- **Cross-LLM rubric jury re-baselined to Opus 4.8.** The Opus seat in `scripts/cross-llm-rubric.mjs` moved from `claude-opus-4-7` to `claude-opus-4-8` (current Opus tier). This is a deliberate re-baseline, not stale drift: scores produced from 2026-06-10 onward are **not** directly comparable to the v1.0 CONTEXT.md pilot results scored under the 4.7 jury. The header comment records 2026-06-10 as the new scoring baseline.
-- **`scripts/external-review.mjs` default Opus model** bumped from `claude-opus-4-7` to `claude-opus-4-8` (maintainer-only cross-LLM review tool; not shipped in the scaffold payload).
+- **Cross-LLM rubric jury re-baselined to Opus 4.8.** The Opus seat in `scripts/cross-llm-rubric.mjs` moved from `claude-opus-4-7` to `claude-opus-4-8`. This is a deliberate re-baseline: scores produced from 2026-06-10 onward are **not** directly comparable to the v1.0 CONTEXT.md pilot results scored under the 4.7 jury.
+- **`scripts/external-review.mjs` default Opus model** bumped from `claude-opus-4-7` to `claude-opus-4-8` (maintainer-only tool; not shipped in the scaffold payload).
+- **Staging workflow.** `staging` is now the default branch and permanent integration base. All feature work branches off `staging` via a local `new-worktree.sh` helper (gitignored). `main` is squash-only, promoted from `staging` at release time.
 
 ### Docs
 
-- **`docs/operational-guide.md`** version header and footer synced from `1.28.0` to `1.29.2` to match `packages/cli/package.json` (closes the arch-audit CDK-C19 version-triple drift). The MCP read-only posture note now reads "unchanged through v1.29.2". Added a maintainer comment flagging the file size (~1490 lines, ~2.5x the ~600-line soft threshold from arch-audit P5) and a future progressive-disclosure split as a tracked task.
-- **`docs/reviews/anthropic-spec-deviations.md`** last-reviewed date refreshed to 2026-06-10 with an arch-audit re-review note: documented deviations still hold, source URLs still resolve, and the current model tier (`claude-opus-4-8`, plus `claude-fable-5` GA from 2026-06-09) is recorded for awareness.
-- **`README.md`** stale `v1.28.0` stamps synced to `v1.29.2`: the MCP read-only posture line and the "Current" release blurb, which now headlines the v1.29.x cross-LLM rubric automation. The arch-audit CDK-C19 version-triple check did not cover the README, so this drift slipped past the prior round; the local audit check has been extended to include it.
+- **`docs/operational-guide.md`** version header and footer synced to `1.30.0`.
+- **`docs/reviews/anthropic-spec-deviations.md`** last-reviewed date refreshed to 2026-06-10; current model tier (`claude-opus-4-8`, `claude-fable-5` GA) recorded.
+- **`README.md`** version stamps updated to `v1.30.0`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Read-only tools exposed:
 | `cdk_package_meta`      | CDK package name, version, CLI path, cwd                                                                                                                         |
 | `cdk_pr_review`         | reads existing `/pr-review` skill comments on a GitHub PR (verdict, severity counts). Read-only — to generate a fresh review, invoke the `/pr-review` CDK skill. |
 
-The server resolves the project root from `$CDK_PROJECT_ROOT` if set, otherwise from `process.cwd()`. v1.17.0 launched read-only by design; that posture is unchanged through v1.29.2.
+The server resolves the project root from `$CDK_PROJECT_ROOT` if set, otherwise from `process.cwd()`. v1.17.0 launched read-only by design; that posture is unchanged through v1.30.0.
 
 ---
 
@@ -219,7 +219,7 @@ The server resolves the project root from `$CDK_PROJECT_ROOT` if set, otherwise 
 
 ```bash
 node packages/cli/test/integration/run.js    # 1132 integration checks
-node --test packages/cli/test/unit/*.test.js   # 554 unit tests
+node --test 'packages/cli/test/unit/**/*.test.js'   # 585 unit tests
 ```
 
 Covers: file structure per tier, Stop hook presence, pipeline gate counts, placeholder resolution, skill pruning, security variant selection, native stack adaptation, rubric scoring, cross-stack content invariants (10 stacks — the named stacks excluding the `other` fallback), golden-file assertions (Swift, Node-TS, Python), full CLI execution via `--answers` fixtures.
@@ -251,7 +251,7 @@ A separate **template-coverage** layer (under `packages/cli/test/template-covera
 
 See [GitHub Milestones](https://github.com/marcoguillermaz/claude-dev-kit/milestones) for the 12-month plan.
 
-**Current**: v1.29.2 lands the cross-LLM rubric automation for the Context Builder (shipped in v1.29.0, closing v1.1 P5): SHOULD-PASS scoring of `CONTEXT.md` now runs as a single maintainer command against the locked jury, with v1.29.1 fixing the npm-publish lockfile and v1.29.2 dropping the deprecated `temperature` param that 400'd on Opus. Carried forward: v1.28.0's skill-review pipeline P3 robustness (Phase 1→2 gate, behavioral-fixture coverage 6→11 skills, Phase 10 closure sweep), v1.27.0's Context Builder v1.1 cycle (schema-validated `CONTEXT.md` driving non-interactive scaffolding across all four tiers), v1.22.0's `/skill-dev` v2 hotspot step (churn × debt), v1.21.0's PreToolUse runtime enforcement, and v1.20.0's MCP-aware audit skills pinned to `mcp-nvd` and `package-registry-mcp`.
+**Current**: v1.30.0 ships the VS Code extension (P1–P3): governance tree view with skill and rule browsing, live health status bar with arch-audit staleness, and CDK doctor findings surfaced as Problems panel diagnostics. Also adds `/skill-security` (SkillSpector integration, tier S+), a 64-pattern vulnerability scanner for Claude Code skill files. Carried forward: v1.29.x cross-LLM rubric automation for Context Builder, v1.28.0's skill-review pipeline P3 robustness, v1.27.0's Context Builder v1.1 cycle, v1.22.0's `/skill-dev` v2 hotspot step, v1.21.0's PreToolUse runtime enforcement, and v1.20.0's MCP-aware audit skills.
 
 **Next**: `/arch-audit` MCP-aware once the upstream Anthropic spec MCP server lands. `/privacy-audit` re-eval (Issue #97 sub-track 3) when AST tracing matures or demand signal materializes. Q2 #3 VitePress docs site (ICE 432) stays on hold.
 

--- a/docs/operational-guide.md
+++ b/docs/operational-guide.md
@@ -1,6 +1,6 @@
 # claude-dev-kit - Operational Guide
 
-**Version**: 1.29.2
+**Version**: 1.30.0
 **Audience**: Builder PMs, tech leads, and senior developers using Claude Code - from first exploration to structured, reviewable delivery
 **Format**: Reference + step-by-step. Read section 1 and your target tier section first, then use the rest as a lookup.
 
@@ -1318,7 +1318,7 @@ Wire up by adding to `.mcp.json` (project-scoped) or `~/.claude/.mcp.json` (user
 }
 ```
 
-The server resolves the project root from `$CDK_PROJECT_ROOT` if set, otherwise from the calling process's `cwd`. v1.17.0 launched read-only by design; that posture is unchanged through v1.29.2. A read-write surface remains a future-minor decision contingent on adoption signal.
+The server resolves the project root from `$CDK_PROJECT_ROOT` if set, otherwise from the calling process's `cwd`. v1.17.0 launched read-only by design; that posture is unchanged through v1.30.0. A read-write surface remains a future-minor decision contingent on adoption signal.
 
 ### Adding team-specific rules
 
@@ -1491,4 +1491,4 @@ Nine example fixtures are in `packages/cli/test/fixtures/wizard-answers/`. Copy 
 
 ---
 
-_Last updated: 2026-06-10 - v1.29.2_
+_Last updated: 2026-06-16 - v1.30.0_

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mg-claude-dev-kit",
-  "version": "1.29.2",
+  "version": "1.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mg-claude-dev-kit",
-      "version": "1.29.2",
+      "version": "1.30.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mg-claude-dev-kit",
-  "version": "1.29.2",
+  "version": "1.30.0",
   "description": "Scaffold for legible, reviewable AI-assisted development",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- VS Code extension P1–P3: governance tree view, live health status bar, Problems panel diagnostics
- `/skill-security` (SkillSpector, tier S+): 64-pattern vulnerability scanner for Claude Code skills
- Version bump `1.29.2` → `1.30.0` across `package.json`, `CHANGELOG.md`, `README.md`, `docs/operational-guide.md`

## What's included

All feature work is already on `main` (merged via individual PRs #196, #201, #202, #203). This PR adds only the release bookkeeping: version bump, CHANGELOG entry, and README/operational-guide version stamps.

## Test plan

- [x] Unit tests: 585/585 passing (`node --test 'test/unit/**/*.test.js'`)
- [x] Prettier: no formatting changes needed
- [x] Version stamps consistent across all four files
- [x] CHANGELOG [1.30.0] section covers all four PRs merged since v1.29.2

## Post-merge steps

1. Create GitHub release `v1.30.0` with the CHANGELOG [1.30.0] section as release notes
2. npm-publish workflow triggers automatically on release publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)