### PR TITLE
feat(vscode): P4 — codelens + palette + skill invocation bridge to Claude Code (#95)

### DIFF
--- a/packages/vscode-extension/esbuild.js
+++ b/packages/vscode-extension/esbuild.js
@@ -44,12 +44,20 @@ async function main() {
     outfile: 'dist/diagnostics.js',
   });
 
+  // Pure Claude Code bridge (URI builder + skill-header parser), standalone for tests.
+  const ccBridge = await esbuild.context({
+    ...baseOptions,
+    entryPoints: ['src/ccBridge.ts'],
+    outfile: 'dist/ccBridge.js',
+  });
+
   if (watch) {
     await Promise.all([
       extension.watch(),
       backend.watch(),
       health.watch(),
       diagnostics.watch(),
+      ccBridge.watch(),
     ]);
     console.log('[esbuild] watching…');
     return;
@@ -59,10 +67,12 @@ async function main() {
   await backend.rebuild();
   await health.rebuild();
   await diagnostics.rebuild();
+  await ccBridge.rebuild();
   await extension.dispose();
   await backend.dispose();
   await health.dispose();
   await diagnostics.dispose();
+  await ccBridge.dispose();
   console.log('[esbuild] build complete');
 }
 

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -51,6 +51,19 @@
         "command": "cdk.refreshGovernance",
         "title": "Claude Dev Kit: Refresh Governance",
         "icon": "$(refresh)"
+      },
+      {
+        "command": "cdk.runSkill",
+        "title": "Claude Dev Kit: Run Skill in Claude Code"
+      },
+      {
+        "command": "cdk.runSkillByName",
+        "title": "Claude Dev Kit: Run Skill (by name)"
+      },
+      {
+        "command": "cdk.runSkillInCc",
+        "title": "Run in Claude Code",
+        "icon": "$(play)"
       }
     ],
     "menus": {
@@ -59,6 +72,28 @@
           "command": "cdk.refreshGovernance",
           "when": "view == cdk.governance",
           "group": "navigation"
+        }
+      ],
+      "view/item/context": [
+        {
+          "command": "cdk.runSkillInCc",
+          "when": "view == cdk.governance && viewItem == cdk.skill.invocable",
+          "group": "inline"
+        },
+        {
+          "command": "cdk.runSkillInCc",
+          "when": "view == cdk.governance && viewItem == cdk.skill.invocable",
+          "group": "navigation"
+        }
+      ],
+      "commandPalette": [
+        {
+          "command": "cdk.runSkillByName",
+          "when": "false"
+        },
+        {
+          "command": "cdk.runSkillInCc",
+          "when": "false"
         }
       ]
     },

--- a/packages/vscode-extension/src/ccBridge.ts
+++ b/packages/vscode-extension/src/ccBridge.ts
@@ -1,0 +1,49 @@
+// Bridges skill invocation to Claude Code via its official URI handler. Claude
+// Code owns the agent loop — the extension only opens a CC tab with the slash
+// command pre-filled (NOT auto-submitted; the user reviews and presses Enter).
+// Slash commands cannot be passed on the `claude` CLI, and CC exposes no public
+// command API, so the documented `vscode://anthropic.claude-code/open` URI is
+// the supported trigger.
+
+const CC_OPEN_URI = 'vscode://anthropic.claude-code/open';
+
+/** Builds the Claude Code URI that opens a tab with `prompt` pre-filled. */
+export function buildCcUri(prompt: string): string {
+  return `${CC_OPEN_URI}?prompt=${encodeURIComponent(prompt)}`;
+}
+
+/** The slash-command form that runs a skill once submitted in Claude Code. */
+export function skillPrompt(skillName: string): string {
+  return `/${skillName}`;
+}
+
+export interface SkillHeader {
+  name: string | null;
+  /** True only when the frontmatter declares `user-invocable: true`. */
+  userInvocable: boolean;
+}
+
+/**
+ * Reads `name` and `user-invocable` from a SKILL.md frontmatter block. Pure (no
+ * `vscode`) so the codelens gating is unit-testable. Skills that don't declare
+ * `user-invocable: true` are not offered for invocation.
+ */
+export function parseSkillHeader(text: string): SkillHeader {
+  const header: SkillHeader = { name: null, userInvocable: false };
+  const match = text.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) {
+    return header;
+  }
+  for (const line of match[1].split('\n')) {
+    const pair = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (!pair) {
+      continue;
+    }
+    if (pair[1] === 'name') {
+      header.name = pair[2].trim();
+    } else if (pair[1] === 'user-invocable') {
+      header.userInvocable = pair[2].trim() === 'true';
+    }
+  }
+  return header;
+}

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -1,8 +1,10 @@
 import * as vscode from 'vscode';
 import { CdkBackend } from './cdkBackend';
-import { GovernanceTreeProvider } from './governanceTree';
+import { GovernanceTreeProvider, type GovernanceNode } from './governanceTree';
 import { CdkStatusBar } from './statusBar';
 import { CdkDiagnostics } from './diagnosticsProvider';
+import { SkillCodeLensProvider } from './skillCodeLens';
+import { buildCcUri, skillPrompt } from './ccBridge';
 
 export function activate(context: vscode.ExtensionContext): void {
   const output = vscode.window.createOutputChannel('Claude Dev Kit');
@@ -63,10 +65,25 @@ export function activate(context: vscode.ExtensionContext): void {
     statusBar,
     diagnostics,
     vscode.window.registerTreeDataProvider('cdk.governance', treeProvider),
+    vscode.languages.registerCodeLensProvider(
+      { pattern: '**/.claude/skills/**/SKILL.md' },
+      new SkillCodeLensProvider(),
+    ),
     vscode.commands.registerCommand('cdk.refreshGovernance', () => void refreshSurfaces()),
     vscode.commands.registerCommand('cdk.showDoctorReport', () =>
       runDoctorReport(output, statusBar, diagnostics),
     ),
+    vscode.commands.registerCommand('cdk.runSkill', () => pickAndRunSkill()),
+    vscode.commands.registerCommand('cdk.runSkillByName', (name: unknown) => {
+      if (typeof name === 'string') {
+        invokeSkill(name);
+      }
+    }),
+    vscode.commands.registerCommand('cdk.runSkillInCc', (node?: GovernanceNode) => {
+      if (node && node.kind === 'skill') {
+        invokeSkill(node.skill.name);
+      }
+    }),
     vscode.workspace.onDidChangeWorkspaceFolders(() => void refreshSurfaces()),
     { dispose: () => debounce && clearTimeout(debounce) },
   );
@@ -125,6 +142,36 @@ async function runDoctorReport(
     void vscode.window.showWarningMessage(message);
   } else {
     void vscode.window.showInformationMessage(message);
+  }
+}
+
+/** Opens a Claude Code tab with the skill's slash command pre-filled (not auto-run). */
+function invokeSkill(name: string): void {
+  void vscode.env.openExternal(vscode.Uri.parse(buildCcUri(skillPrompt(name))));
+}
+
+/** Palette entry: pick a user-invocable skill and bridge it to Claude Code. */
+async function pickAndRunSkill(): Promise<void> {
+  const backend = resolveBackend();
+  if (!backend) {
+    void vscode.window.showWarningMessage('Claude Dev Kit: open a workspace folder first.');
+    return;
+  }
+  const skills = (await backend.getSkillInventory()).filter((s) => s.userInvocable === true);
+  if (skills.length === 0) {
+    void vscode.window.showInformationMessage('Claude Dev Kit: no user-invocable skills found.');
+    return;
+  }
+  const picked = await vscode.window.showQuickPick(
+    skills.map((s) => ({
+      label: `$(play) /${s.name}`,
+      description: s.description ?? undefined,
+      name: s.name,
+    })),
+    { placeHolder: 'Run a skill in Claude Code' },
+  );
+  if (picked) {
+    invokeSkill(picked.name);
   }
 }
 

--- a/packages/vscode-extension/src/governanceTree.ts
+++ b/packages/vscode-extension/src/governanceTree.ts
@@ -52,7 +52,9 @@ export class GovernanceTreeProvider implements vscode.TreeDataProvider<Governanc
         item.description = skill.isCustom ? 'custom' : (skill.model ?? undefined);
         item.tooltip = skill.description ?? undefined;
         item.iconPath = new vscode.ThemeIcon(skill.isCustom ? 'star-full' : 'symbol-method');
-        item.contextValue = 'cdk.skill';
+        // `.invocable` gates the "Run in Claude Code" action to user-invocable
+        // skills, matching the codelens and palette filters.
+        item.contextValue = skill.userInvocable === true ? 'cdk.skill.invocable' : 'cdk.skill';
         item.resourceUri = vscode.Uri.file(skill.path);
         item.command = openFileCommand(skill.path);
         return item;

--- a/packages/vscode-extension/src/skillCodeLens.ts
+++ b/packages/vscode-extension/src/skillCodeLens.ts
@@ -1,0 +1,23 @@
+import * as vscode from 'vscode';
+import { parseSkillHeader } from './ccBridge';
+
+/**
+ * Adds a "Run in Claude Code" codelens at the top of a user-invocable
+ * `SKILL.md`. The lens triggers `cdk.runSkillByName`, which bridges to Claude
+ * Code. Skills without `user-invocable: true` get no lens.
+ */
+export class SkillCodeLensProvider implements vscode.CodeLensProvider {
+  provideCodeLenses(document: vscode.TextDocument): vscode.CodeLens[] {
+    const header = parseSkillHeader(document.getText());
+    if (!header.name || !header.userInvocable) {
+      return [];
+    }
+    return [
+      new vscode.CodeLens(new vscode.Range(0, 0, 0, 0), {
+        title: `$(play) Run /${header.name} in Claude Code`,
+        command: 'cdk.runSkillByName',
+        arguments: [header.name],
+      }),
+    ];
+  }
+}

--- a/packages/vscode-extension/test/ccBridge.test.js
+++ b/packages/vscode-extension/test/ccBridge.test.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { buildCcUri, skillPrompt, parseSkillHeader } = require('../dist/ccBridge.js');
+
+test('skillPrompt prefixes the skill name with a slash', () => {
+  assert.equal(skillPrompt('arch-audit'), '/arch-audit');
+});
+
+test('buildCcUri targets the Claude Code open handler with an encoded prompt', () => {
+  assert.equal(
+    buildCcUri('/arch-audit'),
+    'vscode://anthropic.claude-code/open?prompt=%2Farch-audit',
+  );
+});
+
+test('buildCcUri encodes spaces and reserved characters', () => {
+  const uri = buildCcUri('/skill-db target:table users');
+  assert.match(uri, /^vscode:\/\/anthropic\.claude-code\/open\?prompt=/);
+  assert.ok(!uri.includes(' '), 'spaces must be percent-encoded');
+  assert.equal(decodeURIComponent(uri.split('prompt=')[1]), '/skill-db target:table users');
+});
+
+test('parseSkillHeader reads name and a true user-invocable flag', () => {
+  const header = parseSkillHeader(
+    '---\nname: commit\ndescription: x\nuser-invocable: true\nmodel: sonnet\n---\nbody\n',
+  );
+  assert.equal(header.name, 'commit');
+  assert.equal(header.userInvocable, true);
+});
+
+test('parseSkillHeader treats a false flag as not invocable', () => {
+  const header = parseSkillHeader('---\nname: internal\nuser-invocable: false\n---\n');
+  assert.equal(header.name, 'internal');
+  assert.equal(header.userInvocable, false);
+});
+
+test('parseSkillHeader defaults user-invocable to false when absent', () => {
+  const header = parseSkillHeader('---\nname: bare\ndescription: x\n---\n');
+  assert.equal(header.name, 'bare');
+  assert.equal(header.userInvocable, false);
+});
+
+test('parseSkillHeader returns null name and false when there is no frontmatter', () => {
+  assert.deepEqual(parseSkillHeader('# just a heading\n'), { name: null, userInvocable: false });
+});


### PR DESCRIPTION
## P4 — Codelens + palette + skill invocation (bridge to Claude Code)

Fifth phase of the VS Code extension (#95). Adds three ways to launch a skill in Claude Code, all going through CC's official URI handler — the extension triggers, Claude Code owns the agent loop.

### Bridge mechanism
- `vscode.env.openExternal("vscode://anthropic.claude-code/open?prompt=<encoded /skill>")` — opens a Claude Code tab with the slash command **pre-filled, not auto-submitted** (the user reviews and presses Enter). This is the only documented public trigger: slash commands can't be passed on the `claude` CLI, and CC exposes no extension command API (confirmed against the official VS Code / CLI docs).
- `src/ccBridge.ts` is the pure, vscode-free layer (`buildCcUri`, `skillPrompt`, `parseSkillHeader`) — unit-tested.

### Surfaces
- **Codelens** on `.claude/skills/**/SKILL.md`: "▶ Run /<skill> in Claude Code" at the top — only when the frontmatter declares `user-invocable: true`.
- **Command palette**: "Claude Dev Kit: Run Skill in Claude Code" → QuickPick of the user-invocable skills from the inventory.
- **Tree**: an inline ▶ icon and a right-click "Run in Claude Code" on skill nodes — gated to user-invocable skills via the `cdk.skill.invocable` context value, matching the codelens and palette filters.

### Verification
- 40/40 unit tests, typecheck clean, builds on esbuild 0.28.1.
- **Empirical F5 gate passed** (Extension Development Host, staff-manager):
  - Codelens positive: `commit/SKILL.md` (`user-invocable: true`) shows the lens.
  - Codelens negative: `phase-design/SKILL.md` (`user-invocable: false`) shows no lens.
  - Bridge: clicking the lens opens a Claude Code tab with exactly `/commit` pre-filled (recognised as a slash command, not auto-run).
  - The tree gating fix (invocable-only) landed after the F5 screenshots; it reuses the same `user-invocable` signal as the verified codelens gating (a declarative `when`-clause change).

### Notes
- Built in an isolated git worktree (`worktree-vscode-p4`) per the new multi-session workflow; base is an ancestor of `staging`, so this targets `staging` with a clean P4-only diff.
- No CLI dependency — the surfaces read skills from disk; no `doctor` shell-out, so no `cdk.cliPath` needed.
- Top-level README / operational-guide still defer to packaging (P5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
