### PR TITLE
rebrand: claude-dev-kit → tierward (M1 R1 — reversible, name + reference sweep)

### DIFF
--- a/.claude/skills/external-review/SKILL.md
+++ b/.claude/skills/external-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: external-review
-description: Run a fresh-context review of CDK before a release. --mode=quick spawns a Claude general-purpose subagent with no project memory and an auto-bundled snapshot. --mode=full fans out the same bundle to GPT-4.1, Gemini 2.5 Pro, Mistral Large, and Perplexity Sonar Pro for cross-LLM coverage. Maintainer-only; not shipped to user projects.
+description: Run a fresh-context review of Tierward before a release. --mode=quick spawns a Claude general-purpose subagent with no project memory and an auto-bundled snapshot. --mode=full fans out the same bundle to GPT-4.1, Gemini 2.5 Pro, Mistral Large, and Perplexity Sonar Pro for cross-LLM coverage. Maintainer-only; not shipped to user projects.
 user-invocable: true
 model: sonnet
 context: fork
@@ -10,7 +10,7 @@ argument-hint: --mode=quick|full [--focus=<area>]
 
 # external-review
 
-Pre-release sanity pass for CDK. Two modes:
+Pre-release sanity pass for Tierward. Two modes:
 
 - `--mode=quick` (default) — single fresh-context Claude review. Cost: ~$0.10, ~60 seconds. Use on every release.
 - `--mode=full` — cross-LLM (GPT-4.1 / Gemini 2.5 Pro / Mistral Large / Perplexity Sonar Pro) via `scripts/external-review.mjs`. Cost: ~$0.50–2, ~5 minutes. Use at milestones (v2.0, every 4–6 minor releases, before strategic pivots).
@@ -21,7 +21,7 @@ Cross-LLM catches two distinct blind-spot classes: (a) memory-isolation / fresh-
 
 ## Configuration
 
-- Prompt source: `docs/reviews/external-review-prompt.md` (single living file, frontmatter `version:` synced to current CDK release)
+- Prompt source: `docs/reviews/external-review-prompt.md` (single living file, frontmatter `version:` synced to current Tierward release)
 - Bundle script: `scripts/external-review-bundle.mjs` (auto-curated: README + CHANGELOG slice + 1 SKILL sample + Tier-M pipeline + roadmap-status)
 - Cross-LLM script: `scripts/external-review.mjs` (existing, providers via env keys)
 - Output base: `docs/reviews/<YYYY-MM-DD>-<mode>/` (committed; cite in PRs and roadmap entries)
@@ -38,7 +38,7 @@ Compute `RUN_DIR=docs/reviews/$(date -u +%Y-%m-%d)-<mode>/`. If it already exist
 
 ### Step 2 — Verify prompt freshness
 
-Read frontmatter of `docs/reviews/external-review-prompt.md`. If `version` does not match the current CDK release (read from `packages/cli/package.json`), STOP and print: "Prompt is stale (prompt={X}, CDK={Y}). Update docs/reviews/external-review-prompt.md frontmatter and content before running." Do NOT auto-update — the prompt body has CDK-state numbers that need a human review.
+Read frontmatter of `docs/reviews/external-review-prompt.md`. If `version` does not match the current Tierward release (read from `packages/cli/package.json`), STOP and print: "Prompt is stale (prompt={X}, Tierward={Y}). Update docs/reviews/external-review-prompt.md frontmatter and content before running." Do NOT auto-update — the prompt body has Tierward-state numbers that need a human review.
 
 ### Step 3 — Auto-bundle
 
@@ -46,14 +46,14 @@ Run `node scripts/external-review-bundle.mjs --out RUN_DIR/bundle/`. Verify exit
 
 ### Step 4 — Materialize the prompt
 
-Read `docs/reviews/external-review-prompt.md`, substitute `{VERSION}` → current CDK version (from `package.json`) and `{FOCUS_AREA}` → the resolved focus token. Write to `RUN_DIR/prompt.md`.
+Read `docs/reviews/external-review-prompt.md`, substitute `{VERSION}` → current Tierward version (from `package.json`) and `{FOCUS_AREA}` → the resolved focus token. Write to `RUN_DIR/prompt.md`.
 
 ### Step 5a — Quick mode (default)
 
 Use the Agent tool with `subagent_type=general-purpose`. Compose the agent prompt as:
 
 ```
-You have NO prior memory of the claude-dev-kit project. The only context you have is the bundle below. Treat any claim not grounded in the bundle as unverified.
+You have NO prior memory of the tierward project. The only context you have is the bundle below. Treat any claim not grounded in the bundle as unverified.
 
 [contents of RUN_DIR/prompt.md]
 
@@ -77,7 +77,7 @@ BUNDLE FILES (each is a separate file in the same review snapshot):
 [contents]
 ```
 
-Inline the bundle contents (read from `RUN_DIR/bundle/`). Spawn a single agent. Capture its response. Write to `RUN_DIR/responses/claude-fresh.md` with a header line: `## Claude (general-purpose, fresh context) — CDK <VERSION> — Focus: <FOCUS_AREA> — <ISO date>`.
+Inline the bundle contents (read from `RUN_DIR/bundle/`). Spawn a single agent. Capture its response. Write to `RUN_DIR/responses/claude-fresh.md` with a header line: `## Claude (general-purpose, fresh context) — Tierward <VERSION> — Focus: <FOCUS_AREA> — <ISO date>`.
 
 ### Step 5b — Full mode
 
@@ -97,7 +97,7 @@ Verify the script's preflight: 0 providers = abort with the printed instruction.
 Read every file in `RUN_DIR/responses/`. Produce `RUN_DIR/synthesis.md` with this structure:
 
 ```
-# CDK <VERSION> — External Review Synthesis
+# Tierward <VERSION> — External Review Synthesis
 Date: <ISO>
 Mode: <mode>
 Focus: <focus>
@@ -137,4 +137,4 @@ Print the path to `RUN_DIR/`, list every file produced, and the suggested `git a
 
 ## Output
 
-A populated `docs/reviews/<YYYY-MM-DD>-<mode>/` directory and a printed summary. No git commit, no version bump, no modification to other CDK files.
+A populated `docs/reviews/<YYYY-MM-DD>-<mode>/` directory and a printed summary. No git commit, no version bump, no modification to other Tierward files.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -20,7 +20,7 @@ body:
     attributes:
       label: Steps to reproduce
       placeholder: |
-        1. Run `npx mg-claude-dev-kit ...`
+        1. Run `npx tierward ...`
         2. ...
     validations:
       required: true
@@ -36,7 +36,7 @@ body:
   - type: input
     id: cdk-version
     attributes:
-      label: claude-dev-kit version
+      label: tierward version
       placeholder: "1.28.0"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Support / Questions
-    url: https://github.com/marcoguillermaz/claude-dev-kit/discussions/categories/q-a
+    url: https://github.com/marcoguillermaz/tierward/discussions/categories/q-a
     about: Ask questions and get help from the community in GitHub Discussions.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -25,7 +25,7 @@ body:
       options:
         - label: Builder PM
         - label: Tech lead / staff engineer
-        - label: Developer on team using claude-dev-kit
+        - label: Developer on team using tierward
         - label: All users
 
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/skill_request.yml
+++ b/.github/ISSUE_TEMPLATE/skill_request.yml
@@ -1,5 +1,5 @@
 name: Skill request
-description: Request a new audit skill for claude-dev-kit
+description: Request a new audit skill for tierward
 labels: ["skill-request"]
 body:
   - type: input

--- a/.github/drift-tracker/features.json
+++ b/.github/drift-tracker/features.json
@@ -20,7 +20,7 @@
         "packages/cli/src/generators/claude-md.js",
         "packages/cli/templates/"
       ],
-      "notes": "Anthropic's /init already generates CLAUDE.md. Watch for richer templates that overlap with CDK's tiered scaffolding."
+      "notes": "Anthropic's /init already generates CLAUDE.md. Watch for richer templates that overlap with Tierward's tiered scaffolding."
     },
     {
       "id": "settings-json-config",
@@ -39,7 +39,7 @@
         "packages/cli/templates/tier-m/.claude/settings.json",
         "packages/cli/templates/tier-l/.claude/settings.json"
       ],
-      "notes": "Anthropic has a managed settings scope. If they ship a configuration wizard or admin console, CDK's scaffolded settings.json loses unique value."
+      "notes": "Anthropic has a managed settings scope. If they ship a configuration wizard or admin console, Tierward's scaffolded settings.json loses unique value."
     },
     {
       "id": "generic-hooks",
@@ -58,7 +58,7 @@
         "packages/cli/templates/tier-m/.claude/settings.json",
         "packages/cli/src/commands/doctor.js"
       ],
-      "notes": "CDK wires Stop, SessionStart, PostToolUse hooks. If Anthropic ships pre-configured hook templates, this becomes redundant."
+      "notes": "Tierward wires Stop, SessionStart, PostToolUse hooks. If Anthropic ships pre-configured hook templates, this becomes redundant."
     },
     {
       "id": "shallow-skills",
@@ -76,7 +76,7 @@
         "packages/cli/templates/common/skills/commit/",
         "packages/cli/templates/common/skills/simplify/"
       ],
-      "notes": "CDK ships /commit and /simplify as shallow skills. If Anthropic bundles equivalent skills natively, these lose value."
+      "notes": "Tierward ships /commit and /simplify as shallow skills. If Anthropic bundles equivalent skills natively, these lose value."
     },
     {
       "id": "stack-detection",
@@ -94,7 +94,7 @@
         "packages/cli/src/utils/detect-stack.js",
         "packages/cli/src/scaffold/skill-registry.js"
       ],
-      "notes": "CDK detects 11 tech stacks to adapt security rules, skills, and permissions. Native stack detection would reduce this advantage."
+      "notes": "Tierward detects 11 tech stacks to adapt security rules, skills, and permissions. Native stack detection would reduce this advantage."
     },
     {
       "id": "multi-tier-scaffolding",
@@ -114,7 +114,7 @@
         "packages/cli/templates/tier-m/",
         "packages/cli/templates/tier-l/"
       ],
-      "notes": "CDK's four tiers (Discovery/Fast Lane/Standard/Full) are its primary structural differentiator."
+      "notes": "Tierward's four tiers (Discovery/Fast Lane/Standard/Full) are its primary structural differentiator."
     },
     {
       "id": "rules-markdown",
@@ -131,7 +131,7 @@
       "cdkFiles": [
         "packages/cli/templates/common/rules/"
       ],
-      "notes": "CDK scaffolds pipeline.md, security.md, git.md as rules. If Anthropic ships starter rule templates, this overlap grows."
+      "notes": "Tierward scaffolds pipeline.md, security.md, git.md as rules. If Anthropic ships starter rule templates, this overlap grows."
     },
     {
       "id": "pipeline-stop-gates",
@@ -149,7 +149,7 @@
         "packages/cli/templates/tier-m/rules/pipeline.md",
         "packages/cli/templates/tier-l/rules/pipeline.md"
       ],
-      "notes": "CDK's multi-phase pipeline with STOP gates is deep and opinionated. Low absorption risk but monitor for native workflow features."
+      "notes": "Tierward's multi-phase pipeline with STOP gates is deep and opinionated. Low absorption risk but monitor for native workflow features."
     },
     {
       "id": "team-settings",
@@ -164,7 +164,7 @@
       ],
       "keywordMode": "any",
       "cdkFiles": [],
-      "notes": "CDK plans team-settings.json for org enforcement. Anthropic has server-managed settings via admin console - watch for expansion."
+      "notes": "Tierward plans team-settings.json for org enforcement. Anthropic has server-managed settings via admin console - watch for expansion."
     },
     {
       "id": "cross-project-analytics",
@@ -178,7 +178,7 @@
       ],
       "keywordMode": "any",
       "cdkFiles": [],
-      "notes": "CDK's SaaS layer (Q2) aggregates doctor reports across projects. No current Anthropic equivalent."
+      "notes": "Tierward's SaaS layer (Q2) aggregates doctor reports across projects. No current Anthropic equivalent."
     },
     {
       "id": "deep-audit-skills",
@@ -195,7 +195,7 @@
       "cdkFiles": [
         "packages/cli/templates/common/skills/"
       ],
-      "notes": "CDK ships 12 deep audit skills with model routing. Single-skill native equivalents are possible but full suite is unlikely."
+      "notes": "Tierward ships 12 deep audit skills with model routing. Single-skill native equivalents are possible but full suite is unlikely."
     },
     {
       "id": "skill-marketplace",
@@ -212,7 +212,7 @@
       "cdkFiles": [
         "packages/cli/src/scaffold/skill-registry.js"
       ],
-      "notes": "CDK plans a public skill registry (Q4). If Anthropic ships a native skill marketplace, this becomes redundant."
+      "notes": "Tierward plans a public skill registry (Q4). If Anthropic ships a native skill marketplace, this becomes redundant."
     }
   ]
 }

--- a/.github/workflows/discussion-monitor.yml
+++ b/.github/workflows/discussion-monitor.yml
@@ -20,12 +20,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh issue list \
-            --repo marcoguillermaz/claude-dev-kit \
+            --repo marcoguillermaz/tierward \
             --label "discussions" \
             --state open \
             --json number -q '.[].number' | while read num; do
             gh issue close "$num" \
-              --repo marcoguillermaz/claude-dev-kit \
+              --repo marcoguillermaz/tierward \
               --comment "Superseded by new weekly scan."
           done
 
@@ -38,7 +38,7 @@ jobs:
 
           # Look up Q&A category ID dynamically
           QA_ID=$(gh api graphql -f query='
-            { repository(owner:"marcoguillermaz", name:"claude-dev-kit") {
+            { repository(owner:"marcoguillermaz", name:"tierward") {
               discussionCategories(first:10) {
                 nodes { id slug }
               }
@@ -52,7 +52,7 @@ jobs:
 
           RESULT=$(gh api graphql -f query='
             query($categoryId: ID!) {
-              repository(owner:"marcoguillermaz", name:"claude-dev-kit") {
+              repository(owner:"marcoguillermaz", name:"tierward") {
                 discussions(
                   first: 50
                   categoryId: $categoryId
@@ -101,7 +101,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh issue create \
-            --repo marcoguillermaz/claude-dev-kit \
+            --repo marcoguillermaz/tierward \
             --title "Unanswered Q&A discussions — $(date -u '+%Y-%m-%d')" \
             --body "${{ steps.query.outputs.body }}" \
             --label "discussions"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to claude-dev-kit are documented here.
+All notable changes to tierward (formerly claude-dev-kit) are documented here.
 
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
@@ -8,6 +8,10 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ---
 
 ## [Unreleased]
+
+### Changed
+
+- **Renamed `claude-dev-kit` → `tierward`.** The npm package, CLI binary, and MCP server now ship as `tierward` (and `tierward-mcp`). The old `claude-dev-kit` and `claude-dev-kit-mcp` binaries stay working as aliases through the deprecation window, the `mg-claude-dev-kit` npm package is deprecated in favour of `tierward`, and existing clones keep pulling via GitHub's repository redirect. (Release announcement prose is humanized at cutover per R2.)
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to claude-dev-kit
+# Contributing to tierward
 
-Thanks for considering a contribution. claude-dev-kit (CDK) is a scaffold for legible, reviewable AI-assisted development on top of Claude Code. Its core differentiation is mechanical enforcement: a Stop hook that blocks task completion until tests pass, and audit skills that run static checks rather than judgment-heavy probes. Every contribution should preserve that principle. When in doubt, prefer a check that grep can execute over one that needs an LLM to reason about.
+Thanks for considering a contribution. tierward (Tierward) is a scaffold for legible, reviewable AI-assisted development on top of Claude Code. Its core differentiation is mechanical enforcement: a Stop hook that blocks task completion until tests pass, and audit skills that run static checks rather than judgment-heavy probes. Every contribution should preserve that principle. When in doubt, prefer a check that grep can execute over one that needs an LLM to reason about.
 
 This guide covers what you need to ship a PR: local setup, the conventions we follow, how PRs are reviewed, and what we expect from skill authors. Read the section that matches your contribution and skim the rest. The "For maintainers" section at the end is for repo administrators handling release cycles.
 
@@ -21,8 +21,8 @@ This guide covers what you need to ship a PR: local setup, the conventions we fo
 **Requirements**: Node.js >= 22, Git, a working `gh` CLI if you plan to open a PR from the terminal.
 
 ```bash
-git clone https://github.com/marcoguillermaz/claude-dev-kit.git
-cd claude-dev-kit
+git clone https://github.com/marcoguillermaz/tierward.git
+cd tierward
 cd packages/cli && npm install
 ```
 
@@ -61,10 +61,10 @@ CI runs prettier --check on every PR. A failure here blocks merge — apply `for
 ## 3. Project structure
 
 ```
-claude-dev-kit/
+tierward/
 ├── CHANGELOG.md, README.md, CONTRIBUTING.md, SECURITY.md
 ├── docs/
-│   ├── operational-guide.md         # Audience: teams adopting CDK (full reference)
+│   ├── operational-guide.md         # Audience: teams adopting Tierward (full reference)
 │   ├── custom-skills.md             # Audience: skill authors (frontmatter + body schema)
 │   ├── product-brief.md             # Strategic positioning
 │   ├── workspace-quality-rubric.md  # 8-dimension scoring
@@ -113,7 +113,7 @@ These principles drive review decisions. Internalize them before writing code or
 
 **Byte-identical Tier M and Tier L by default.** When a skill applies to both M and L, the two copies must be byte-identical. Use `cp` after writing the M version. If a skill genuinely needs different framing for L (rare), explain why in the PR description.
 
-**Body length budget**: 500 lines per `SKILL.md` body (frontmatter excluded). Doctor enforces this as `skill-md-size-budget` (warn). Integration test enforces it as a hard fail (CDK-internal). When you approach the limit, extract content into a sibling file (`PATTERNS.md`, `REPORT.md`, `PROFILES.md`, `advanced-checks.md`) — progressive disclosure per Anthropic spec.
+**Body length budget**: 500 lines per `SKILL.md` body (frontmatter excluded). Doctor enforces this as `skill-md-size-budget` (warn). Integration test enforces it as a hard fail (Tierward-internal). When you approach the limit, extract content into a sibling file (`PATTERNS.md`, `REPORT.md`, `PROFILES.md`, `advanced-checks.md`) — progressive disclosure per Anthropic spec.
 
 **Spec-compliant frontmatter.** `allowed-tools` must be space-separated (`Read Glob Grep Bash`), not comma-separated. The doctor check `skill-allowed-tools-syntax` warns on commas; integration tests fail on them.
 
@@ -123,7 +123,7 @@ These principles drive review decisions. Internalize them before writing code or
 
 These conventions are mandatory for every PR. We follow them ourselves on every release; we expect contributors to follow them too.
 
-**R1 — Every commit goes through `/commit`.** The CDK repo uses the `/commit` skill (defined in `.claude/skills/commit/SKILL.md`) to enforce Conventional Commits 1.0.0 with a fixed scope taxonomy: `cli`, `scaffold`, `wizard`, `templates`, `drift-tracker`, `arch-audit`, `docs`, `deps`, `release`, `ci`, `context`, `scripts`. No `git commit -m "..."` directly. If a pre-commit hook fails, fix the underlying issue and re-invoke `/commit` — never `--amend`, never `--no-verify`.
+**R1 — Every commit goes through `/commit`.** The Tierward repo uses the `/commit` skill (defined in `.claude/skills/commit/SKILL.md`) to enforce Conventional Commits 1.0.0 with a fixed scope taxonomy: `cli`, `scaffold`, `wizard`, `templates`, `drift-tracker`, `arch-audit`, `docs`, `deps`, `release`, `ci`, `context`, `scripts`. No `git commit -m "..."` directly. If a pre-commit hook fails, fix the underlying issue and re-invoke `/commit` — never `--amend`, never `--no-verify`.
 
 **R2 — Humanize prose for user-facing GitHub content.** Run the `/humanize` skill on README updates, CHANGELOG release-note paragraphs (the human prose, not the bullet list), CONTRIBUTING / SECURITY changes, GitHub Release descriptions, and PR bodies. The skill removes AI tells (mechanical scaffolding, hedging, em-dash overuse, "In conclusion" closers) without inventing facts. Domain hints: `announcement` for marketing copy, `generico` for technical sections.
 
@@ -269,7 +269,7 @@ Pick a short uppercase prefix for findings that the skill produces. Existing pre
 
 ## 7. Testing strategy
 
-CDK ships two test layers:
+Tierward ships two test layers:
 
 **Unit tests** (`packages/cli/test/unit/*.test.js`) cover pure functions: `skill-registry`, `doctor-cross-file`, `skill-frontmatter`, individual scaffold helpers. Use `node:test`. Run via `npm run --prefix packages/cli test:unit`. Total: 373 tests across 61 suites.
 
@@ -323,12 +323,12 @@ We respond to all PRs within a few working days. Drive-by typo fixes get fast-me
 ## 9. Reporting bugs and feature requests
 
 **Bug Report** template fields:
-- Command you ran (`npx mg-claude-dev-kit init`, `doctor`, etc.)
+- Command you ran (`npx tierward init`, `doctor`, etc.)
 - Expected vs actual behavior
 - Node.js version (`node --version`)
 - OS and shell
 
-**Feature Request** template asks for use case before feature description. We weigh feature requests against the active roadmap (see [GitHub Milestones](https://github.com/marcoguillermaz/claude-dev-kit/milestones) and the `roadmap-status.md` rolled into each release). Skill requests via the Skill Request template are evaluated against the existing portfolio — if the request overlaps with an existing skill, we'll suggest extending the existing one rather than creating a new one.
+**Feature Request** template asks for use case before feature description. We weigh feature requests against the active roadmap (see [GitHub Milestones](https://github.com/marcoguillermaz/tierward/milestones) and the `roadmap-status.md` rolled into each release). Skill requests via the Skill Request template are evaluated against the existing portfolio — if the request overlaps with an existing skill, we'll suggest extending the existing one rather than creating a new one.
 
 For security-relevant issues, use the SECURITY.md disclosure path, not a public GitHub issue.
 

--- a/README.md
+++ b/README.md
@@ -1,27 +1,27 @@
-# claude-dev-kit
+# tierward
 
-[![npm version](https://img.shields.io/npm/v/mg-claude-dev-kit.svg)](https://www.npmjs.com/package/mg-claude-dev-kit)
+[![npm version](https://img.shields.io/npm/v/tierward.svg)](https://www.npmjs.com/package/tierward)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Node.js >= 22](https://img.shields.io/badge/node-%3E%3D22-brightgreen.svg)](https://nodejs.org)
-[![CI](https://github.com/marcoguillermaz/claude-dev-kit/actions/workflows/ci.yml/badge.svg)](https://github.com/marcoguillermaz/claude-dev-kit/actions/workflows/ci.yml)
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/marcoguillermaz/claude-dev-kit/badge)](https://securityscorecards.dev/viewer/?uri=github.com/marcoguillermaz/claude-dev-kit)
+[![CI](https://github.com/marcoguillermaz/tierward/actions/workflows/ci.yml/badge.svg)](https://github.com/marcoguillermaz/tierward/actions/workflows/ci.yml)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/marcoguillermaz/tierward/badge)](https://securityscorecards.dev/viewer/?uri=github.com/marcoguillermaz/tierward)
 
 > Scaffold for legible, reviewable AI-assisted development.
 > Claude generates. Your team decides.
-> MCP-native — read CDK governance state from Claude Desktop, ChatGPT, Cursor, VS Code.
+> MCP-native — read Tierward governance state from Claude Desktop, ChatGPT, Cursor, VS Code.
 
 Claude Code is a powerful CLI that reads, writes, and reasons about your entire codebase. Without shared process, it makes autonomous decisions that are hard to track and harder to review.
 
-**claude-dev-kit** scaffolds a structured, reviewable development process on top of Claude Code. It enforces one non-negotiable rule mechanically: Claude cannot declare a task complete until your tests pass. Everything else scales with your needs.
+**tierward** scaffolds a structured, reviewable development process on top of Claude Code. It enforces one non-negotiable rule mechanically: Claude cannot declare a task complete until your tests pass. Everything else scales with your needs.
 
-Since v1.17.0, CDK ships an MCP server alongside the CLI. Any MCP-aware client can read your project's doctor report, team-settings policy, last arch-audit, and skill inventory without anyone running the CDK CLI. See [MCP server](#mcp-server).
+Since v1.17.0, Tierward ships an MCP server alongside the CLI. Any MCP-aware client can read your project's doctor report, team-settings policy, last arch-audit, and skill inventory without anyone running the Tierward CLI. See [MCP server](#mcp-server).
 
 ---
 
 ## Quick Start
 
 ```bash
-npx mg-claude-dev-kit init
+npx tierward init
 ```
 
 The wizard detects your project state and guides you through setup. Three paths available:
@@ -39,11 +39,11 @@ After init, open Claude Code and start working. The scaffold is active immediate
 Run `context` before `init` if you want the scaffold to come out the same way every time, with a written record of what you asked for:
 
 ```bash
-npx mg-claude-dev-kit context                       # produces CONTEXT.md
-npx mg-claude-dev-kit init                          # reads CONTEXT.md, scaffolds with no further prompts
-npx mg-claude-dev-kit context --all                 # one-shot: context then init
-npx mg-claude-dev-kit context --from-yaml file.md   # bypass interview, validate + copy
-npx mg-claude-dev-kit validate-context              # CI gate: exit 0/1 on schema check
+npx tierward context                       # produces CONTEXT.md
+npx tierward init                          # reads CONTEXT.md, scaffolds with no further prompts
+npx tierward context --all                 # one-shot: context then init
+npx tierward context --from-yaml file.md   # bypass interview, validate + copy
+npx tierward validate-context              # CI gate: exit 0/1 on schema check
 ```
 
 `CONTEXT.md` is a schema-validated project context file. Greenfield runs a PM-friendly interview. Existing repos go through three-phase inference: algorithmic detection, LLM extraction, hybrid PM review. The first question routes you to a PM or developer flow. The developer flow reuses the technical questions from the legacy `init` wizards (projectName, stack, commands, scaffold options) and auto-derives `tier.rationale` from team size + work scope, so devs are not asked to write PM rationale prose.
@@ -63,7 +63,7 @@ As of v1.27.0, the schema covers all four pipeline tiers: tier 0 (Discovery) and
 | **M - Standard**  | 8 phases, 2 STOP gates  | Feature blocks, 1-2 collaborators     |
 | **L - Full**      | 14 phases, 4 STOP gates | Team projects, complex domain changes |
 
-Start at Tier 0. Move up when you need more structure: `npx mg-claude-dev-kit upgrade --tier=m`
+Start at Tier 0. Move up when you need more structure: `npx tierward upgrade --tier=m`
 
 ### 24 audit skills
 
@@ -86,7 +86,7 @@ Executable multi-step programs that run inside Claude Code. Not prompt instructi
 | `/ui-audit`            | M L   | Design token compliance, component adoption, empty states.                                                                                                                                                                                                                                                                                                                                                                                     |
 | `/accessibility-audit` | M L   | axe-core WCAG 2.2, APCA contrast, static a11y (aria, tabindex, focus, labels).                                                                                                                                                                                                                                                                                                                                                                 |
 | `/test-audit`          | M L   | Coverage (lcov/Istanbul/Cobertura/go/tarpaulin/xcresult), pyramid shape, anti-patterns (`.only`, skipped, empty, no-assertion, sleeps).                                                                                                                                                                                                                                                                                                        |
-| `/doc-audit`           | M L   | Doc drift: link resolution, code-block syntax (json/yaml/toml), CDK placeholder residuals, slash-command name match, skill-count consistency, ADR freshness, stack-sync (Next.js/Django/Swift).                                                                                                                                                                                                                                                |
+| `/doc-audit`           | M L   | Doc drift: link resolution, code-block syntax (json/yaml/toml), Tierward placeholder residuals, slash-command name match, skill-count consistency, ADR freshness, stack-sync (Next.js/Django/Swift).                                                                                                                                                                                                                                                |
 | `/api-contract-audit`  | M L   | OpenAPI contract drift (endpoints, schemas, status), breaking-change detection vs previous spec, versioning consistency, security scheme alignment, Richardson Maturity L0-L3 scoring. Auto-gen for FastAPI / NestJS / Express+swagger-jsdoc / Next.js route handlers / Django REST.                                                                                                                                                           |
 | `/infra-audit`         | M L   | Infrastructure security across GitHub Actions (pwn-request, secret logging, pinning, permissions), Dockerfile (root, latest tag, URL add), K8s (runAsNonRoot, privileged, hostNetwork), Terraform (IAM wildcards, state in git), GitLab CI. Stack-agnostic.                                                                                                                                                                                    |
 | `/compliance-audit`    | M L   | GDPR profile: data-subject rights (delete, export, rectify), consent, lawful basis, PII identification, encryption-at-rest on special-category, logging hygiene, retention, sub-processors. SOC 2 / HIPAA scaffolded for v1.15+.                                                                                                                                                                                                               |
@@ -104,16 +104,16 @@ Node.js/TS, Node.js/JS, Python, Go, Swift, Kotlin, Rust, .NET, Ruby, Java - plus
 
 ### MCP server (v1.17.0+)
 
-The `mg-claude-dev-kit` package ships an MCP server (`claude-dev-kit-mcp` binary) alongside the CLI, version-locked, single `npm install -g`. Any MCP-aware client (Claude Desktop, ChatGPT desktop, Cursor, VS Code, Copilot Studio) can query CDK governance state without the CDK CLI running. Six read-only tools cover doctor report, team-settings, last arch-audit, skill inventory, package metadata, and `/pr-review` comments. Full reference in the [MCP server](#mcp-server) section below.
+The `tierward` package ships an MCP server (`tierward-mcp` binary) alongside the CLI, version-locked, single `npm install -g`. Any MCP-aware client (Claude Desktop, ChatGPT desktop, Cursor, VS Code, Copilot Studio) can query Tierward governance state without the Tierward CLI running. Six read-only tools cover doctor report, team-settings, last arch-audit, skill inventory, package metadata, and `/pr-review` comments. Full reference in the [MCP server](#mcp-server) section below.
 
 ### Incremental adoption
 
 Install individual components without a full scaffold:
 
 ```bash
-npx mg-claude-dev-kit add skill security-audit   # install one skill
-npx mg-claude-dev-kit add rule git                # install one rule
-npx mg-claude-dev-kit add rule security --stack swift  # stack-specific variant
+npx tierward add skill security-audit   # install one skill
+npx tierward add rule git                # install one rule
+npx tierward add rule security --stack swift  # stack-specific variant
 ```
 
 Custom skills (`custom-*` prefix) are preserved across upgrades. See [Custom Skills Guide](docs/custom-skills.md).
@@ -135,7 +135,7 @@ your-project/
 │   │   └── output-style.md      # Communication rules
 │   ├── skills/                  # Audit skills (conditional per project)
 │   ├── session/                 # Session recovery (gitignored)
-│   └── .mcp.json                # Wire claude-dev-kit-mcp into MCP-aware clients (v1.17+)
+│   └── .mcp.json                # Wire tierward-mcp into MCP-aware clients (v1.17+)
 ├── docs/                        # Requirements, specs, backlog (M/L)
 ├── .github/                     # PR template, CODEOWNERS
 └── .pre-commit-config.yaml      # Secret scanning
@@ -148,32 +148,32 @@ The Stop hook in `settings.json` is the core enforcement mechanism. It blocks Cl
 ## CLI Commands
 
 ```bash
-npx mg-claude-dev-kit init                    # scaffold wizard
-npx mg-claude-dev-kit init --dry-run          # preview without writing
-npx mg-claude-dev-kit init --answers file.json  # skip prompts (CI/automation)
-npx mg-claude-dev-kit doctor                  # validate setup (29 checks)
-npx mg-claude-dev-kit doctor --report         # JSON output for CI
-npx mg-claude-dev-kit doctor --ci             # silent, exit 1 on failure
-npx mg-claude-dev-kit upgrade                 # update template files
-npx mg-claude-dev-kit upgrade --tier=m        # promote to higher tier
-npx mg-claude-dev-kit upgrade --anthropic     # show diff for Anthropic-influenced files (dry-run)
-npx mg-claude-dev-kit upgrade --anthropic --apply  # write the diff (with .bak backup)
-npx mg-claude-dev-kit add skill <name>        # install one skill
-npx mg-claude-dev-kit add rule <name>         # install one rule
-npx mg-claude-dev-kit new skill               # create a custom skill (wizard)
-claude-dev-kit-mcp                            # MCP server (stdio); wire from .mcp.json
+npx tierward init                    # scaffold wizard
+npx tierward init --dry-run          # preview without writing
+npx tierward init --answers file.json  # skip prompts (CI/automation)
+npx tierward doctor                  # validate setup (29 checks)
+npx tierward doctor --report         # JSON output for CI
+npx tierward doctor --ci             # silent, exit 1 on failure
+npx tierward upgrade                 # update template files
+npx tierward upgrade --tier=m        # promote to higher tier
+npx tierward upgrade --anthropic     # show diff for Anthropic-influenced files (dry-run)
+npx tierward upgrade --anthropic --apply  # write the diff (with .bak backup)
+npx tierward add skill <name>        # install one skill
+npx tierward add rule <name>         # install one rule
+npx tierward new skill               # create a custom skill (wizard)
+tierward-mcp                            # MCP server (stdio); wire from .mcp.json
 ```
 
 ## MCP server
 
-`claude-dev-kit-mcp` is a Model Context Protocol server that exposes CDK governance signals to any MCP-aware client (Claude Desktop, ChatGPT desktop, Cursor, VS Code, Copilot Studio). The CLI and MCP server ship in the same npm package, version-locked.
+`tierward-mcp` is a Model Context Protocol server that exposes Tierward governance signals to any MCP-aware client (Claude Desktop, ChatGPT desktop, Cursor, VS Code, Copilot Studio). The CLI and MCP server ship in the same npm package, version-locked.
 
 Wire it up by adding to `.mcp.json` (project-scoped) or `~/.claude/.mcp.json` (user-scoped):
 
 ```json
 {
   "mcpServers": {
-    "cdk": { "command": "claude-dev-kit-mcp" }
+    "cdk": { "command": "tierward-mcp" }
   }
 }
 ```
@@ -186,8 +186,8 @@ Read-only tools exposed:
 | `cdk_team_settings`     | parsed `.claude/team-settings.json`                                                                                                                              |
 | `cdk_arch_audit_status` | last `arch-audit` run timestamp + age                                                                                                                            |
 | `cdk_skill_inventory`   | installed skills + frontmatter snapshot                                                                                                                          |
-| `cdk_package_meta`      | CDK package name, version, CLI path, cwd                                                                                                                         |
-| `cdk_pr_review`         | reads existing `/pr-review` skill comments on a GitHub PR (verdict, severity counts). Read-only — to generate a fresh review, invoke the `/pr-review` CDK skill. |
+| `cdk_package_meta`      | Tierward package name, version, CLI path, cwd                                                                                                                         |
+| `cdk_pr_review`         | reads existing `/pr-review` skill comments on a GitHub PR (verdict, severity counts). Read-only — to generate a fresh review, invoke the `/pr-review` Tierward skill. |
 
 The server resolves the project root from `$CDK_PROJECT_ROOT` if set, otherwise from `process.cwd()`. v1.17.0 launched read-only by design; that posture is unchanged through v1.30.0.
 
@@ -240,8 +240,8 @@ A separate **template-coverage** layer (under `packages/cli/test/template-covera
 
 | Document                                           | Audience                    | Content                                                        |
 | -------------------------------------------------- | --------------------------- | -------------------------------------------------------------- |
-| [Operational Guide](docs/operational-guide.md)     | Teams adopting CDK          | Full reference: installation, tiers, workflow, governance, FAQ |
-| [Custom Skills Guide](docs/custom-skills.md)       | Developers extending CDK    | SKILL.md format, frontmatter schema, authoring patterns        |
+| [Operational Guide](docs/operational-guide.md)     | Teams adopting Tierward          | Full reference: installation, tiers, workflow, governance, FAQ |
+| [Custom Skills Guide](docs/custom-skills.md)       | Developers extending Tierward    | SKILL.md format, frontmatter schema, authoring patterns        |
 | [Product Brief](docs/product-brief.md)             | Stakeholders                | Strategic positioning, target users, scope                     |
 | [Quality Rubric](docs/workspace-quality-rubric.md) | Teams evaluating workspaces | 8-dimension scoring (D1-D8, 0-100%)                            |
 
@@ -249,9 +249,9 @@ A separate **template-coverage** layer (under `packages/cli/test/template-covera
 
 ## Roadmap
 
-See [GitHub Milestones](https://github.com/marcoguillermaz/claude-dev-kit/milestones) for the 12-month plan.
+See [GitHub Milestones](https://github.com/marcoguillermaz/tierward/milestones) for the 12-month plan.
 
-**Current**: v1.30.0 ships the VS Code extension (P1–P3): governance tree view with skill and rule browsing, live health status bar with arch-audit staleness, and CDK doctor findings surfaced as Problems panel diagnostics. Also adds `/skill-security` (SkillSpector integration, tier S+), a 64-pattern vulnerability scanner for Claude Code skill files. Carried forward: v1.29.x cross-LLM rubric automation for Context Builder, v1.28.0's skill-review pipeline P3 robustness, v1.27.0's Context Builder v1.1 cycle, v1.22.0's `/skill-dev` v2 hotspot step, v1.21.0's PreToolUse runtime enforcement, and v1.20.0's MCP-aware audit skills.
+**Current**: v1.30.0 ships the VS Code extension (P1–P3): governance tree view with skill and rule browsing, live health status bar with arch-audit staleness, and Tierward doctor findings surfaced as Problems panel diagnostics. Also adds `/skill-security` (SkillSpector integration, tier S+), a 64-pattern vulnerability scanner for Claude Code skill files. Carried forward: v1.29.x cross-LLM rubric automation for Context Builder, v1.28.0's skill-review pipeline P3 robustness, v1.27.0's Context Builder v1.1 cycle, v1.22.0's `/skill-dev` v2 hotspot step, v1.21.0's PreToolUse runtime enforcement, and v1.20.0's MCP-aware audit skills.
 
 **Next**: `/arch-audit` MCP-aware once the upstream Anthropic spec MCP server lands. `/privacy-audit` re-eval (Issue #97 sub-track 3) when AST tracing matures or demand signal materializes. Q2 #3 VitePress docs site (ICE 432) stays on hold.
 
@@ -269,4 +269,4 @@ To report a security issue, see [SECURITY.md](SECURITY.md).
 
 ---
 
-Built and maintained by [Marco Guillermaz](https://github.com/marcoguillermaz). Distributed on npm as [`mg-claude-dev-kit`](https://www.npmjs.com/package/mg-claude-dev-kit). Discussions and questions: [GitHub Discussions](https://github.com/marcoguillermaz/claude-dev-kit/discussions).
+Built and maintained by [Marco Guillermaz](https://github.com/marcoguillermaz). Distributed on npm as [`tierward`](https://www.npmjs.com/package/tierward). Discussions and questions: [GitHub Discussions](https://github.com/marcoguillermaz/tierward/discussions).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,7 @@
 
 **Do not open a public GitHub issue for security vulnerabilities.**
 
-To report a security issue, use [GitHub's private vulnerability reporting](https://github.com/marcoguillermaz/claude-dev-kit/security/advisories/new).
+To report a security issue, use [GitHub's private vulnerability reporting](https://github.com/marcoguillermaz/tierward/security/advisories/new).
 
 Include:
 - Description of the vulnerability

--- a/docs/architecture/test-coverage-strategy.md
+++ b/docs/architecture/test-coverage-strategy.md
@@ -5,13 +5,13 @@
 **Roadmap**: Q3 #12 / issue #138
 **Owner**: maintainer
 
-This document defines what CDK's test infrastructure does and does NOT cover for the templates shipped by the scaffolder (`packages/cli/templates/**`), the gaps surfaced by issue #138, and the chosen approach for each gap.
+This document defines what Tierward's test infrastructure does and does NOT cover for the templates shipped by the scaffolder (`packages/cli/templates/**`), the gaps surfaced by issue #138, and the chosen approach for each gap.
 
 ---
 
 ## 1. Surface under test
 
-CDK ships three kinds of artifacts that reach the user's project after `npx claude-dev-kit init`:
+Tierward ships three kinds of artifacts that reach the user's project after `npx tierward init`:
 
 1. **Pipeline rules** — `tier-{s,m,l}/.claude/rules/pipeline.md`. Normative prose that Claude Code reads each session to drive phase progression, gate behavior, and stop semantics.
 2. **CLAUDE.md templates** — per-tier project context with wizard-filled placeholders.
@@ -76,13 +76,13 @@ The issue proposes seven approaches A–G tiered by ease. Mapping:
 
 **C — Placeholder enumeration (build now).** For every `[PLACEHOLDER]` referenced in `pipeline.md` template bodies, verify it is (1) in the wizard-managed list, (2) documented in `CLAUDE.md` template, or (3) explicitly listed as user-fill (role names, state names). Complement to issue #134 placeholder meta-rule. Distinct from `assertNoUnfilledWizardPlaceholders` (which operates on post-wizard output).
 
-**D — Snapshot tests per representative stack (roadmap).** Fixture project per stack target (web, backend Python, Go CLI, Swift iOS, Rust crate). Scaffold CDK in each, snapshot the output, diff on PR. Captures cross-tier divergence and post-scaffold behavior at file level. Cost: ~1 week initial + recurring per new stack. To file as a separate issue once A+B+C are in production for at least one release cycle.
+**D — Snapshot tests per representative stack (roadmap).** Fixture project per stack target (web, backend Python, Go CLI, Swift iOS, Rust crate). Scaffold Tierward in each, snapshot the output, diff on PR. Captures cross-tier divergence and post-scaffold behavior at file level. Cost: ~1 week initial + recurring per new stack. To file as a separate issue once A+B+C are in production for at least one release cycle.
 
 **E — Gate matrix completeness (roadmap).** Builds on B. For each gate, verify matrix completeness across stack targets. Detects gates that leave legitimate stacks uncovered. Requires explicit enumeration of target stacks. To file as a separate issue after B has surfaced any concrete completeness questions.
 
 **F — LLM-based prose semantic eval (defer).** Rationale: (1) cost — would run per-PR touching templates, not on-demand; (2) non-determinism — same prose can score differently across runs; (3) Phase 6 cross-LLM of the skill-review pipeline already exercises this pattern on-demand for the same surface. The marginal value of converting it to a per-PR gate is unclear until B/E reveal what semantic checks are actually missed by mechanical lint. Re-evaluate when A/B/C have been in production for two release cycles and a recurring class of drift escapes them.
 
-**G — Behavioral fixture testing (defer).** Rationale: weeks of setup, recurring per new stack/skill, non-trivial runtime cost. Conceptually the strongest test but the failure mode it catches (Claude interprets prose differently across runs) is also the hardest to assert against. Re-evaluate when CDK has paying customers whose deployments depend on phase semantics.
+**G — Behavioral fixture testing (defer).** Rationale: weeks of setup, recurring per new stack/skill, non-trivial runtime cost. Conceptually the strongest test but the failure mode it catches (Claude interprets prose differently across runs) is also the hardest to assert against. Re-evaluate when Tierward has paying customers whose deployments depend on phase semantics.
 
 ---
 

--- a/docs/custom-skills.md
+++ b/docs/custom-skills.md
@@ -1,10 +1,10 @@
 # Custom Skills Guide
 
-Create project-specific skills that CDK preserves across `upgrade` and `init` operations.
+Create project-specific skills that Tierward preserves across `upgrade` and `init` operations.
 
 ## Convention
 
-Place custom skills in `.claude/skills/custom-<name>/SKILL.md`. The `custom-` prefix signals CDK to never overwrite, prune, or modify the skill during any operation.
+Place custom skills in `.claude/skills/custom-<name>/SKILL.md`. The `custom-` prefix signals Tierward to never overwrite, prune, or modify the skill during any operation.
 
 Examples:
 ```
@@ -140,4 +140,4 @@ After creating a custom skill, add it to the `## Active Skills` section in CLAUD
 - `/custom-check-deps` - check for outdated dependencies
 ```
 
-Or use the CLI: `npx mg-claude-dev-kit add skill` does not support custom skills (it installs CDK-managed skills only). Custom skill registration in CLAUDE.md is manual.
+Or use the CLI: `npx tierward add skill` does not support custom skills (it installs Tierward-managed skills only). Custom skill registration in CLAUDE.md is manual.

--- a/docs/operational-guide.md
+++ b/docs/operational-guide.md
@@ -1,4 +1,4 @@
-# claude-dev-kit - Operational Guide
+# tierward - Operational Guide
 
 **Version**: 1.30.0
 **Audience**: Builder PMs, tech leads, and senior developers using Claude Code - from first exploration to structured, reviewable delivery
@@ -36,7 +36,7 @@
 
 Claude Code is a powerful CLI assistant that can read, write, and reason about your entire codebase. Without shared process, it makes autonomous decisions that are hard to track and harder to review.
 
-`claude-dev-kit` scaffolds a structured, reviewable development process on top of Claude Code. It does not limit what Claude can do - it makes every meaningful action visible, auditable, and reversible.
+`tierward` scaffolds a structured, reviewable development process on top of Claude Code. It does not limit what Claude can do - it makes every meaningful action visible, auditable, and reversible.
 
 **What you get:**
 
@@ -72,7 +72,7 @@ What you get: three files, one hard constraint (tests must pass before Claude de
 When you're ready for more structure - usually after a few sessions, once Claude Code is part of the daily workflow:
 
 ```bash
-npx mg-claude-dev-kit upgrade --tier=s
+npx tierward upgrade --tier=s
 ```
 
 This adds the Fast Lane pipeline non-destructively. Your existing files are not overwritten.
@@ -128,14 +128,14 @@ npm install -g @anthropic-ai/claude-code
 Run this from any directory:
 
 ```bash
-npx mg-claude-dev-kit init
+npx tierward init
 ```
 
 The wizard asks about your project state first:
 
 ```
 ? What's the state of this project?
-  > Existing project - add CDK to a project that already has code
+  > Existing project - add Tierward to a project that already has code
     New project - starting from scratch, you'll fill in the details
     From existing docs - share your docs and Claude populates everything
 ```
@@ -147,11 +147,11 @@ Three init paths are available. All support `--dry-run` (preview without writing
 Run `context` before `init` to make the scaffold reproducible and reviewable:
 
 ```bash
-npx mg-claude-dev-kit context                       # produces CONTEXT.md
-npx mg-claude-dev-kit init                          # reads CONTEXT.md, scaffolds with no further prompts
-npx mg-claude-dev-kit context --all                 # one-shot: context then init
-npx mg-claude-dev-kit context --from-yaml file.md   # bypass: validate + copy an existing CONTEXT.md (v1.26.0+)
-npx mg-claude-dev-kit validate-context              # CI gate: exits 0 on pass, 1 on fail (v1.25.0+)
+npx tierward context                       # produces CONTEXT.md
+npx tierward init                          # reads CONTEXT.md, scaffolds with no further prompts
+npx tierward context --all                 # one-shot: context then init
+npx tierward context --from-yaml file.md   # bypass: validate + copy an existing CONTEXT.md (v1.26.0+)
+npx tierward validate-context              # CI gate: exits 0 on pass, 1 on fail (v1.25.0+)
 ```
 
 When `CONTEXT.md` is present in the cwd, `init` reads it and scaffolds without asking anything else. Pass `--ignore-context` to fall back to the prompt-based flow.
@@ -238,7 +238,7 @@ The CLI:
 3. Counts your source files to suggest an appropriate tier.
 4. Creates all governance files **without overwriting** `CLAUDE.md`, `MEMORY.md`, `.gitignore`, or `README.md` if they already exist.
 5. Generates `CONTEXT_IMPORT.md` pointing to the current directory.
-6. Appends claude-dev-kit entries to `.gitignore`.
+6. Appends tierward entries to `.gitignore`.
 7. Optionally runs `doctor` inline to validate the scaffold.
 8. Optionally installs pre-commit hooks inline.
 
@@ -277,7 +277,7 @@ On every Claude Code session, Claude reads this file first. If the status is `PE
 
 ## 6. The four pipeline tiers
 
-The pipeline is the sequence of phases Claude follows for every development task. You choose the tier when running `init`. Change it later with: `npx mg-claude-dev-kit upgrade --tier=m`.
+The pipeline is the sequence of phases Claude follows for every development task. You choose the tier when running `init`. Change it later with: `npx tierward upgrade --tier=m`.
 
 ### Tier 0 - Discovery
 
@@ -301,9 +301,9 @@ The pipeline is the sequence of phases Claude follows for every development task
 **Upgrading from Tier 0:**
 
 ```bash
-npx mg-claude-dev-kit upgrade --tier=s   # adds branch discipline + commit rules
-npx mg-claude-dev-kit upgrade --tier=m   # adds phased pipeline + review gates + docs
-npx mg-claude-dev-kit upgrade --tier=l   # adds full governance + audit skills
+npx tierward upgrade --tier=s   # adds branch discipline + commit rules
+npx tierward upgrade --tier=m   # adds phased pipeline + review gates + docs
+npx tierward upgrade --tier=l   # adds full governance + audit skills
 ```
 
 Upgrade is non-destructive - it adds new files without overwriting your existing `CLAUDE.md` or `settings.json`.
@@ -425,14 +425,14 @@ You can start at Tier 0 or S and escalate. Claude notifies you when scope expand
 
 ## 7. Incremental adoption
 
-You don't need a full scaffold to start using CDK components. Install individual skills or rules into any project that already has a `.claude/` directory.
+You don't need a full scaffold to start using Tierward components. Install individual skills or rules into any project that already has a `.claude/` directory.
 
 ### Adding a single skill
 
 ```bash
-npx mg-claude-dev-kit add skill security-audit
-npx mg-claude-dev-kit add skill perf-audit
-npx mg-claude-dev-kit add skill commit
+npx tierward add skill security-audit
+npx tierward add skill perf-audit
+npx tierward add skill commit
 ```
 
 This copies the SKILL.md file into `.claude/skills/<name>/` and appends it to the `## Active Skills` section in CLAUDE.md (if that section exists). No other files are modified.
@@ -447,10 +447,10 @@ Options:
 ### Adding a single rule
 
 ```bash
-npx mg-claude-dev-kit add rule git
-npx mg-claude-dev-kit add rule output-style
-npx mg-claude-dev-kit add rule security
-npx mg-claude-dev-kit add rule security --stack swift
+npx tierward add rule git
+npx tierward add rule output-style
+npx tierward add rule security
+npx tierward add rule security --stack swift
 ```
 
 Available rules: `git`, `output-style`, `security`.
@@ -469,7 +469,7 @@ Options: `--force`, `--dry-run` (same as `add skill`).
 ### 7c. Creating custom skills
 
 ```bash
-npx mg-claude-dev-kit new skill
+npx tierward new skill
 ```
 
 Interactive wizard that generates a complete custom skill:
@@ -486,15 +486,15 @@ Options:
 - `--dry-run` - preview what would be created
 - `--answers <json>` - bypass all prompts with JSON (for automation)
 
-### Minimum viable CDK
+### Minimum viable Tierward
 
-The smallest useful CDK setup - no full scaffold required:
+The smallest useful Tierward setup - no full scaffold required:
 
 ```bash
 mkdir -p .claude/skills .claude/rules
-npx mg-claude-dev-kit add rule git
-npx mg-claude-dev-kit add skill commit
-npx mg-claude-dev-kit add skill security-audit
+npx tierward add rule git
+npx tierward add skill commit
+npx tierward add skill security-audit
 ```
 
 This gives you: conventional commits, security auditing, and git discipline - without a pipeline, session files, or STOP gates. Add more components as needed.
@@ -668,7 +668,7 @@ Stack-aware security rules. The scaffold selects the appropriate variant based o
 
 Selection logic: Swift always gets native-apple, Kotlin always gets native-android. Rust/Go/.NET/Java get the systems variant when `hasApi=false`, otherwise the web variant. All other stacks get the web variant. The output file is always named `security.md` regardless of variant.
 
-You can also install a specific variant via `npx mg-claude-dev-kit add rule security --stack swift`.
+You can also install a specific variant via `npx tierward add rule security --stack swift`.
 
 ---
 
@@ -772,7 +772,7 @@ All skill applicability rules are managed by a central skill registry (`packages
 - Each skill runs in an isolated context fork (`context: fork`) - it does not pollute the main session window.
 - Each skill delegates grep-heavy scanning to a Haiku Explore subagent to protect the main context window.
 - Before first run: fill in the `## Configuration` placeholders at the top of each `SKILL.md`.
-- Skills not installed at init can be added later: `npx mg-claude-dev-kit add skill <name>`.
+- Skills not installed at init can be added later: `npx tierward add skill <name>`.
 
 ### Block-scoped audit in Phase 5d (Tier M/L)
 
@@ -786,8 +786,8 @@ After the smoke test and before the outcome checklist, three tracks can run:
 
 **Track C - Test + doc + infra audit** (runs for every block after Phase 3 is green):
 `/test-audit` - static analysis of coverage reports (lcov / Istanbul / Cobertura / go / tarpaulin / xcresult), pyramid shape (unit/integration/e2e ratio), and anti-patterns (`.only` leaks, skipped tests, empty bodies, no-assertion tests, hardcoded sleeps).
-`/doc-audit` - static doc-drift check: relative-link resolution, code-block syntax (json/yaml/toml), CDK placeholder residuals, slash-command name match, skill-count consistency, ADR freshness, and stack-specific doc sync (Next.js / Django / Swift).
-`/infra-audit` - static infrastructure-security check across five layers (GitHub Actions, Dockerfile, K8s manifests, Terraform, GitLab CI); each layer runs only if its markers are detected. Critical findings from any of the three skills (`.only` committed, 0% coverage on a changed file, CDK placeholder in README, pwn-request in workflow, secret logging in CI, privileged K8s container, IAM wildcard action, hardcoded secret in Terraform, no right-to-delete endpoint when PII is stored) block Phase 6.
+`/doc-audit` - static doc-drift check: relative-link resolution, code-block syntax (json/yaml/toml), Tierward placeholder residuals, slash-command name match, skill-count consistency, ADR freshness, and stack-specific doc sync (Next.js / Django / Swift).
+`/infra-audit` - static infrastructure-security check across five layers (GitHub Actions, Dockerfile, K8s manifests, Terraform, GitLab CI); each layer runs only if its markers are detected. Critical findings from any of the three skills (`.only` committed, 0% coverage on a changed file, Tierward placeholder in README, pwn-request in workflow, secret logging in CI, privileged K8s container, IAM wildcard action, hardcoded secret in Terraform, no right-to-delete endpoint when PII is stored) block Phase 6.
 
 ### Severity handling
 
@@ -916,9 +916,9 @@ Checks:
 
 - **D1 Relative-link resolution**: markdown links to local files (`[text](./path)`, `[text](../path)`) resolve to existing paths. `http(s)://`, `mailto:`, and anchor-only links skipped. Severity: Critical for broken links to user-visible flow docs (CONTRIBUTING, SECURITY, linked guides); High otherwise.
 - **D2 Code-block syntax**: fenced blocks tagged `json`, `yaml`, `toml` are parsed with a stack-appropriate tool (`node -e 'JSON.parse'`, `python -c 'yaml.safe_load'`, `python -c 'tomllib.loads'`). Blocks tagged `bash`, `sh`, `text`, unlabelled, or containing template markers (`<...>`, `{{...}}`) are skipped. Severity: High per unparseable block.
-- **D3 CDK placeholder residuals**: uses a pinned list of the ten scaffold tokens (`[TEST_COMMAND]`, `[FRAMEWORK_VALUE]`, `[LANGUAGE_VALUE]`, `[INSTALL_COMMAND]`, `[DEV_COMMAND]`, `[BUILD_COMMAND]`, `[TYPE_CHECK_COMMAND]`, `[E2E_COMMAND]`, `[ENUM_CASE_CONVENTION]`, `[MIGRATION_COMMAND]`). Every entry is verified against `packages/cli/templates/**` so only tokens the scaffold actually writes are included. Generic `[UPPERCASE]` regex is deliberately avoided to prevent false positives on legitimate user conventions (`[API_KEY]`, `[YOUR_DOMAIN]`, `[FEATURE_FLAG]`). Severity: Critical in `README.md`, High in other user-facing docs.
-- **D4 Slash-command name match**: every `/name` reference in docs is cross-checked against `.claude/skills/<name>/`. Allowlist covers CDK CLI verbs (`init`, `upgrade`, `doctor`, `add`, `new`). Severity: Medium per orphan.
-- **D5 Skill-count consistency**: numeric claims like "16 skills" in README / docs are cross-verified against `ls .claude/skills/ | grep -v '^custom-' | wc -l`. Severity: Medium if mismatch ≤ 2; High if > 2. Scope is intentionally narrow - doctor / test counts are source-specific to the CDK codebase and not in scope for user-project audits.
+- **D3 Tierward placeholder residuals**: uses a pinned list of the ten scaffold tokens (`[TEST_COMMAND]`, `[FRAMEWORK_VALUE]`, `[LANGUAGE_VALUE]`, `[INSTALL_COMMAND]`, `[DEV_COMMAND]`, `[BUILD_COMMAND]`, `[TYPE_CHECK_COMMAND]`, `[E2E_COMMAND]`, `[ENUM_CASE_CONVENTION]`, `[MIGRATION_COMMAND]`). Every entry is verified against `packages/cli/templates/**` so only tokens the scaffold actually writes are included. Generic `[UPPERCASE]` regex is deliberately avoided to prevent false positives on legitimate user conventions (`[API_KEY]`, `[YOUR_DOMAIN]`, `[FEATURE_FLAG]`). Severity: Critical in `README.md`, High in other user-facing docs.
+- **D4 Slash-command name match**: every `/name` reference in docs is cross-checked against `.claude/skills/<name>/`. Allowlist covers Tierward CLI verbs (`init`, `upgrade`, `doctor`, `add`, `new`). Severity: Medium per orphan.
+- **D5 Skill-count consistency**: numeric claims like "16 skills" in README / docs are cross-verified against `ls .claude/skills/ | grep -v '^custom-' | wc -l`. Severity: Medium if mismatch ≤ 2; High if > 2. Scope is intentionally narrow - doctor / test counts are source-specific to the Tierward codebase and not in scope for user-project audits.
 - **D6 ADR marker freshness**: if an ADR directory is configured, frontmatter `date:` / `updated:` fields older than 180 days without a terminal `status:` (`accepted`, `deprecated`, `superseded`, `rejected`) are flagged. Severity: Low.
 - **D7 Stack-specific doc sync**: runs only for `node-ts`, `python`, `swift` - other stacks skip D7 and run only D1-D6. Patterns live in a sibling `PATTERNS.md`:
   - **node-ts**: Next.js `app/` or `pages/` routes cross-referenced against `docs/sitemap.md` and README; `package.json` dependencies cross-referenced against README.
@@ -1054,11 +1054,11 @@ Handles checks C1-C3 of the context review (credential scan, placeholder scan, f
 
 ## 12. Custom skills
 
-You can create project-specific skills that CDK preserves across `upgrade` and `init` operations.
+You can create project-specific skills that Tierward preserves across `upgrade` and `init` operations.
 
 ### Convention
 
-Place custom skills in `.claude/skills/custom-<name>/SKILL.md`. The `custom-` prefix signals CDK to never overwrite, prune, or modify the skill during any CLI operation.
+Place custom skills in `.claude/skills/custom-<name>/SKILL.md`. The `custom-` prefix signals Tierward to never overwrite, prune, or modify the skill during any CLI operation.
 
 ```
 .claude/skills/custom-deploy/SKILL.md
@@ -1203,10 +1203,10 @@ Imperative mood, under 72 characters. Scope is optional but encouraged.
 ### Upgrading
 
 ```bash
-npx mg-claude-dev-kit upgrade
-npx mg-claude-dev-kit upgrade --tier=m            # promote to higher tier
-npx mg-claude-dev-kit upgrade --anthropic         # show diff for Anthropic-influenced files (dry-run)
-npx mg-claude-dev-kit upgrade --anthropic --apply # write the diff with .bak backup
+npx tierward upgrade
+npx tierward upgrade --tier=m            # promote to higher tier
+npx tierward upgrade --anthropic         # show diff for Anthropic-influenced files (dry-run)
+npx tierward upgrade --anthropic --apply # write the diff with .bak backup
 ```
 
 Non-destructive files are updated to the latest template version (rules, context-review, files-guide, PR template). Files containing your customizations (`CLAUDE.md`, `pipeline.md`, `settings.json`, `SKILL.md` files) are flagged for manual review.
@@ -1220,9 +1220,9 @@ Non-destructive files are updated to the latest template version (rules, context
 ### Checking setup health
 
 ```bash
-npx mg-claude-dev-kit doctor           # interactive report (default)
-npx mg-claude-dev-kit doctor --report  # JSON compliance output for CI pipelines
-npx mg-claude-dev-kit doctor --ci      # silent mode: exit 1 if any check fails
+npx tierward doctor           # interactive report (default)
+npx tierward doctor --report  # JSON compliance output for CI pipelines
+npx tierward doctor --ci      # silent mode: exit 1 if any check fails
 ```
 
 Runs 29 checks:
@@ -1252,7 +1252,7 @@ Runs 29 checks:
 23. `security.md` variant matches the detected stack (warn on drift)
 24. `.claude/rules/context-review.md` includes C12 (warn if not present - upgrade needed)
 25. Stop hook has `timeout` configured and ≤ 600s (warn if missing - prevents hanging test commands)
-26. Anthropic-influenced files match the installed CDK template — `arch-audit/advanced-checks.md` in v1.15.0 (warn on drift, suggest `upgrade --anthropic`)
+26. Anthropic-influenced files match the installed Tierward template — `arch-audit/advanced-checks.md` in v1.15.0 (warn on drift, suggest `upgrade --anthropic`)
 27. Repo state matches `.claude/team-settings.json` — minTier ≥ scaffold tier, no blocked skills installed, all required skills present (warn-level; skips when the file is absent)
 28. `team-settings.json` runtime enforcement hook is scaffolded and registered on the `Skill` matcher in `.claude/settings.json` (warn-level; skips when `team-settings.json` is absent — added in v1.21.0)
 29. No duplicate entries in `permissions.deny` list (warn if duplicates found)
@@ -1261,13 +1261,13 @@ Checks 12-29 are skipped for Tier 0 projects.
 
 **`--report` output**: machine-readable JSON with timestamp, cwd, summary (passed/warned/failed/skipped), and per-check details. Consumed by CI systems or external audit tools.
 
-**CI integration**: `.github/workflows/claude-dev-kit-verify.yml` (scaffolded by `init`) runs doctor on every PR. Prevents merging when the scaffold is broken or bypassed.
+**CI integration**: `.github/workflows/tierward-verify.yml` (scaffolded by `init`) runs doctor on every PR. Prevents merging when the scaffold is broken or bypassed.
 
 ---
 
 ### Team-wide policy with `team-settings.json`
 
-For teams that want to enforce a baseline across every member's clone, drop a `.claude/team-settings.json` into the repo. The file is opt-in: when absent, CDK behaves as before. When present, the CLI applies the policy at every relevant entry point.
+For teams that want to enforce a baseline across every member's clone, drop a `.claude/team-settings.json` into the repo. The file is opt-in: when absent, Tierward behaves as before. When present, the CLI applies the policy at every relevant entry point.
 
 Schema (v1):
 
@@ -1283,9 +1283,9 @@ Schema (v1):
 Field semantics:
 
 - `minTier` — `s` | `m` | `l`. The lowest tier the project may scaffold to. `init` refuses lower tiers. `upgrade` refuses to run on a current scaffold below the floor and points the user at `init --tier=<min>` to promote.
-- `allowedSkills` — whitelist for `add skill`. Skills outside the list are rejected. `custom-*` skills bypass this list by design (custom skills aren't part of CDK governance).
+- `allowedSkills` — whitelist for `add skill`. Skills outside the list are rejected. `custom-*` skills bypass this list by design (custom skills aren't part of Tierward governance).
 - `blockedSkills` — denylist for `add skill` and the doctor compliance check. `custom-*` skills are NOT exempt from the blocklist (governance overrides the "custom skills preserved across upgrades" convention).
-- `requiredSkills` — must be installed in `.claude/skills/`. Doctor warns if any are missing; CDK does not auto-install on its own.
+- `requiredSkills` — must be installed in `.claude/skills/`. Doctor warns if any are missing; Tierward does not auto-install on its own.
 
 `allowedSkills ∩ blockedSkills` is rejected at parse time as a mutual-exclusion error.
 
@@ -1297,23 +1297,23 @@ v1.16.0 introduced CLI-side enforcement only; native `Skill()` permission rules 
 
 ### MCP server
 
-The `mg-claude-dev-kit` npm package ships two binaries: `claude-dev-kit` (the wizard CLI) and `claude-dev-kit-mcp` (a Model Context Protocol server). Version-locked, single install.
+The `tierward` npm package ships two binaries: `tierward` (the wizard CLI) and `tierward-mcp` (a Model Context Protocol server). Version-locked, single install.
 
-The MCP server exposes CDK governance state to any MCP-aware client (Claude Desktop, ChatGPT desktop, Cursor, VS Code, Copilot Studio). Six read-only tools:
+The MCP server exposes Tierward governance state to any MCP-aware client (Claude Desktop, ChatGPT desktop, Cursor, VS Code, Copilot Studio). Six read-only tools:
 
 - `cdk_doctor_report` — runs `doctor --report` and returns the JSON
 - `cdk_team_settings` — parsed `.claude/team-settings.json` contents
 - `cdk_arch_audit_status` — last arch-audit run timestamp + age in days
 - `cdk_skill_inventory` — installed skills with frontmatter snapshot
 - `cdk_package_meta` — package name, version, CLI path, project root
-- `cdk_pr_review` — reads existing `/pr-review` comments on a GitHub PR (verdict + severity counts). Read-only; to generate a fresh review, invoke the `/pr-review` CDK skill.
+- `cdk_pr_review` — reads existing `/pr-review` comments on a GitHub PR (verdict + severity counts). Read-only; to generate a fresh review, invoke the `/pr-review` Tierward skill.
 
 Wire up by adding to `.mcp.json` (project-scoped) or `~/.claude/.mcp.json` (user-scoped):
 
 ```json
 {
   "mcpServers": {
-    "cdk": { "command": "claude-dev-kit-mcp" }
+    "cdk": { "command": "tierward-mcp" }
   }
 }
 ```
@@ -1343,11 +1343,11 @@ Do not edit scaffolded rule files directly if you want upgrade compatibility. In
 
 ## 15b. Anthropic drift tracking
 
-CDK features risk being absorbed as Anthropic ships native Claude Code capabilities. The drift tracker monitors this automatically.
+Tierward features risk being absorbed as Anthropic ships native Claude Code capabilities. The drift tracker monitors this automatically.
 
 **How it works**: Every Monday at 9 AM UTC, a GitHub Action fetches the Anthropic Claude Code changelog, matches content against a feature manifest (`.github/drift-tracker/features.json`), and opens issues for any overlap detected.
 
-**Feature manifest**: Each entry in `features.json` defines a CDK feature with keywords, risk level (high/medium/low), and affected CDK files. To add a new feature to track, add a JSON object to the `features` array.
+**Feature manifest**: Each entry in `features.json` defines a Tierward feature with keywords, risk level (high/medium/low), and affected Tierward files. To add a new feature to track, add a JSON object to the `features` array.
 
 **Manual scan**: Go to Actions > "Anthropic drift tracker" > Run workflow. Enable "Dry run" to see results without creating issues. Adjust the lookback window with the "days" input.
 
@@ -1359,7 +1359,7 @@ CDK features risk being absorbed as Anthropic ships native Claude Code capabilit
 
 ## 15c. Template coverage tests (maintainer-only)
 
-CDK ships normative prose inside `pipeline.md` per tier and inside per-tier `CLAUDE.md` templates. Drift between tiers, broken gate clauses, and undocumented placeholders quietly degrade what customers receive. The template-coverage layer catches these regressions before the templates reach `npm`.
+Tierward ships normative prose inside `pipeline.md` per tier and inside per-tier `CLAUDE.md` templates. Drift between tiers, broken gate clauses, and undocumented placeholders quietly degrade what customers receive. The template-coverage layer catches these regressions before the templates reach `npm`.
 
 Three standalone scripts under `packages/cli/test/template-coverage/`:
 
@@ -1392,7 +1392,7 @@ Output: `report.json` (machine-readable), `report.md` (human-readable table), an
 
 The locked jury is `claude-opus-4-7` + `claude-sonnet-4-6` + `gemini-2.5-pro`. PASS requires all medians ≥ 2 **and** ≥ 80 % of criteria with median ≥ 2. The script hard-fails (exit 2) if `ANTHROPIC_API_KEY` or `GEMINI_API_KEY` is missing, and hard-fails at runtime (exit 1) on any provider network error; a model that responds with malformed JSON is penalised in scoring rather than crashing the run.
 
-This is a maintainer gate: run it before any release that touches `packages/cli/src/context-builder/**`, the schema, or prompt templates. End users do not run it; they get the deterministic MUST PASS via `npx mg-claude-dev-kit validate-context`.
+This is a maintainer gate: run it before any release that touches `packages/cli/src/context-builder/**`, the schema, or prompt templates. End users do not run it; they get the deterministic MUST PASS via `npx tierward validate-context`.
 
 Full reference: `packages/cli/test/cross-llm-rubric/README.md`. Locked design in `memory/project_context_builder_rubric_v1.md`.
 
@@ -1400,7 +1400,7 @@ Full reference: `packages/cli/test/cross-llm-rubric/README.md`. Locked design in
 
 ## 16. Frequently asked questions
 
-**Q: Do I need to run `npx mg-claude-dev-kit init` every time I start a session?**
+**Q: Do I need to run `npx tierward init` every time I start a session?**
 
 No. You run it once to scaffold the governance layer. After that, open Claude Code (`claude`) from the project root. The governance files load automatically.
 
@@ -1408,7 +1408,7 @@ No. You run it once to scaffold the governance layer. After that, open Claude Co
 
 **Q: What happens if Claude ignores the pipeline?**
 
-The Stop hook is a mechanical enforcement: it does not rely on Claude following instructions. Even if Claude tries to declare a task complete without running tests, the hook blocks it. The STOP gates rely on Claude respecting the instructions in `pipeline.md`. If you observe Claude skipping a gate, check that `pipeline.md` is being loaded (run `npx mg-claude-dev-kit doctor`).
+The Stop hook is a mechanical enforcement: it does not rely on Claude following instructions. Even if Claude tries to declare a task complete without running tests, the hook blocks it. The STOP gates rely on Claude respecting the instructions in `pipeline.md`. If you observe Claude skipping a gate, check that `pipeline.md` is being loaded (run `npx tierward doctor`).
 
 ---
 
@@ -1424,15 +1424,15 @@ No. In-place mode uses safe scaffold: files that already exist are never overwri
 
 ---
 
-**Q: Can I add CDK components without running the full init?**
+**Q: Can I add Tierward components without running the full init?**
 
-Yes. Use `npx mg-claude-dev-kit add skill <name>` or `add rule <name>` to install individual components. See [section 7](#7-incremental-adoption).
+Yes. Use `npx tierward add skill <name>` or `add rule <name>` to install individual components. See [section 7](#7-incremental-adoption).
 
 ---
 
 **Q: How do I create my own audit skill?**
 
-Create `.claude/skills/custom-<name>/SKILL.md` with YAML frontmatter and step-by-step instructions. The `custom-` prefix ensures CDK never touches it during upgrade or init. See [section 12](#12-custom-skills) and [Custom Skills Guide](custom-skills.md).
+Create `.claude/skills/custom-<name>/SKILL.md` with YAML frontmatter and step-by-step instructions. The `custom-` prefix ensures Tierward never touches it during upgrade or init. See [section 12](#12-custom-skills) and [Custom Skills Guide](custom-skills.md).
 
 ---
 
@@ -1456,7 +1456,7 @@ Rules: each worktree has its own branch. Merge to `staging` sequentially - smoke
 
 **Q: Can I switch tiers on an existing project?**
 
-Yes. Run `npx mg-claude-dev-kit upgrade --tier=m` to promote non-destructively. Or edit `.claude/rules/pipeline.md` directly if you need fine-grained control.
+Yes. Run `npx tierward upgrade --tier=m` to promote non-destructively. Or edit `.claude/rules/pipeline.md` directly if you need fine-grained control.
 
 ---
 
@@ -1484,7 +1484,7 @@ Edit `CLAUDE.md` Key Commands section. Replace `# not configured` with your actu
 Yes. All init commands accept `--answers <path>` that bypasses every wizard prompt:
 
 ```bash
-npx mg-claude-dev-kit init --answers ./answers.json
+npx tierward init --answers ./answers.json
 ```
 
 Nine example fixtures are in `packages/cli/test/fixtures/wizard-answers/`. Copy one as a starting point.

--- a/docs/product-brief.md
+++ b/docs/product-brief.md
@@ -1,4 +1,4 @@
-# claude-dev-kit - Product Brief
+# tierward - Product Brief
 
 > Strategic context for the team. Not referenced by Claude during coding sessions - kept here to pass Anthropic's CLAUDE.md inclusion test.
 
@@ -30,7 +30,7 @@ Lack of shared process - the issue is neither Claude nor the human, it is the ab
 
 ## Shipped
 
-- **Context Builder (v1.23.0 → v1.27.0)**: now part of CDK as the `context` sub-command. A guided interview between Claude and the user (PM, Dev, Tech Lead, Founder, Other) produces a schema-validated `CONTEXT.md`, which `init` then consumes to scaffold deterministically. Greenfield runs either a PM-friendly interview or a developer flow that reuses the legacy wizard's technical questions. Existing repos go through three-phase inference: algorithmic detection, LLM extraction, hybrid PM review. The schema covers all four pipeline tiers (0/S/M/L). Companion CLI: `validate-context` for CI gating, `--from-yaml` to bypass the interview for templates and automation.
+- **Context Builder (v1.23.0 → v1.27.0)**: now part of Tierward as the `context` sub-command. A guided interview between Claude and the user (PM, Dev, Tech Lead, Founder, Other) produces a schema-validated `CONTEXT.md`, which `init` then consumes to scaffold deterministically. Greenfield runs either a PM-friendly interview or a developer flow that reuses the legacy wizard's technical questions. Existing repos go through three-phase inference: algorithmic detection, LLM extraction, hybrid PM review. The schema covers all four pipeline tiers (0/S/M/L). Companion CLI: `validate-context` for CI gating, `--from-yaml` to bypass the interview for templates and automation.
 
 ## Roadmap
 

--- a/docs/workspace-quality-rubric.md
+++ b/docs/workspace-quality-rubric.md
@@ -311,7 +311,7 @@ Copy and fill for each evaluation run.
 Project: _______________
 Date: _______________
 Evaluator: _______________
-Workspace tool: _______________ (CDK / manual / other)
+Workspace tool: _______________ (Tierward / manual / other)
 Tier (if applicable): _______________
 
 | Dim | Score (0-3) | Weight | Weighted | Key gaps | Attribution (T/U/D) |
@@ -352,4 +352,4 @@ When gaps are found, prioritize fixes in this order:
 
 ## Changelog
 
-- **v1.0** (2026-04-03): Initial version. 8 dimensions, weighted scoring, gap attribution model. Anchored to Anthropic official documentation (code.claude.com/docs), context engineering blog, CDK v1.6.1 template analysis, and cross-tool community patterns.
+- **v1.0** (2026-04-03): Initial version. 8 dimensions, weighted scoring, gap attribution model. Anchored to Anthropic official documentation (code.claude.com/docs), context engineering blog, Tierward v1.6.1 template analysis, and cross-tool community patterns.

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "mg-claude-dev-kit",
+  "name": "tierward",
   "version": "1.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "mg-claude-dev-kit",
+      "name": "tierward",
       "version": "1.30.0",
       "license": "MIT",
       "dependencies": {
@@ -21,7 +21,9 @@
       },
       "bin": {
         "claude-dev-kit": "src/index.js",
-        "claude-dev-kit-mcp": "src/mcp/server.js"
+        "claude-dev-kit-mcp": "src/mcp/server.js",
+        "tierward": "src/index.js",
+        "tierward-mcp": "src/mcp/server.js"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,9 +1,11 @@
 {
-  "name": "mg-claude-dev-kit",
+  "name": "tierward",
   "version": "1.30.0",
   "description": "Scaffold for legible, reviewable AI-assisted development",
   "type": "module",
   "bin": {
+    "tierward": "src/index.js",
+    "tierward-mcp": "src/mcp/server.js",
     "claude-dev-kit": "src/index.js",
     "claude-dev-kit-mcp": "src/mcp/server.js"
   },
@@ -55,11 +57,11 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/marcoguillermaz/claude-dev-kit.git"
+    "url": "git+https://github.com/marcoguillermaz/tierward.git"
   },
-  "homepage": "https://github.com/marcoguillermaz/claude-dev-kit#readme",
+  "homepage": "https://github.com/marcoguillermaz/tierward#readme",
   "bugs": {
-    "url": "https://github.com/marcoguillermaz/claude-dev-kit/issues"
+    "url": "https://github.com/marcoguillermaz/tierward/issues"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/packages/cli/src/commands/add.js
+++ b/packages/cli/src/commands/add.js
@@ -49,9 +49,7 @@ export async function addSkill(name, options) {
   // Require .claude/ directory (signals an initialized project)
   if (!fs.existsSync(path.join(cwd, '.claude'))) {
     console.error(chalk.red('No .claude/ directory found.'));
-    console.log(
-      'Run ' + chalk.cyan('claude-dev-kit init') + ' first, or create .claude/ manually.',
-    );
+    console.log('Run ' + chalk.cyan('tierward init') + ' first, or create .claude/ manually.');
     process.exit(1);
   }
 

--- a/packages/cli/src/commands/context.js
+++ b/packages/cli/src/commands/context.js
@@ -227,8 +227,7 @@ export async function contextCommand(options = {}) {
 
   console.log();
   console.log(
-    chalk.bold('claude-dev-kit context') +
-      chalk.dim(' — generate CONTEXT.md from interview/inference'),
+    chalk.bold('tierward context') + chalk.dim(' — generate CONTEXT.md from interview/inference'),
   );
   console.log();
 

--- a/packages/cli/src/commands/doctor.js
+++ b/packages/cli/src/commands/doctor.js
@@ -55,7 +55,7 @@ const checks = [
       const exists = fs.existsSync(path.join(cwd, 'CLAUDE.md'));
       return {
         pass: exists,
-        fix: 'Run `claude-dev-kit init` to scaffold CLAUDE.md',
+        fix: 'Run `tierward init` to scaffold CLAUDE.md',
       };
     },
   },
@@ -80,7 +80,7 @@ const checks = [
       const exists = fs.existsSync(path.join(cwd, '.claude', 'settings.json'));
       return {
         pass: exists,
-        fix: 'Run `claude-dev-kit init` or copy from the template.',
+        fix: 'Run `tierward init` or copy from the template.',
       };
     },
   },
@@ -91,7 +91,7 @@ const checks = [
       const exists = fs.existsSync(path.join(cwd, '.claude', 'rules', 'pipeline.md'));
       return {
         pass: exists,
-        fix: 'Run `claude-dev-kit init` to scaffold the pipeline.',
+        fix: 'Run `tierward init` to scaffold the pipeline.',
       };
     },
   },
@@ -103,7 +103,7 @@ const checks = [
       return {
         pass: exists,
         warn: true,
-        fix: 'Copy security.md from the claude-dev-kit template.',
+        fix: 'Copy security.md from the tierward template.',
       };
     },
   },
@@ -222,7 +222,7 @@ const checks = [
       return {
         pass: exists,
         warn: true,
-        fix: 'Run `claude-dev-kit upgrade` to add output-style.md, or copy from the template.',
+        fix: 'Run `tierward upgrade` to add output-style.md, or copy from the template.',
       };
     },
   },
@@ -236,7 +236,7 @@ const checks = [
       return {
         pass: exists,
         warn: true,
-        fix: 'Run `claude-dev-kit upgrade` to add docs/claudemd-standards.md, or copy from the template.',
+        fix: 'Run `tierward upgrade` to add docs/claudemd-standards.md, or copy from the template.',
       };
     },
   },
@@ -250,7 +250,7 @@ const checks = [
       return {
         pass: exists,
         warn: true,
-        fix: 'Run `claude-dev-kit upgrade` to add docs/pipeline-standards.md, or copy from the template.',
+        fix: 'Run `tierward upgrade` to add docs/pipeline-standards.md, or copy from the template.',
       };
     },
   },
@@ -264,7 +264,7 @@ const checks = [
       return {
         pass: exists,
         warn: true,
-        fix: 'Run `claude-dev-kit upgrade` to add the commit skill, or copy from the template.',
+        fix: 'Run `tierward upgrade` to add the commit skill, or copy from the template.',
       };
     },
   },
@@ -444,7 +444,7 @@ const checks = [
           pass: false,
           warn: true,
           info: 'pipeline.md H1 does not declare a tier (Fast Lane / Tier M / Tier L)',
-          fix: 'Restore the canonical H1 from the CDK template (Fast Lane Pipeline, Standard Development Pipeline - Tier M, or Full Development Pipeline - Tier L).',
+          fix: 'Restore the canonical H1 from the Tierward template (Fast Lane Pipeline, Standard Development Pipeline - Tier M, or Full Development Pipeline - Tier L).',
         };
       }
       const bodyTier = detectPhaseCountTier(content);
@@ -455,7 +455,7 @@ const checks = [
         info: pass
           ? undefined
           : `H1 declares Tier ${declaredTier.toUpperCase()} but phase markers look like Tier ${bodyTier.toUpperCase()}`,
-        fix: 'Reconcile pipeline.md: H1 and phase sections must agree on tier. Reinstall via `claude-dev-kit upgrade --tier=<tier>` if in doubt.',
+        fix: 'Reconcile pipeline.md: H1 and phase sections must agree on tier. Reinstall via `tierward upgrade --tier=<tier>` if in doubt.',
       };
     },
   },
@@ -474,7 +474,7 @@ const checks = [
           pass: false,
           warn: true,
           info: 'security.md variant could not be identified (H1 and content markers absent)',
-          fix: 'Reinstall security.md via `claude-dev-kit upgrade` so the correct variant is written.',
+          fix: 'Reinstall security.md via `tierward upgrade` so the correct variant is written.',
         };
       }
       const hasApi = fs.existsSync(path.join(cwd, 'CLAUDE.md'))
@@ -488,7 +488,7 @@ const checks = [
         info: pass
           ? undefined
           : `stack "${stack}" expects "${expected}" variant, found "${actual}"`,
-        fix: `Reinstall security.md for stack "${stack}" via \`claude-dev-kit upgrade\` — expected variant "${expected}".`,
+        fix: `Reinstall security.md for stack "${stack}" via \`tierward upgrade\` — expected variant "${expected}".`,
       };
     },
   },
@@ -502,7 +502,7 @@ const checks = [
       return {
         pass: content.includes('C12'),
         warn: true,
-        fix: 'Run `claude-dev-kit upgrade` to update context-review.md to include C12 (canonical docs currency check).',
+        fix: 'Run `tierward upgrade` to update context-review.md to include C12 (canonical docs currency check).',
       };
     },
   },
@@ -538,7 +538,7 @@ const checks = [
   {
     id: 'anthropic-files-current',
     label:
-      'Anthropic-influenced files (arch-audit, claudemd-standards, pipeline-standards) match the installed CDK template',
+      'Anthropic-influenced files (arch-audit, claudemd-standards, pipeline-standards) match the installed Tierward template',
     check: (cwd) => {
       const tier = detectScaffoldedTier(cwd);
       if (!tier) return { pass: true, skip: true };
@@ -560,7 +560,7 @@ const checks = [
         pass: drifted.length === 0,
         warn: true,
         info: drifted.length > 0 ? `drift: ${drifted.join(', ')}` : undefined,
-        fix: `Run \`claude-dev-kit upgrade --anthropic\` to view diff, then \`--anthropic --apply\` to refresh${drifted.length > 0 ? ` (${drifted.length} file${drifted.length === 1 ? '' : 's'})` : ''}.`,
+        fix: `Run \`tierward upgrade --anthropic\` to view diff, then \`--anthropic --apply\` to refresh${drifted.length > 0 ? ` (${drifted.length} file${drifted.length === 1 ? '' : 's'})` : ''}.`,
       };
     },
   },
@@ -615,7 +615,7 @@ const checks = [
         info: violations.length > 0 ? violations.join('; ') : undefined,
         fix:
           violations.length > 0
-            ? 'Resolve each violation: re-init at the higher tier, remove blocked skills with `rm -rf .claude/skills/<name>`, add required skills with `claude-dev-kit add skill <name>`.'
+            ? 'Resolve each violation: re-init at the higher tier, remove blocked skills with `rm -rf .claude/skills/<name>`, add required skills with `tierward add skill <name>`.'
             : undefined,
       };
     },
@@ -634,7 +634,7 @@ const checks = [
           pass: false,
           warn: true,
           info: 'team-settings.json present but `.claude/hooks/team-settings-enforcement.mjs` missing — runtime enforcement disabled (CLI-side enforcement only).',
-          fix: 'Run `claude-dev-kit upgrade` to refresh the hook script, or copy it manually from the CDK template.',
+          fix: 'Run `tierward upgrade` to refresh the hook script, or copy it manually from the Tierward template.',
         };
       }
 
@@ -644,7 +644,7 @@ const checks = [
           pass: false,
           warn: true,
           info: 'team-settings.json + hook script present, but `.claude/settings.json` missing — hook will not fire.',
-          fix: 'Run `claude-dev-kit init` to scaffold settings.json, or restore from the CDK template.',
+          fix: 'Run `tierward init` to scaffold settings.json, or restore from the Tierward template.',
         };
       }
 
@@ -769,7 +769,7 @@ export async function doctor(options = {}) {
 
   // interactive mode (default)
   console.log();
-  console.log(chalk.bold('claude-dev-kit doctor') + chalk.dim(` - ${cwd}`));
+  console.log(chalk.bold('tierward doctor') + chalk.dim(` - ${cwd}`));
   console.log();
 
   for (const r of results) {

--- a/packages/cli/src/commands/init-from-context.js
+++ b/packages/cli/src/commands/init-from-context.js
@@ -243,7 +243,7 @@ export async function initFromContext(options) {
     chalk.yellow.bold('Important:') +
       ' CONTEXT_IMPORT.md is added to .gitignore - it contains local paths.',
   );
-  console.log(chalk.dim('Docs: https://github.com/marcoguillermaz/claude-dev-kit'));
+  console.log(chalk.dim('Docs: https://github.com/marcoguillermaz/tierward'));
 }
 
 async function appendToGitignore(dir, entries) {
@@ -256,7 +256,7 @@ async function appendToGitignore(dir, entries) {
 
   const toAdd = entries.filter((e) => !content.includes(e));
   if (toAdd.length > 0) {
-    const additions = '\n# claude-dev-kit context import\n' + toAdd.join('\n') + '\n';
+    const additions = '\n# tierward context import\n' + toAdd.join('\n') + '\n';
     await fs.appendFile(gitignorePath, additions);
   }
 }

--- a/packages/cli/src/commands/init-greenfield.js
+++ b/packages/cli/src/commands/init-greenfield.js
@@ -394,9 +394,7 @@ export async function initGreenfield(options) {
     console.log(`  2. Run ${chalk.cyan('claude')} from this directory to start your first session`);
     console.log(`  3. Read ${chalk.cyan('GETTING_STARTED.md')} - or share it with your team`);
     console.log();
-    console.log(
-      chalk.dim("When you're ready for more structure: npx mg-claude-dev-kit upgrade --tier=s"),
-    );
+    console.log(chalk.dim("When you're ready for more structure: npx tierward upgrade --tier=s"));
   } else {
     console.log(chalk.green.bold('✓ Greenfield scaffold complete'));
     console.log();
@@ -407,5 +405,5 @@ export async function initGreenfield(options) {
   }
 
   console.log();
-  console.log(chalk.dim('Docs: https://github.com/marcoguillermaz/claude-dev-kit'));
+  console.log(chalk.dim('Docs: https://github.com/marcoguillermaz/tierward'));
 }

--- a/packages/cli/src/commands/init-in-place.js
+++ b/packages/cli/src/commands/init-in-place.js
@@ -112,7 +112,7 @@ export async function initInPlace(options) {
       {
         type: 'input',
         name: 'testCommand',
-        message: "Test command (reference only - CDK won't run it):",
+        message: "Test command (reference only - Tierward won't run it):",
         default: (a) => {
           if (a.techStack === 'other') return '';
           if (detected.testCommand) return detected.testCommand;
@@ -460,7 +460,7 @@ export async function initInPlace(options) {
   console.log(chalk.bold('Next steps:'));
   printNextSteps(config, { ranDoctor, ranPreCommit });
   console.log();
-  console.log(chalk.dim('Docs: https://github.com/marcoguillermaz/claude-dev-kit'));
+  console.log(chalk.dim('Docs: https://github.com/marcoguillermaz/tierward'));
 }
 
 async function detectConflicts(dir, _config) {
@@ -484,7 +484,7 @@ async function appendIfMissing(dir, entries) {
 
   const toAdd = entries.filter((e) => !content.includes(e));
   if (toAdd.length > 0) {
-    const section = '\n# claude-dev-kit\n' + toAdd.join('\n') + '\n';
+    const section = '\n# tierward\n' + toAdd.join('\n') + '\n';
     await fs.appendFile(gitignorePath, section);
   }
 }

--- a/packages/cli/src/commands/init.js
+++ b/packages/cli/src/commands/init.js
@@ -12,7 +12,7 @@ const CONTEXT_FILENAME = 'CONTEXT.md';
 export async function init(options) {
   console.log();
   console.log(
-    chalk.bold('claude-dev-kit') +
+    chalk.bold('tierward') +
       chalk.dim(' - rules, workflows, and pipeline templates for Claude Code'),
   );
   console.log();
@@ -52,7 +52,7 @@ export async function init(options) {
         message: "What's the state of this project?",
         choices: [
           {
-            name: 'Existing project - add CDK to a project that already has code',
+            name: 'Existing project - add Tierward to a project that already has code',
             value: 'in-place',
           },
           {

--- a/packages/cli/src/commands/new-skill.js
+++ b/packages/cli/src/commands/new-skill.js
@@ -140,9 +140,7 @@ export async function newSkill(options) {
   // Require .claude/ directory
   if (!fs.existsSync(path.join(cwd, '.claude'))) {
     console.error(chalk.red('No .claude/ directory found.'));
-    console.log(
-      'Run ' + chalk.cyan('claude-dev-kit init') + ' first, or create .claude/ manually.',
-    );
+    console.log('Run ' + chalk.cyan('tierward init') + ' first, or create .claude/ manually.');
     process.exit(1);
   }
 

--- a/packages/cli/src/commands/upgrade.js
+++ b/packages/cli/src/commands/upgrade.js
@@ -102,7 +102,7 @@ function resolveTemplatePath(entry, tier) {
 export async function upgrade(options) {
   const cwd = process.cwd();
   console.log();
-  console.log(chalk.bold('claude-dev-kit upgrade'));
+  console.log(chalk.bold('tierward upgrade'));
   console.log();
 
   const settings = loadTeamSettingsOrExit(cwd);
@@ -116,7 +116,7 @@ export async function upgrade(options) {
         ),
       );
       console.error(
-        `  Re-run ${chalk.cyan(`claude-dev-kit init --tier=${required}`)} to promote, or edit .claude/team-settings.json.`,
+        `  Re-run ${chalk.cyan(`tierward init --tier=${required}`)} to promote, or edit .claude/team-settings.json.`,
       );
       process.exit(1);
     }
@@ -126,7 +126,7 @@ export async function upgrade(options) {
 
   if (options.anthropic) {
     console.log();
-    console.log(chalk.bold('claude-dev-kit upgrade --anthropic'));
+    console.log(chalk.bold('tierward upgrade --anthropic'));
     console.log();
     await runAnthropicUpgrade(cwd, options);
   }

--- a/packages/cli/src/commands/validate-context.js
+++ b/packages/cli/src/commands/validate-context.js
@@ -10,7 +10,7 @@
  *   --json  — machine-readable JSON ({ valid, errors, data, body })
  *
  * Use cases (v1.1):
- *   - CI gating: `npx mg-claude-dev-kit validate-context && build`
+ *   - CI gating: `npx tierward validate-context && build`
  *   - Hand-edited CONTEXT.md verified before commit
  *   - Reproducing the same MUST PASS check that `context` runs after write
  */

--- a/packages/cli/src/context-builder/interview/dev-flow.js
+++ b/packages/cli/src/context-builder/interview/dev-flow.js
@@ -337,7 +337,7 @@ export async function runDevInterview(options = {}) {
 
   if (HARD_STOP_TIERS.includes(answers.tier)) {
     const err = new Error(
-      `Tier ${answers.tier.toUpperCase()} not supported in v1. Use \`npx mg-claude-dev-kit init\` (legacy wizard) instead.`,
+      `Tier ${answers.tier.toUpperCase()} not supported in v1. Use \`npx tierward init\` (legacy wizard) instead.`,
     );
     err.code = 'TIER_NOT_SUPPORTED_V1';
     throw err;

--- a/packages/cli/src/context-builder/interview/pm-flow.js
+++ b/packages/cli/src/context-builder/interview/pm-flow.js
@@ -448,7 +448,7 @@ export async function runPmInterview(options = {}) {
 
   if (HARD_STOP_TIERS.includes(answers.tier)) {
     const err = new Error(
-      `Tier ${answers.tier.toUpperCase()} not supported in v1. Use \`npx mg-claude-dev-kit init\` (legacy) instead.`,
+      `Tier ${answers.tier.toUpperCase()} not supported in v1. Use \`npx tierward init\` (legacy) instead.`,
     );
     err.code = 'TIER_NOT_SUPPORTED_V1';
     throw err;

--- a/packages/cli/src/generators/readme.js
+++ b/packages/cli/src/generators/readme.js
@@ -33,7 +33,7 @@ ${config.typeCheckCommand ? config.typeCheckCommand + '   # type check' : ''}
 
 ## AI-Assisted Development
 
-This project uses [Claude Code](https://claude.ai/code) with a governance scaffold provided by [claude-dev-kit](https://github.com/marcoguillermaz/claude-dev-kit).
+This project uses [Claude Code](https://claude.ai/code) with a governance scaffold provided by [tierward](https://github.com/marcoguillermaz/tierward).
 
 **Pipeline**: ${tierDesc}
 

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -60,7 +60,7 @@ program
 
 program
   .command('upgrade')
-  .description('Update template files to the latest claude-dev-kit version')
+  .description('Update template files to the latest tierward version')
   .option('--dry-run', 'Show what would change without writing any files')
   .option(
     '--anthropic',
@@ -104,7 +104,7 @@ newCmd
 
 program.on('command:*', () => {
   console.error(chalk.red(`Unknown command: ${program.args.join(' ')}`));
-  console.log(`Run ${chalk.cyan('claude-dev-kit --help')} for available commands.`);
+  console.log(`Run ${chalk.cyan('tierward --help')} for available commands.`);
   process.exit(1);
 });
 

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -14,7 +14,7 @@ import chalk from 'chalk';
 const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
 
 program
-  .name('claude-dev-kit')
+  .name('tierward')
   .description('Scaffold for legible, reviewable AI-assisted development')
   .version(pkg.version);
 

--- a/packages/cli/src/mcp/server.js
+++ b/packages/cli/src/mcp/server.js
@@ -10,9 +10,17 @@ import { fileURLToPath } from 'node:url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CLI_PATH = resolve(__dirname, '..', 'index.js');
 
-function readPackageVersion() {
+function readPackageField(field) {
   const pkg = JSON.parse(readFileSync(resolve(__dirname, '..', '..', 'package.json'), 'utf8'));
-  return pkg.version;
+  return pkg[field];
+}
+
+function readPackageVersion() {
+  return readPackageField('version');
+}
+
+function readPackageName() {
+  return readPackageField('name');
 }
 
 function getCwd() {
@@ -227,7 +235,7 @@ function readPrReviewState(prNumber) {
 
 function getPackageMeta() {
   return {
-    name: 'mg-claude-dev-kit',
+    name: readPackageName(),
     version: readPackageVersion(),
     cliPath: CLI_PATH,
     cwd: getCwd(),
@@ -236,7 +244,7 @@ function getPackageMeta() {
 
 export function buildServer() {
   const server = new McpServer({
-    name: 'mg-claude-dev-kit',
+    name: readPackageName(),
     version: readPackageVersion(),
   });
 

--- a/packages/cli/src/mcp/server.js
+++ b/packages/cli/src/mcp/server.js
@@ -225,10 +225,10 @@ function readPrReviewState(prNumber) {
     },
     skillReviewComments: skillReviews,
     skillReviewCount: skillReviews.length,
-    cliInvocation: `claude-dev-kit /pr-review ${prNumber}`,
+    cliInvocation: `tierward /pr-review ${prNumber}`,
     note:
       skillReviews.length === 0
-        ? `No /pr-review skill comment found on this PR yet. Run \`claude-dev-kit /pr-review ${prNumber}\` (or invoke the skill from Claude Code) to generate one.`
+        ? `No /pr-review skill comment found on this PR yet. Run \`tierward /pr-review ${prNumber}\` (or invoke the skill from Claude Code) to generate one.`
         : `${skillReviews.length} /pr-review skill comment(s) found. Latest verdict: ${skillReviews[skillReviews.length - 1].verdict || 'unknown'}.`,
   };
 }
@@ -251,9 +251,9 @@ export function buildServer() {
   server.registerTool(
     'cdk_doctor_report',
     {
-      title: 'CDK doctor report',
+      title: 'Tierward doctor report',
       description:
-        'Runs `claude-dev-kit doctor --report` against the current project and returns the JSON compliance summary (28 checks: governance files, hooks, skill spec, security variant, drift markers).',
+        'Runs `tierward doctor --report` against the current project and returns the JSON compliance summary (28 checks: governance files, hooks, skill spec, security variant, drift markers).',
       inputSchema: {},
     },
     async () => buildToolReply(runDoctorReport(getCwd())),
@@ -262,9 +262,9 @@ export function buildServer() {
   server.registerTool(
     'cdk_team_settings',
     {
-      title: 'CDK team-settings.json contents',
+      title: 'Tierward team-settings.json contents',
       description:
-        'Returns the parsed `.claude/team-settings.json` for the current project. The `present` flag indicates whether the file exists; when absent, the project is unrestricted by CDK governance.',
+        'Returns the parsed `.claude/team-settings.json` for the current project. The `present` flag indicates whether the file exists; when absent, the project is unrestricted by Tierward governance.',
       inputSchema: {},
     },
     async () => buildToolReply(readTeamSettings(getCwd())),
@@ -297,7 +297,7 @@ export function buildServer() {
     {
       title: 'Read /pr-review skill state on a PR',
       description:
-        "Reads the audit trail of `/pr-review` skill comments on a GitHub PR (verdict, severity counts, body preview). Read-only: this tool does not run a fresh review. To generate a new review, invoke the `/pr-review` CDK skill via the CLI (the tool returns the exact invocation in `cliInvocation`). Requires the `gh` CLI to be authenticated against the project's GitHub repo.",
+        "Reads the audit trail of `/pr-review` skill comments on a GitHub PR (verdict, severity counts, body preview). Read-only: this tool does not run a fresh review. To generate a new review, invoke the `/pr-review` Tierward skill via the CLI (the tool returns the exact invocation in `cliInvocation`). Requires the `gh` CLI to be authenticated against the project's GitHub repo.",
       inputSchema: {
         prNumber: z.number().int().positive().describe('GitHub PR number to inspect'),
       },
@@ -308,9 +308,9 @@ export function buildServer() {
   server.registerTool(
     'cdk_package_meta',
     {
-      title: 'CDK package metadata',
+      title: 'Tierward package metadata',
       description:
-        'Returns the CDK package name, installed version, CLI path, and resolved project root. Useful for clients to verify which CDK CLI is wired up to this MCP server.',
+        'Returns the Tierward package name, installed version, CLI path, and resolved project root. Useful for clients to verify which Tierward CLI is wired up to this MCP server.',
       inputSchema: {},
     },
     async () => buildToolReply(getPackageMeta()),
@@ -328,7 +328,7 @@ export async function startStdio() {
 const isMain = import.meta.url === `file://${process.argv[1]}`;
 if (isMain) {
   startStdio().catch((err) => {
-    process.stderr.write(`mg-claude-dev-kit-mcp fatal: ${err.message}\n`);
+    process.stderr.write(`tierward-mcp fatal: ${err.message}\n`);
     process.exit(1);
   });
 }

--- a/packages/cli/src/scaffold/index.js
+++ b/packages/cli/src/scaffold/index.js
@@ -252,7 +252,7 @@ async function patchSettingsPermissions(targetDir, config) {
     // is a subtle correctness failure. Surface the problem so the user
     // can fix the template or re-run with --force.
     console.warn(
-      `[claude-dev-kit] Warning: could not patch ${settingsPath} — ${err.message}. ` +
+      `[tierward] Warning: could not patch ${settingsPath} — ${err.message}. ` +
         `Stack-specific permissions for "${config.techStack}" were NOT applied; ` +
         `the file may be malformed JSON or read-only.`,
     );

--- a/packages/cli/src/utils/constants.js
+++ b/packages/cli/src/utils/constants.js
@@ -5,7 +5,7 @@ export const AUDIT_MODELS = [
 
 /**
  * Maximum length of a SKILL.md `description:` frontmatter value.
- * Enforced by new-skill wizard + validateSkillMd (CDK convention).
+ * Enforced by new-skill wizard + validateSkillMd (Tierward convention).
  */
 export const SKILL_DESC_MAX_CHARS = 250;
 

--- a/packages/cli/src/utils/print-plan.js
+++ b/packages/cli/src/utils/print-plan.js
@@ -164,7 +164,7 @@ function getPreCommitInstallCmd() {
 function getDoctorCmd() {
   const argv1 = process.argv[1] || '';
   const isLocal = argv1.endsWith('index.js') && !argv1.includes('node_modules');
-  return isLocal ? `node ${argv1} doctor` : 'npx mg-claude-dev-kit doctor';
+  return isLocal ? `node ${argv1} doctor` : 'npx tierward doctor';
 }
 
 /**

--- a/packages/cli/src/utils/team-settings-cli.js
+++ b/packages/cli/src/utils/team-settings-cli.js
@@ -19,7 +19,7 @@ export function enforceTeamSettingsTier(cwd, tier, { suggestUpgrade = false } = 
   );
   if (suggestUpgrade) {
     console.error(
-      `  Promote first: ${chalk.cyan(`claude-dev-kit upgrade --tier=${required}`)}, then retry.`,
+      `  Promote first: ${chalk.cyan(`tierward upgrade --tier=${required}`)}, then retry.`,
     );
   } else {
     console.error(`  Choose tier ${required} or higher, or edit .claude/team-settings.json.`);

--- a/packages/cli/templates/common/pipeline-standards.md
+++ b/packages/cli/templates/common/pipeline-standards.md
@@ -154,7 +154,7 @@ Rules derived from Conventional Commits 1.0.0:
   1. Commit 1 - code (after Phase 3 green build)
   2. Commit 2 - docs (Phase 8: requirements, contracts, changelogs, schema/route maps — only what changed)
   3. Commit 3 - context files (CLAUDE.md and project-specific context files — only if updated) *(Source: project pipeline)*
-- **CLAUDE.md is a committed project file**: include it in version control — it is shared team context. Personal local overrides (e.g., `CLAUDE.local.md`) should be gitignored. *(Source: CDK pattern)*
+- **CLAUDE.md is a committed project file**: include it in version control — it is shared team context. Personal local overrides (e.g., `CLAUDE.local.md`) should be gitignored. *(Source: Tierward pattern)*
 - **Never commit directly to protected branches** (`main`, `staging`, or project-equivalent): functional blocks use worktrees; fixes use `fix/` branches. Promotion is via merge commands only. *(Source: project HARD RULES)*
 - **Intermediate commit at Phase 3**: commit after green build + tests, before UAT. Creates a known-good checkpoint. *(Source: 2)*
 

--- a/packages/cli/templates/tier-0/GETTING_STARTED.md
+++ b/packages/cli/templates/tier-0/GETTING_STARTED.md
@@ -85,9 +85,9 @@ Tier 0 (what you have now) gives you the minimum viable scaffold:
 When your team grows or your project complexity increases, upgrade to a higher tier:
 
 ```bash
-npx mg-claude-dev-kit upgrade --tier=s   # Fast Lane: branch discipline + commit rules
-npx mg-claude-dev-kit upgrade --tier=m   # Standard: phased pipeline with review gates
-npx mg-claude-dev-kit upgrade --tier=l   # Full: audit skills, security review, multi-agent
+npx tierward upgrade --tier=s   # Fast Lane: branch discipline + commit rules
+npx tierward upgrade --tier=m   # Standard: phased pipeline with review gates
+npx tierward upgrade --tier=l   # Full: audit skills, security review, multi-agent
 ```
 
 Upgrade is non-destructive - it adds new files without overwriting your existing ones.
@@ -102,7 +102,7 @@ Upgrade is non-destructive - it adds new files without overwriting your existing
 | Give Claude context | Edit `CLAUDE.md` |
 | Run tests manually | `[TEST_COMMAND]` |
 | See what Claude can do | Ask: "What slash commands are available?" |
-| Add more structure | `npx mg-claude-dev-kit upgrade --tier=s` |
+| Add more structure | `npx tierward upgrade --tier=s` |
 
 ---
 

--- a/packages/cli/templates/tier-l/.claude/FIRST_SESSION.md
+++ b/packages/cli/templates/tier-l/.claude/FIRST_SESSION.md
@@ -128,7 +128,7 @@ At the scope gate, Claude also declares whether **Phase 4 E2E** and **Phase 5d q
 | `/responsive-audit` | Breakpoint correctness (375px / 768px / 1024px) |
 | `/perf-audit` | Rendering boundaries, bundle size, N+1 patterns |
 | `/compact` | Frees context window (run at Phase 8.5) |
-| `npx mg-claude-dev-kit doctor` | Checks your scaffold setup |
+| `npx tierward doctor` | Checks your scaffold setup |
 
 ---
 

--- a/packages/cli/templates/tier-l/.claude/cheatsheet.md
+++ b/packages/cli/templates/tier-l/.claude/cheatsheet.md
@@ -49,7 +49,7 @@ Run these on demand. Each skill reads the codebase, produces a structured report
 | `/ux-audit` | Task completion paths, feedback clarity, cognitive load, error recovery | After adding user flows; before usability reviews |
 | `/ui-audit` | Design system token compliance, component adoption, empty/error/loading states | After UI changes; when design system is configured |
 | `/test-audit` | Coverage (lcov/Istanbul/Cobertura/go/tarpaulin/xcresult), pyramid shape, anti-patterns (`.only`, skipped, empty, no-assertion, sleeps) | After Phase 3 tests green; every block |
-| `/doc-audit` | Relative-link resolution, code-block syntax (json/yaml/toml), CDK placeholder residuals, slash-command name match, skill-count consistency, ADR freshness, stack-specific doc sync (Next.js / Django / Swift) | After doc changes; every block that touches README or `docs/` |
+| `/doc-audit` | Relative-link resolution, code-block syntax (json/yaml/toml), Tierward placeholder residuals, slash-command name match, skill-count consistency, ADR freshness, stack-specific doc sync (Next.js / Django / Swift) | After doc changes; every block that touches README or `docs/` |
 | `/api-contract-audit` | OpenAPI contract drift (endpoints, schemas, status codes), breaking-change detection vs previous spec, versioning consistency, security scheme alignment, Richardson Maturity L0-L3 scoring | After API changes; before releasing contract updates to external consumers |
 | `/infra-audit` | GitHub Actions (pwn-request, secret logging, pinning, permissions), Dockerfile (root user, latest tag, URL add), K8s (runAsNonRoot, privileged, hostNetwork), Terraform (IAM wildcards, state in git), GitLab CI | After pipeline or IaC changes; every block that touches `.github/workflows/`, `Dockerfile`, K8s manifests, or `*.tf` |
 | `/compliance-audit` | GDPR profile: data-subject rights (delete, export, rectify), consent capture, lawful basis, PII identification, encryption-at-rest on special-category, logging hygiene, retention, sub-processors. SOC 2 and HIPAA scaffolded for v1.15+ | Before EU-facing product launch; quarterly review |
@@ -89,5 +89,5 @@ Run these on demand. Each skill reads the codebase, produces a structured report
 cat ~/.claude/audit/[PROJECT_NAME].jsonl | tail -20 | jq .
 
 # Validate Claude setup
-npx mg-claude-dev-kit doctor
+npx tierward doctor
 ```

--- a/packages/cli/templates/tier-l/.claude/rules/pipeline.md
+++ b/packages/cli/templates/tier-l/.claude/rules/pipeline.md
@@ -244,10 +244,10 @@ If the project is CLI-only, backend-only, or native-standalone without a UI laye
 
 **Track C - Test + doc + infra audit** *(runs for every block after Phase 3 is green - static analysis, no dev server needed)*
 - Run `/test-audit` - static analysis of coverage (auto-detects lcov / Istanbul / Cobertura / go / tarpaulin / xcresult), pyramid shape (unit/integration/e2e ratio), anti-patterns (`.only` leaks, skipped tests, empty bodies, no-assertion tests, hardcoded sleeps).
-- Run `/doc-audit` - static doc-drift check (relative-link resolution, code-block syntax, CDK placeholder residuals, slash-command name match, skill-count consistency, ADR freshness). Stack-aware for Next.js / Django / Swift.
+- Run `/doc-audit` - static doc-drift check (relative-link resolution, code-block syntax, Tierward placeholder residuals, slash-command name match, skill-count consistency, ADR freshness). Stack-aware for Next.js / Django / Swift.
 - Run `/infra-audit` - static infra-security check across GitHub Actions, Dockerfile, Kubernetes manifests, Terraform, GitLab CI. Each layer runs only if its markers are detected. Stack-agnostic.
 - Run `/dependency-audit` if the block touches `package.json`, `pyproject.toml`, `Package.swift`, `Cargo.toml`, `go.mod`, or any other dependency manifest - tier classification (A/B/C), changelog summary for Tier B/C, codebase impact grep, runtime LTS status. Audit-only in v1.
-- Output: one-paragraph summary per skill. Critical findings (`.only` committed, 0% coverage on a file changed in this block, CDK placeholder in README, pwn-request in workflow, secret logging in CI, privileged K8s container, IAM wildcard action, hardcoded secret in Terraform) block Phase 6.
+- Output: one-paragraph summary per skill. Critical findings (`.only` committed, 0% coverage on a file changed in this block, Tierward placeholder in README, pwn-request in workflow, secret logging in CI, privileged K8s container, IAM wildcard action, hardcoded secret in Terraform) block Phase 6.
 
 **Severity handling - all tracks**:
 - **Critical**: fix before Phase 6. Do not proceed with open Critical issues.

--- a/packages/cli/templates/tier-l/.claude/skills/doc-audit/PATTERNS.md
+++ b/packages/cli/templates/tier-l/.claude/skills/doc-audit/PATTERNS.md
@@ -1,13 +1,13 @@
 # Doc Audit - Patterns
 
-Reference file for `/doc-audit`. Contains the pinned CDK placeholder list (agnostic) and stack-specific grep patterns for D7 doc-sync checks.
+Reference file for `/doc-audit`. Contains the pinned Tierward placeholder list (agnostic) and stack-specific grep patterns for D7 doc-sync checks.
 The executing agent reads this file at the start of Step 3. For D3, use the placeholder list verbatim. For D7, select the section matching the detected stack; if the detected stack is not in the top 3 (`node-ts`, `python`, `swift`), skip D7 entirely.
 
 ---
 
-## D3 - CDK placeholder list (agnostic)
+## D3 - Tierward placeholder list (agnostic)
 
-The CDK scaffold emits these placeholder tokens. Readers are expected to replace each one with a concrete value. A token left in place after first-run configuration signals an incomplete adoption, not an intentional user convention.
+The Tierward scaffold emits these placeholder tokens. Readers are expected to replace each one with a concrete value. A token left in place after first-run configuration signals an incomplete adoption, not an intentional user convention.
 
 ```
 [TEST_COMMAND]
@@ -22,9 +22,9 @@ The CDK scaffold emits these placeholder tokens. Readers are expected to replace
 [MIGRATION_COMMAND]
 ```
 
-**Extension rule**: this list is grepped against the CDK template tree (`packages/cli/templates/**`) - only tokens that are actually emitted by the scaffold belong here. When a new CDK release adds a placeholder to any scaffold template, append it to this list and bump the skill's internal version note in the next release. Generic `[UPPERCASE]` regex is deliberately avoided - it produces false positives on legitimate user conventions (`[API_KEY]`, `[YOUR_DOMAIN]`, `[FEATURE_FLAG]`).
+**Extension rule**: this list is grepped against the Tierward template tree (`packages/cli/templates/**`) - only tokens that are actually emitted by the scaffold belong here. When a new Tierward release adds a placeholder to any scaffold template, append it to this list and bump the skill's internal version note in the next release. Generic `[UPPERCASE]` regex is deliberately avoided - it produces false positives on legitimate user conventions (`[API_KEY]`, `[YOUR_DOMAIN]`, `[FEATURE_FLAG]`).
 
-**Exclusion**: skip files under `packages/cli/templates/**` (the CDK template source itself - placeholders are intentional there). Apply this exclusion only when auditing the CDK repo itself; in user projects, the exclusion is a no-op.
+**Exclusion**: skip files under `packages/cli/templates/**` (the Tierward template source itself - placeholders are intentional there). Apply this exclusion only when auditing the Tierward repo itself; in user projects, the exclusion is a no-op.
 
 ---
 

--- a/packages/cli/templates/tier-l/.claude/skills/doc-audit/SKILL.md
+++ b/packages/cli/templates/tier-l/.claude/skills/doc-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: doc-audit
-description: Static documentation drift audit - relative-link resolution, code-block syntax, CDK placeholder residuals, slash-command name match, skill-count consistency, ADR marker freshness, stack-specific doc sync (Next.js / Django / Swift).
+description: Static documentation drift audit - relative-link resolution, code-block syntax, Tierward placeholder residuals, slash-command name match, skill-count consistency, ADR marker freshness, stack-specific doc sync (Next.js / Django / Swift).
 user-invocable: true
 model: sonnet
 context: fork
@@ -108,11 +108,11 @@ Skip `bash`, `sh`, `shell`, `text`, `console`, `diff`, and any unlabelled fence.
 
 Report: each failing block with `FILE:LINE - lang=<tag> - <parser error excerpt>`.
 
-### D3 - CDK placeholder residuals
+### D3 - Tierward placeholder residuals
 
 **High per occurrence in user-facing docs; Critical if found in `README.md`.** Placeholders shipped unfilled indicate an incomplete scaffold adoption.
 
-The CDK scaffold emits a **fixed set** of `[UPPERCASE]` tokens that the user is expected to resolve. Generic `[UPPERCASE]` regex would produce false positives on legitimate user conventions (`[API_KEY]`, `[YOUR_DOMAIN]`, `[FEATURE_FLAG_NAME]`). Use the pinned list from `PATTERNS.md` (agnostic section, `D3 CDK placeholder list`):
+The Tierward scaffold emits a **fixed set** of `[UPPERCASE]` tokens that the user is expected to resolve. Generic `[UPPERCASE]` regex would produce false positives on legitimate user conventions (`[API_KEY]`, `[YOUR_DOMAIN]`, `[FEATURE_FLAG_NAME]`). Use the pinned list from `PATTERNS.md` (agnostic section, `D3 Tierward placeholder list`):
 
 ```
 [TEST_COMMAND] [FRAMEWORK_VALUE] [LANGUAGE_VALUE] [INSTALL_COMMAND]
@@ -120,7 +120,7 @@ The CDK scaffold emits a **fixed set** of `[UPPERCASE]` tokens that the user is 
 [ENUM_CASE_CONVENTION] [MIGRATION_COMMAND]
 ```
 
-Grep each doc for any exact token from the list. Exclude files under `packages/cli/templates/**` (the CDK template source itself - placeholders are intentional there).
+Grep each doc for any exact token from the list. Exclude files under `packages/cli/templates/**` (the Tierward template source itself - placeholders are intentional there).
 
 Report: each match with `FILE:LINE - <token> - replace with concrete value`.
 
@@ -128,7 +128,7 @@ Report: each match with `FILE:LINE - <token> - replace with concrete value`.
 
 **Medium per orphan reference.** Readers click / copy a skill name that does not exist in `.claude/skills/`.
 
-Grep every doc for `/[a-z][a-z0-9-]+` occurrences inside prose (filter: must be preceded by whitespace or start-of-line and followed by a word boundary; ignore URL paths by excluding matches inside a `(...)` link target). For each unique command name, verify `.claude/skills/<name>/` exists. Allowlist CDK CLI verbs that are not skills: `init`, `upgrade`, `doctor`, `add`, `new` (these live in `packages/cli/src/commands/`, not in `.claude/skills/`).
+Grep every doc for `/[a-z][a-z0-9-]+` occurrences inside prose (filter: must be preceded by whitespace or start-of-line and followed by a word boundary; ignore URL paths by excluding matches inside a `(...)` link target). For each unique command name, verify `.claude/skills/<name>/` exists. Allowlist Tierward CLI verbs that are not skills: `init`, `upgrade`, `doctor`, `add`, `new` (these live in `packages/cli/src/commands/`, not in `.claude/skills/`).
 
 Report: each orphan with `FILE:LINE - /<name> - no matching skill directory`.
 
@@ -142,7 +142,7 @@ Grep README and `[DOC_PATH]` for numeric skill claims: `\b(\d+)\s+(audit\s+)?ski
 ls .claude/skills/ | grep -v '^custom-' | wc -l
 ```
 
-If the claimed count does not match the actual directory count, flag the mismatch. Note: this check intentionally scopes to **skill count only** - doctor/test counts are source-specific to the CDK codebase and are not in scope for user-project audits.
+If the claimed count does not match the actual directory count, flag the mismatch. Note: this check intentionally scopes to **skill count only** - doctor/test counts are source-specific to the Tierward codebase and are not in scope for user-project audits.
 
 Report: `FILE:LINE - claim "<N> skills" - actual <M> in .claude/skills/`.
 
@@ -189,7 +189,7 @@ If nothing Critical/High: state that explicitly ("No Critical or High findings -
 |---|---|---|
 | Link hygiene | strong / adequate / weak | [D1 broken link count] |
 | Code-block validity | strong / adequate / weak | [D2 unparseable blocks] |
-| Placeholder discipline | strong / adequate / weak | [D3 CDK tokens remaining] |
+| Placeholder discipline | strong / adequate / weak | [D3 Tierward tokens remaining] |
 | Skill coherence | strong / adequate / weak | [D4 orphans + D5 count mismatch] |
 | ADR freshness | strong / adequate / weak | [D6 stale count; N/A if ADR_PATH unset] |
 | Stack sync | strong / adequate / weak | [D7 orphans; N/A for non-top-3 stacks] |
@@ -200,7 +200,7 @@ If nothing Critical/High: state that explicitly ("No Critical or High findings -
 |---|---|---|---|
 | D1 | Relative-link resolution | ✅/⚠️ | [N broken] |
 | D2 | Code-block syntax | ✅/⚠️ | [N unparseable] |
-| D3 | CDK placeholder residuals | ✅/⚠️ | [N occurrences] |
+| D3 | Tierward placeholder residuals | ✅/⚠️ | [N occurrences] |
 | D4 | Slash-command name match | ✅/⚠️ | [N orphans] |
 | D5 | Skill-count consistency | ✅/⚠️ | [mismatch or OK] |
 | D6 | ADR marker freshness | ✅/⚠️ / N/A | [N stale; N/A if no ADR_PATH] |
@@ -242,8 +242,8 @@ Then write ONLY the approved entries to `docs/refactoring-backlog.md`:
 
 ### Severity guide
 
-- **Critical**: broken link to a user-visible flow doc (CONTRIBUTING, SECURITY, linked guide) (D1); CDK placeholder in `README.md` (D3)
-- **High**: unparseable `json` / `yaml` / `toml` code block (D2); CDK placeholder in any other user-facing doc (D3); skill-count mismatch > 2 (D5)
+- **Critical**: broken link to a user-visible flow doc (CONTRIBUTING, SECURITY, linked guide) (D1); Tierward placeholder in `README.md` (D3)
+- **High**: unparseable `json` / `yaml` / `toml` code block (D2); Tierward placeholder in any other user-facing doc (D3); skill-count mismatch > 2 (D5)
 - **Medium**: orphan `/skill-name` reference (D4); skill-count mismatch ≤ 2 (D5); stack-specific orphan surface (D7); broken link to non-critical asset (D1)
 - **Low**: stale ADR without terminal status (D6)
 

--- a/packages/cli/templates/tier-l/.claude/skills/skill-review/CALIBRATION_KIT.md
+++ b/packages/cli/templates/tier-l/.claude/skills/skill-review/CALIBRATION_KIT.md
@@ -18,7 +18,7 @@
 
 ## 1. Severity anchor catalog
 
-12 canonical examples, 3 per level. Two are abstract references from P2; one per level is a CDK-specific anchor tied to a known pilot-project or spec artifact.
+12 canonical examples, 3 per level. Two are abstract references from P2; one per level is a Tierward-specific anchor tied to a known pilot-project or spec artifact.
 
 ### Critical anchors (3)
 
@@ -56,7 +56,7 @@
 
 ## 2. Known traps (avoid these)
 
-Trap = a pattern that has historically caused mislabeling in CDK. Read once; do not re-evaluate at runtime - anchor on the rule.
+Trap = a pattern that has historically caused mislabeling in Tierward. Read once; do not re-evaluate at runtime - anchor on the rule.
 
 **T-1. Staff-manager literal contamination**
 Any reference to `Color.red`, SwiftUI-specific types, Vapor routes, or the pilot project's domain model (staff, shifts, invitations) in a scaffold skill is **Critical**. These artifacts survived extraction and produce false positives on every other stack.

--- a/packages/cli/templates/tier-l/.claude/skills/skill-review/REVIEW_FRAMEWORK.md
+++ b/packages/cli/templates/tier-l/.claude/skills/skill-review/REVIEW_FRAMEWORK.md
@@ -5,7 +5,7 @@
 **Updated**: 2026-05-01 - P2 mechanical checks from 2026-04-29 cross-LLM meta-review: Phase 1 checks 7+8 (architectural/paradigm vocab scan + reference file coverage), Phase 2.A(e) test-runner idiom expansion.
 **Status**: Consolidated - ready for execution once pre-work artifacts P1-P5 are produced.
 
-**Purpose**: single source of truth for the quality review of all 18 CDK skills. Replaces any prior partial framework. Every check, decision point, and severity level lives here.
+**Purpose**: single source of truth for the quality review of all 18 Tierward skills. Replaces any prior partial framework. Every check, decision point, and severity level lives here.
 
 ---
 
@@ -14,7 +14,7 @@
 The review validates each SKILL.md in `packages/cli/templates/tier-*/.claude/skills/` against:
 
 1. **Anthropic spec compliance** - conforms to documented frontmatter and body structure.
-2. **CDK scope alignment** - stack-agnostic, registry-coherent, pipeline-integrated.
+2. **Tierward scope alignment** - stack-agnostic, registry-coherent, pipeline-integrated.
 3. **Internal quality** - checks are universal, severity calibrated, report template matches body.
 4. **Cross-skill coherence** - references accurate, boundaries don't overlap, boilerplate intentional.
 5. **Behavioral correctness** *(added v1.2)* - skills behave correctly when executed, not only when read. Validated via targeted behavioral fixtures on high-risk skills.
@@ -207,7 +207,7 @@ Grouped by gravity. 2.A/2.B/2.C autonomous; 2.D interactive; 2.E targeted on hig
 
 1. **Frontmatter↔body coherence**: argument-hint targets/modes match body handlers.
 2. **Project-agnosticity test - extended** *(D3 - 4 dimensions)*:
-   - **(a) Literal contamination**: no example, file path, entity name, API reference tied to a specific project. Every reference is a placeholder or universal concept. Universal = applies unchanged across ≥3 of 6 CDK-supported stacks.
+   - **(a) Literal contamination**: no example, file path, entity name, API reference tied to a specific project. Every reference is a placeholder or universal concept. Universal = applies unchanged across ≥3 of 6 Tierward-supported stacks.
    - **(b) Severity habits**: severity labels not inherited from pilot project's domain. E.g., "any hardcoded color = Critical" is a pilot-project habit; in non-UI projects, color is not Critical.
    - **(c) Remediation style**: fix suggestions not formatted/structured in pilot project's conventions. E.g., remediation always in "SwiftUI-like" declarative form.
    - **(d) Architectural assumptions**: no implicit assumption about routing, state management, persistence layer, auth pattern tied to pilot's architecture.
@@ -216,7 +216,7 @@ Grouped by gravity. 2.A/2.B/2.C autonomous; 2.D interactive; 2.E targeted on hig
    If a reader who doesn't know the origin project could ask "why this specific case?" on ANY of (a)-(e), it's an artifact.
 
 3. **Output template↔body coherence**: every report row matches body check name + severity.
-4. **Multi-stack + agnostic verification**: skill applies (or explicitly gates with `[web only]`/`[SSR only]`) across CDK-supported stacks.
+4. **Multi-stack + agnostic verification**: skill applies (or explicitly gates with `[web only]`/`[SSR only]`) across Tierward-supported stacks.
 
 #### 2.B - Coerenza strutturale (cross-skill + cross-tier)
 
@@ -243,7 +243,7 @@ Grouped by gravity. 2.A/2.B/2.C autonomous; 2.D interactive; 2.E targeted on hig
 
    Per opportunity: **apply now** / **register roadmap** / **ignore**.
 
-14. **Section-by-section walkthrough**: Claude explains purpose + CDK relevance; user flags issues.
+14. **Section-by-section walkthrough**: Claude explains purpose + Tierward relevance; user flags issues.
 
 15. **Cross-tier diff review (C6 STOP)**: if skill is multi-tier, user reviews cross-tier diff artifact (column-by-column comparison showing frontmatter, tool set, check list, severity labels, report template across variants). User approves propagation strategy.
 
@@ -479,7 +479,7 @@ Deferred to vNext (v1.3 or later):
 
 ## Changelog
 
-- **v1.3 (2026-05-01)**: P2 mechanical checks (CDK #131). Phase 1 check 7: architectural (layer/MVC/hexagonal/microservice/monolith/repository pattern/service boundary/bounded context) + paradigm (props/state management/virtual DOM/bundler/reactive/component tree/hydration) unguarded-match scan feeding Phase 2.A(d)+(e). Phase 1 check 8: reference file coverage check for stack-dependent skills (missing check ID = High). Phase 2.A(e): test-runner idiom detection extended to Rust (#[test]), Swift XCTest, JUnit (@Test).
+- **v1.3 (2026-05-01)**: P2 mechanical checks (Tierward #131). Phase 1 check 7: architectural (layer/MVC/hexagonal/microservice/monolith/repository pattern/service boundary/bounded context) + paradigm (props/state management/virtual DOM/bundler/reactive/component tree/hydration) unguarded-match scan feeding Phase 2.A(d)+(e). Phase 1 check 8: reference file coverage check for stack-dependent skills (missing check ID = High). Phase 2.A(e): test-runner idiom detection extended to Rust (#[test]), Swift XCTest, JUnit (@Test).
 - **v1.2 (2026-04-14)**: cross-model review integrated. Fixes C1-C7 convergent + T2.1 targeted (D1 behavioral fixtures on 6 skills) + T2.3 (D2 P5 calibration + Phase 9 midpoint drift check) + T2.4 (D3 4-dimensional project-agnosticity) + T2.5/T2.6 trivial. New pre-work P5. New Phase 2.E and Phase 9. Severity scale patched (C5). Retroactive re-application freezed (C3). 2 new STOP gates (C6 cross-tier + C7 Phase 3→4).
 - **v1.1 (2026-04-14)**: O1-O5 omissions fixed; P1/P2 potential codified; Phase 2 regrouped (2.A/B/C/D); severity mapping clarified.
 - **v1.0 (2026-04-14)**: initial consolidation.

--- a/packages/cli/templates/tier-l/.claude/skills/skill-review/SKILLS_INVENTORY.md
+++ b/packages/cli/templates/tier-l/.claude/skills/skill-review/SKILLS_INVENTORY.md
@@ -1,6 +1,6 @@
 # Skills Inventory (P3)
 
-> **EXPORT NOTE**: this file is bundled as an example. Replace the inventory below with your project's skills before running `/skill-review`. The structure (summary stats + main table + coverage check) is the template - the content is a placeholder from CDK's own review cycle.
+> **EXPORT NOTE**: this file is bundled as an example. Replace the inventory below with your project's skills before running `/skill-review`. The structure (summary stats + main table + coverage check) is the template - the content is a placeholder from Tierward's own review cycle.
 >
 > **How to adapt**:
 > 1. Run `find .claude/skills -name SKILL.md` to list your skills.

--- a/packages/cli/templates/tier-l/.claude/skills/skill-review/SPEC_SNAPSHOT.md
+++ b/packages/cli/templates/tier-l/.claude/skills/skill-review/SPEC_SNAPSHOT.md
@@ -28,7 +28,7 @@ Every field below is **documented by Anthropic**. Fields outside this list are f
 
 | Field | Type | Purpose / valid values |
 |---|---|---|
-| `allowed-tools` | string OR list | Subset of tools the skill can invoke. Space-separated string or YAML list. CDK convention: space-separated string. |
+| `allowed-tools` | string OR list | Subset of tools the skill can invoke. Space-separated string or YAML list. Tierward convention: space-separated string. |
 | `model` | string | Model identifier: `sonnet`, `haiku`, `opus`. |
 | `context` | string | Only documented value: `fork`. |
 | `agent` | string | Subagent type: `Explore`, `Plan`, `general-purpose`. |
@@ -36,7 +36,7 @@ Every field below is **documented by Anthropic**. Fields outside this list are f
 | `paths` | list | YAML list of glob patterns restricting where the skill activates. |
 | `user-invocable` | boolean | Whether user can invoke via `/skill-name`. |
 | `disable-model-invocation` | boolean | Whether Claude may auto-invoke the skill. |
-| `hooks` | object | Lifecycle hook registration (no CDK skill currently uses this). |
+| `hooks` | object | Lifecycle hook registration (no Tierward skill currently uses this). |
 | `shell` | string | `bash` or `powershell`. |
 | `argument-hint` | string | Free text, hint for argument structure. |
 | `version` | string | Informal version string. |
@@ -49,7 +49,7 @@ Every field below is **documented by Anthropic**. Fields outside this list are f
 
 Any frontmatter key outside the required + optional set above is a spec violation.
 
-**Known non-documented fields present in CDK at snapshot date**:
+**Known non-documented fields present in Tierward at snapshot date**:
 - `effort` - on 6 files: `arch-audit` (S, M, L) and `security-audit` (S, M, L). To be removed during the review cycle.
 
 ---
@@ -114,17 +114,17 @@ If Anthropic publishes spec changes between this snapshot date and the end of th
 2. **Decision gate**: evaluate impact. Two outcomes:
    - **Non-breaking** (new optional field, non-mandatory constraint relaxation): log in `MID_CYCLE_DELTA.md`, complete the cycle against this snapshot, integrate in next snapshot version.
    - **Breaking** (field renamed, new required field, mandatory constraint tightened): bump this snapshot to v1.1, re-run P1 checklist on every already-reviewed skill. Count this as a framework-level event triggering retroactive re-application per `review-framework.md`.
-3. **Either way**: document the decision with the publication date of the Anthropic change + the CDK review date + rationale for non-breaking-vs-breaking classification.
+3. **Either way**: document the decision with the publication date of the Anthropic change + the Tierward review date + rationale for non-breaking-vs-breaking classification.
 
 ---
 
 ## 9. Known ambiguities (flagged at snapshot date)
 
-| Topic | Ambiguity | CDK resolution |
+| Topic | Ambiguity | Tierward resolution |
 |---|---|---|
-| `allowed-tools` separator | Both space-separated and YAML list documented as valid | CDK standard: space-separated string |
-| `hooks` object schema | Documented but no schema reference at canonical URLs | Not used in any CDK skill; no validation enforced until first use |
-| `shell` default | Unclear whether `bash` is implicit when field is absent | CDK behavior: absent field means no shell restriction |
+| `allowed-tools` separator | Both space-separated and YAML list documented as valid | Tierward standard: space-separated string |
+| `hooks` object schema | Documented but no schema reference at canonical URLs | Not used in any Tierward skill; no validation enforced until first use |
+| `shell` default | Unclear whether `bash` is implicit when field is absent | Tierward behavior: absent field means no shell restriction |
 | Combined compaction budget | 25,000 tokens combined, but behavior when exceeded is unspecified | Treat as hard fail; run tokenizer check in P1 C5 |
 
 ---

--- a/packages/cli/templates/tier-m/.claude/FIRST_SESSION.md
+++ b/packages/cli/templates/tier-m/.claude/FIRST_SESSION.md
@@ -112,7 +112,7 @@ You can always override the selection. The Tier 2 sweep adds EARS-style analysis
 | `/security-audit` | Reviews API routes and auth guards |
 | `/skill-dev` | Code quality and tech debt audit |
 | `/compact` | Frees context window (run at Phase 8.5) |
-| `npx mg-claude-dev-kit doctor` | Checks your scaffold setup |
+| `npx tierward doctor` | Checks your scaffold setup |
 
 ---
 

--- a/packages/cli/templates/tier-m/.claude/cheatsheet.md
+++ b/packages/cli/templates/tier-m/.claude/cheatsheet.md
@@ -49,7 +49,7 @@ Run these on demand. Each skill reads the codebase, produces a structured report
 | `/ux-audit` | Task completion paths, feedback clarity, cognitive load, error recovery | After adding user flows; before usability reviews |
 | `/ui-audit` | Design system token compliance, component adoption, empty/error/loading states | After UI changes; when design system is configured |
 | `/test-audit` | Coverage (lcov/Istanbul/Cobertura/go/tarpaulin/xcresult), pyramid shape, anti-patterns (`.only`, skipped, empty, no-assertion, sleeps) | After Phase 3 tests green; every block |
-| `/doc-audit` | Relative-link resolution, code-block syntax (json/yaml/toml), CDK placeholder residuals, slash-command name match, skill-count consistency, ADR freshness, stack-specific doc sync (Next.js / Django / Swift) | After doc changes; every block that touches README or `docs/` |
+| `/doc-audit` | Relative-link resolution, code-block syntax (json/yaml/toml), Tierward placeholder residuals, slash-command name match, skill-count consistency, ADR freshness, stack-specific doc sync (Next.js / Django / Swift) | After doc changes; every block that touches README or `docs/` |
 | `/api-contract-audit` | OpenAPI contract drift (endpoints, schemas, status codes), breaking-change detection vs previous spec, versioning consistency, security scheme alignment, Richardson Maturity L0-L3 scoring | After API changes; before releasing contract updates to external consumers |
 | `/infra-audit` | GitHub Actions (pwn-request, secret logging, pinning, permissions), Dockerfile (root user, latest tag, URL add), K8s (runAsNonRoot, privileged, hostNetwork), Terraform (IAM wildcards, state in git), GitLab CI | After pipeline or IaC changes; every block that touches `.github/workflows/`, `Dockerfile`, K8s manifests, or `*.tf` |
 | `/compliance-audit` | GDPR profile: data-subject rights (delete, export, rectify), consent capture, lawful basis, PII identification, encryption-at-rest on special-category, logging hygiene, retention, sub-processors. SOC 2 and HIPAA scaffolded for v1.15+ | Before EU-facing product launch; quarterly review |
@@ -88,5 +88,5 @@ Run these on demand. Each skill reads the codebase, produces a structured report
 cat ~/.claude/audit/[PROJECT_NAME].jsonl | tail -20 | jq .
 
 # Validate Claude setup
-npx mg-claude-dev-kit doctor
+npx tierward doctor
 ```

--- a/packages/cli/templates/tier-m/.claude/rules/pipeline.md
+++ b/packages/cli/templates/tier-m/.claude/rules/pipeline.md
@@ -213,10 +213,10 @@ If the project is CLI-only, backend-only, or native-standalone without a UI laye
 
 **Track C - Test + doc + infra audit** *(runs for every block after Phase 3 is green - static analysis, no dev server needed)*
 - Run `/test-audit` - static analysis of coverage (auto-detects lcov / Istanbul / Cobertura / go / tarpaulin / xcresult), pyramid shape (unit/integration/e2e ratio), anti-patterns (`.only` leaks, skipped tests, empty bodies, no-assertion tests, hardcoded sleeps).
-- Run `/doc-audit` - static doc-drift check (relative-link resolution, code-block syntax, CDK placeholder residuals, slash-command name match, skill-count consistency, ADR freshness). Stack-aware for Next.js / Django / Swift.
+- Run `/doc-audit` - static doc-drift check (relative-link resolution, code-block syntax, Tierward placeholder residuals, slash-command name match, skill-count consistency, ADR freshness). Stack-aware for Next.js / Django / Swift.
 - Run `/infra-audit` - static infra-security check across GitHub Actions, Dockerfile, Kubernetes manifests, Terraform, GitLab CI. Each layer runs only if its markers are detected. Stack-agnostic.
 - Run `/dependency-audit` if the block touches `package.json`, `pyproject.toml`, `Package.swift`, `Cargo.toml`, `go.mod`, or any other dependency manifest - tier classification (A/B/C), changelog summary for Tier B/C, codebase impact grep, runtime LTS status. Audit-only in v1.
-- Output: one-paragraph summary per skill. Critical findings (`.only` committed, 0% coverage on a file changed in this block, CDK placeholder in README, pwn-request in workflow, secret logging in CI, privileged K8s container, IAM wildcard action, hardcoded secret in Terraform) block Phase 6.
+- Output: one-paragraph summary per skill. Critical findings (`.only` committed, 0% coverage on a file changed in this block, Tierward placeholder in README, pwn-request in workflow, secret logging in CI, privileged K8s container, IAM wildcard action, hardcoded secret in Terraform) block Phase 6.
 
 **Severity handling - all tracks**:
 - **Critical**: fix before Phase 6. Do not proceed with open Critical issues.

--- a/packages/cli/templates/tier-m/.claude/skills/doc-audit/PATTERNS.md
+++ b/packages/cli/templates/tier-m/.claude/skills/doc-audit/PATTERNS.md
@@ -1,13 +1,13 @@
 # Doc Audit - Patterns
 
-Reference file for `/doc-audit`. Contains the pinned CDK placeholder list (agnostic) and stack-specific grep patterns for D7 doc-sync checks.
+Reference file for `/doc-audit`. Contains the pinned Tierward placeholder list (agnostic) and stack-specific grep patterns for D7 doc-sync checks.
 The executing agent reads this file at the start of Step 3. For D3, use the placeholder list verbatim. For D7, select the section matching the detected stack; if the detected stack is not in the top 3 (`node-ts`, `python`, `swift`), skip D7 entirely.
 
 ---
 
-## D3 - CDK placeholder list (agnostic)
+## D3 - Tierward placeholder list (agnostic)
 
-The CDK scaffold emits these placeholder tokens. Readers are expected to replace each one with a concrete value. A token left in place after first-run configuration signals an incomplete adoption, not an intentional user convention.
+The Tierward scaffold emits these placeholder tokens. Readers are expected to replace each one with a concrete value. A token left in place after first-run configuration signals an incomplete adoption, not an intentional user convention.
 
 ```
 [TEST_COMMAND]
@@ -22,9 +22,9 @@ The CDK scaffold emits these placeholder tokens. Readers are expected to replace
 [MIGRATION_COMMAND]
 ```
 
-**Extension rule**: this list is grepped against the CDK template tree (`packages/cli/templates/**`) - only tokens that are actually emitted by the scaffold belong here. When a new CDK release adds a placeholder to any scaffold template, append it to this list and bump the skill's internal version note in the next release. Generic `[UPPERCASE]` regex is deliberately avoided - it produces false positives on legitimate user conventions (`[API_KEY]`, `[YOUR_DOMAIN]`, `[FEATURE_FLAG]`).
+**Extension rule**: this list is grepped against the Tierward template tree (`packages/cli/templates/**`) - only tokens that are actually emitted by the scaffold belong here. When a new Tierward release adds a placeholder to any scaffold template, append it to this list and bump the skill's internal version note in the next release. Generic `[UPPERCASE]` regex is deliberately avoided - it produces false positives on legitimate user conventions (`[API_KEY]`, `[YOUR_DOMAIN]`, `[FEATURE_FLAG]`).
 
-**Exclusion**: skip files under `packages/cli/templates/**` (the CDK template source itself - placeholders are intentional there). Apply this exclusion only when auditing the CDK repo itself; in user projects, the exclusion is a no-op.
+**Exclusion**: skip files under `packages/cli/templates/**` (the Tierward template source itself - placeholders are intentional there). Apply this exclusion only when auditing the Tierward repo itself; in user projects, the exclusion is a no-op.
 
 ---
 

--- a/packages/cli/templates/tier-m/.claude/skills/doc-audit/SKILL.md
+++ b/packages/cli/templates/tier-m/.claude/skills/doc-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: doc-audit
-description: Static documentation drift audit - relative-link resolution, code-block syntax, CDK placeholder residuals, slash-command name match, skill-count consistency, ADR marker freshness, stack-specific doc sync (Next.js / Django / Swift).
+description: Static documentation drift audit - relative-link resolution, code-block syntax, Tierward placeholder residuals, slash-command name match, skill-count consistency, ADR marker freshness, stack-specific doc sync (Next.js / Django / Swift).
 user-invocable: true
 model: sonnet
 context: fork
@@ -108,11 +108,11 @@ Skip `bash`, `sh`, `shell`, `text`, `console`, `diff`, and any unlabelled fence.
 
 Report: each failing block with `FILE:LINE - lang=<tag> - <parser error excerpt>`.
 
-### D3 - CDK placeholder residuals
+### D3 - Tierward placeholder residuals
 
 **High per occurrence in user-facing docs; Critical if found in `README.md`.** Placeholders shipped unfilled indicate an incomplete scaffold adoption.
 
-The CDK scaffold emits a **fixed set** of `[UPPERCASE]` tokens that the user is expected to resolve. Generic `[UPPERCASE]` regex would produce false positives on legitimate user conventions (`[API_KEY]`, `[YOUR_DOMAIN]`, `[FEATURE_FLAG_NAME]`). Use the pinned list from `PATTERNS.md` (agnostic section, `D3 CDK placeholder list`):
+The Tierward scaffold emits a **fixed set** of `[UPPERCASE]` tokens that the user is expected to resolve. Generic `[UPPERCASE]` regex would produce false positives on legitimate user conventions (`[API_KEY]`, `[YOUR_DOMAIN]`, `[FEATURE_FLAG_NAME]`). Use the pinned list from `PATTERNS.md` (agnostic section, `D3 Tierward placeholder list`):
 
 ```
 [TEST_COMMAND] [FRAMEWORK_VALUE] [LANGUAGE_VALUE] [INSTALL_COMMAND]
@@ -120,7 +120,7 @@ The CDK scaffold emits a **fixed set** of `[UPPERCASE]` tokens that the user is 
 [ENUM_CASE_CONVENTION] [MIGRATION_COMMAND]
 ```
 
-Grep each doc for any exact token from the list. Exclude files under `packages/cli/templates/**` (the CDK template source itself - placeholders are intentional there).
+Grep each doc for any exact token from the list. Exclude files under `packages/cli/templates/**` (the Tierward template source itself - placeholders are intentional there).
 
 Report: each match with `FILE:LINE - <token> - replace with concrete value`.
 
@@ -128,7 +128,7 @@ Report: each match with `FILE:LINE - <token> - replace with concrete value`.
 
 **Medium per orphan reference.** Readers click / copy a skill name that does not exist in `.claude/skills/`.
 
-Grep every doc for `/[a-z][a-z0-9-]+` occurrences inside prose (filter: must be preceded by whitespace or start-of-line and followed by a word boundary; ignore URL paths by excluding matches inside a `(...)` link target). For each unique command name, verify `.claude/skills/<name>/` exists. Allowlist CDK CLI verbs that are not skills: `init`, `upgrade`, `doctor`, `add`, `new` (these live in `packages/cli/src/commands/`, not in `.claude/skills/`).
+Grep every doc for `/[a-z][a-z0-9-]+` occurrences inside prose (filter: must be preceded by whitespace or start-of-line and followed by a word boundary; ignore URL paths by excluding matches inside a `(...)` link target). For each unique command name, verify `.claude/skills/<name>/` exists. Allowlist Tierward CLI verbs that are not skills: `init`, `upgrade`, `doctor`, `add`, `new` (these live in `packages/cli/src/commands/`, not in `.claude/skills/`).
 
 Report: each orphan with `FILE:LINE - /<name> - no matching skill directory`.
 
@@ -142,7 +142,7 @@ Grep README and `[DOC_PATH]` for numeric skill claims: `\b(\d+)\s+(audit\s+)?ski
 ls .claude/skills/ | grep -v '^custom-' | wc -l
 ```
 
-If the claimed count does not match the actual directory count, flag the mismatch. Note: this check intentionally scopes to **skill count only** - doctor/test counts are source-specific to the CDK codebase and are not in scope for user-project audits.
+If the claimed count does not match the actual directory count, flag the mismatch. Note: this check intentionally scopes to **skill count only** - doctor/test counts are source-specific to the Tierward codebase and are not in scope for user-project audits.
 
 Report: `FILE:LINE - claim "<N> skills" - actual <M> in .claude/skills/`.
 
@@ -189,7 +189,7 @@ If nothing Critical/High: state that explicitly ("No Critical or High findings -
 |---|---|---|
 | Link hygiene | strong / adequate / weak | [D1 broken link count] |
 | Code-block validity | strong / adequate / weak | [D2 unparseable blocks] |
-| Placeholder discipline | strong / adequate / weak | [D3 CDK tokens remaining] |
+| Placeholder discipline | strong / adequate / weak | [D3 Tierward tokens remaining] |
 | Skill coherence | strong / adequate / weak | [D4 orphans + D5 count mismatch] |
 | ADR freshness | strong / adequate / weak | [D6 stale count; N/A if ADR_PATH unset] |
 | Stack sync | strong / adequate / weak | [D7 orphans; N/A for non-top-3 stacks] |
@@ -200,7 +200,7 @@ If nothing Critical/High: state that explicitly ("No Critical or High findings -
 |---|---|---|---|
 | D1 | Relative-link resolution | ✅/⚠️ | [N broken] |
 | D2 | Code-block syntax | ✅/⚠️ | [N unparseable] |
-| D3 | CDK placeholder residuals | ✅/⚠️ | [N occurrences] |
+| D3 | Tierward placeholder residuals | ✅/⚠️ | [N occurrences] |
 | D4 | Slash-command name match | ✅/⚠️ | [N orphans] |
 | D5 | Skill-count consistency | ✅/⚠️ | [mismatch or OK] |
 | D6 | ADR marker freshness | ✅/⚠️ / N/A | [N stale; N/A if no ADR_PATH] |
@@ -242,8 +242,8 @@ Then write ONLY the approved entries to `docs/refactoring-backlog.md`:
 
 ### Severity guide
 
-- **Critical**: broken link to a user-visible flow doc (CONTRIBUTING, SECURITY, linked guide) (D1); CDK placeholder in `README.md` (D3)
-- **High**: unparseable `json` / `yaml` / `toml` code block (D2); CDK placeholder in any other user-facing doc (D3); skill-count mismatch > 2 (D5)
+- **Critical**: broken link to a user-visible flow doc (CONTRIBUTING, SECURITY, linked guide) (D1); Tierward placeholder in `README.md` (D3)
+- **High**: unparseable `json` / `yaml` / `toml` code block (D2); Tierward placeholder in any other user-facing doc (D3); skill-count mismatch > 2 (D5)
 - **Medium**: orphan `/skill-name` reference (D4); skill-count mismatch ≤ 2 (D5); stack-specific orphan surface (D7); broken link to non-critical asset (D1)
 - **Low**: stale ADR without terminal status (D6)
 

--- a/packages/cli/templates/tier-m/.claude/skills/skill-review/CALIBRATION_KIT.md
+++ b/packages/cli/templates/tier-m/.claude/skills/skill-review/CALIBRATION_KIT.md
@@ -18,7 +18,7 @@
 
 ## 1. Severity anchor catalog
 
-12 canonical examples, 3 per level. Two are abstract references from P2; one per level is a CDK-specific anchor tied to a known pilot-project or spec artifact.
+12 canonical examples, 3 per level. Two are abstract references from P2; one per level is a Tierward-specific anchor tied to a known pilot-project or spec artifact.
 
 ### Critical anchors (3)
 
@@ -56,7 +56,7 @@
 
 ## 2. Known traps (avoid these)
 
-Trap = a pattern that has historically caused mislabeling in CDK. Read once; do not re-evaluate at runtime - anchor on the rule.
+Trap = a pattern that has historically caused mislabeling in Tierward. Read once; do not re-evaluate at runtime - anchor on the rule.
 
 **T-1. Staff-manager literal contamination**
 Any reference to `Color.red`, SwiftUI-specific types, Vapor routes, or the pilot project's domain model (staff, shifts, invitations) in a scaffold skill is **Critical**. These artifacts survived extraction and produce false positives on every other stack.

--- a/packages/cli/templates/tier-m/.claude/skills/skill-review/REVIEW_FRAMEWORK.md
+++ b/packages/cli/templates/tier-m/.claude/skills/skill-review/REVIEW_FRAMEWORK.md
@@ -5,7 +5,7 @@
 **Updated**: 2026-05-01 - P2 mechanical checks from 2026-04-29 cross-LLM meta-review: Phase 1 checks 7+8 (architectural/paradigm vocab scan + reference file coverage), Phase 2.A(e) test-runner idiom expansion.
 **Status**: Consolidated - ready for execution once pre-work artifacts P1-P5 are produced.
 
-**Purpose**: single source of truth for the quality review of all 18 CDK skills. Replaces any prior partial framework. Every check, decision point, and severity level lives here.
+**Purpose**: single source of truth for the quality review of all 18 Tierward skills. Replaces any prior partial framework. Every check, decision point, and severity level lives here.
 
 ---
 
@@ -14,7 +14,7 @@
 The review validates each SKILL.md in `packages/cli/templates/tier-*/.claude/skills/` against:
 
 1. **Anthropic spec compliance** - conforms to documented frontmatter and body structure.
-2. **CDK scope alignment** - stack-agnostic, registry-coherent, pipeline-integrated.
+2. **Tierward scope alignment** - stack-agnostic, registry-coherent, pipeline-integrated.
 3. **Internal quality** - checks are universal, severity calibrated, report template matches body.
 4. **Cross-skill coherence** - references accurate, boundaries don't overlap, boilerplate intentional.
 5. **Behavioral correctness** *(added v1.2)* - skills behave correctly when executed, not only when read. Validated via targeted behavioral fixtures on high-risk skills.
@@ -207,7 +207,7 @@ Grouped by gravity. 2.A/2.B/2.C autonomous; 2.D interactive; 2.E targeted on hig
 
 1. **Frontmatter↔body coherence**: argument-hint targets/modes match body handlers.
 2. **Project-agnosticity test - extended** *(D3 - 4 dimensions)*:
-   - **(a) Literal contamination**: no example, file path, entity name, API reference tied to a specific project. Every reference is a placeholder or universal concept. Universal = applies unchanged across ≥3 of 6 CDK-supported stacks.
+   - **(a) Literal contamination**: no example, file path, entity name, API reference tied to a specific project. Every reference is a placeholder or universal concept. Universal = applies unchanged across ≥3 of 6 Tierward-supported stacks.
    - **(b) Severity habits**: severity labels not inherited from pilot project's domain. E.g., "any hardcoded color = Critical" is a pilot-project habit; in non-UI projects, color is not Critical.
    - **(c) Remediation style**: fix suggestions not formatted/structured in pilot project's conventions. E.g., remediation always in "SwiftUI-like" declarative form.
    - **(d) Architectural assumptions**: no implicit assumption about routing, state management, persistence layer, auth pattern tied to pilot's architecture.
@@ -216,7 +216,7 @@ Grouped by gravity. 2.A/2.B/2.C autonomous; 2.D interactive; 2.E targeted on hig
    If a reader who doesn't know the origin project could ask "why this specific case?" on ANY of (a)-(e), it's an artifact.
 
 3. **Output template↔body coherence**: every report row matches body check name + severity.
-4. **Multi-stack + agnostic verification**: skill applies (or explicitly gates with `[web only]`/`[SSR only]`) across CDK-supported stacks.
+4. **Multi-stack + agnostic verification**: skill applies (or explicitly gates with `[web only]`/`[SSR only]`) across Tierward-supported stacks.
 
 #### 2.B - Coerenza strutturale (cross-skill + cross-tier)
 
@@ -243,7 +243,7 @@ Grouped by gravity. 2.A/2.B/2.C autonomous; 2.D interactive; 2.E targeted on hig
 
    Per opportunity: **apply now** / **register roadmap** / **ignore**.
 
-14. **Section-by-section walkthrough**: Claude explains purpose + CDK relevance; user flags issues.
+14. **Section-by-section walkthrough**: Claude explains purpose + Tierward relevance; user flags issues.
 
 15. **Cross-tier diff review (C6 STOP)**: if skill is multi-tier, user reviews cross-tier diff artifact (column-by-column comparison showing frontmatter, tool set, check list, severity labels, report template across variants). User approves propagation strategy.
 
@@ -479,7 +479,7 @@ Deferred to vNext (v1.3 or later):
 
 ## Changelog
 
-- **v1.3 (2026-05-01)**: P2 mechanical checks (CDK #131). Phase 1 check 7: architectural (layer/MVC/hexagonal/microservice/monolith/repository pattern/service boundary/bounded context) + paradigm (props/state management/virtual DOM/bundler/reactive/component tree/hydration) unguarded-match scan feeding Phase 2.A(d)+(e). Phase 1 check 8: reference file coverage check for stack-dependent skills (missing check ID = High). Phase 2.A(e): test-runner idiom detection extended to Rust (#[test]), Swift XCTest, JUnit (@Test).
+- **v1.3 (2026-05-01)**: P2 mechanical checks (Tierward #131). Phase 1 check 7: architectural (layer/MVC/hexagonal/microservice/monolith/repository pattern/service boundary/bounded context) + paradigm (props/state management/virtual DOM/bundler/reactive/component tree/hydration) unguarded-match scan feeding Phase 2.A(d)+(e). Phase 1 check 8: reference file coverage check for stack-dependent skills (missing check ID = High). Phase 2.A(e): test-runner idiom detection extended to Rust (#[test]), Swift XCTest, JUnit (@Test).
 - **v1.2 (2026-04-14)**: cross-model review integrated. Fixes C1-C7 convergent + T2.1 targeted (D1 behavioral fixtures on 6 skills) + T2.3 (D2 P5 calibration + Phase 9 midpoint drift check) + T2.4 (D3 4-dimensional project-agnosticity) + T2.5/T2.6 trivial. New pre-work P5. New Phase 2.E and Phase 9. Severity scale patched (C5). Retroactive re-application freezed (C3). 2 new STOP gates (C6 cross-tier + C7 Phase 3→4).
 - **v1.1 (2026-04-14)**: O1-O5 omissions fixed; P1/P2 potential codified; Phase 2 regrouped (2.A/B/C/D); severity mapping clarified.
 - **v1.0 (2026-04-14)**: initial consolidation.

--- a/packages/cli/templates/tier-m/.claude/skills/skill-review/SKILLS_INVENTORY.md
+++ b/packages/cli/templates/tier-m/.claude/skills/skill-review/SKILLS_INVENTORY.md
@@ -1,6 +1,6 @@
 # Skills Inventory (P3)
 
-> **EXPORT NOTE**: this file is bundled as an example. Replace the inventory below with your project's skills before running `/skill-review`. The structure (summary stats + main table + coverage check) is the template - the content is a placeholder from CDK's own review cycle.
+> **EXPORT NOTE**: this file is bundled as an example. Replace the inventory below with your project's skills before running `/skill-review`. The structure (summary stats + main table + coverage check) is the template - the content is a placeholder from Tierward's own review cycle.
 >
 > **How to adapt**:
 > 1. Run `find .claude/skills -name SKILL.md` to list your skills.

--- a/packages/cli/templates/tier-m/.claude/skills/skill-review/SPEC_SNAPSHOT.md
+++ b/packages/cli/templates/tier-m/.claude/skills/skill-review/SPEC_SNAPSHOT.md
@@ -28,7 +28,7 @@ Every field below is **documented by Anthropic**. Fields outside this list are f
 
 | Field | Type | Purpose / valid values |
 |---|---|---|
-| `allowed-tools` | string OR list | Subset of tools the skill can invoke. Space-separated string or YAML list. CDK convention: space-separated string. |
+| `allowed-tools` | string OR list | Subset of tools the skill can invoke. Space-separated string or YAML list. Tierward convention: space-separated string. |
 | `model` | string | Model identifier: `sonnet`, `haiku`, `opus`. |
 | `context` | string | Only documented value: `fork`. |
 | `agent` | string | Subagent type: `Explore`, `Plan`, `general-purpose`. |
@@ -36,7 +36,7 @@ Every field below is **documented by Anthropic**. Fields outside this list are f
 | `paths` | list | YAML list of glob patterns restricting where the skill activates. |
 | `user-invocable` | boolean | Whether user can invoke via `/skill-name`. |
 | `disable-model-invocation` | boolean | Whether Claude may auto-invoke the skill. |
-| `hooks` | object | Lifecycle hook registration (no CDK skill currently uses this). |
+| `hooks` | object | Lifecycle hook registration (no Tierward skill currently uses this). |
 | `shell` | string | `bash` or `powershell`. |
 | `argument-hint` | string | Free text, hint for argument structure. |
 | `version` | string | Informal version string. |
@@ -49,7 +49,7 @@ Every field below is **documented by Anthropic**. Fields outside this list are f
 
 Any frontmatter key outside the required + optional set above is a spec violation.
 
-**Known non-documented fields present in CDK at snapshot date**:
+**Known non-documented fields present in Tierward at snapshot date**:
 - `effort` - on 6 files: `arch-audit` (S, M, L) and `security-audit` (S, M, L). To be removed during the review cycle.
 
 ---
@@ -114,17 +114,17 @@ If Anthropic publishes spec changes between this snapshot date and the end of th
 2. **Decision gate**: evaluate impact. Two outcomes:
    - **Non-breaking** (new optional field, non-mandatory constraint relaxation): log in `MID_CYCLE_DELTA.md`, complete the cycle against this snapshot, integrate in next snapshot version.
    - **Breaking** (field renamed, new required field, mandatory constraint tightened): bump this snapshot to v1.1, re-run P1 checklist on every already-reviewed skill. Count this as a framework-level event triggering retroactive re-application per `review-framework.md`.
-3. **Either way**: document the decision with the publication date of the Anthropic change + the CDK review date + rationale for non-breaking-vs-breaking classification.
+3. **Either way**: document the decision with the publication date of the Anthropic change + the Tierward review date + rationale for non-breaking-vs-breaking classification.
 
 ---
 
 ## 9. Known ambiguities (flagged at snapshot date)
 
-| Topic | Ambiguity | CDK resolution |
+| Topic | Ambiguity | Tierward resolution |
 |---|---|---|
-| `allowed-tools` separator | Both space-separated and YAML list documented as valid | CDK standard: space-separated string |
-| `hooks` object schema | Documented but no schema reference at canonical URLs | Not used in any CDK skill; no validation enforced until first use |
-| `shell` default | Unclear whether `bash` is implicit when field is absent | CDK behavior: absent field means no shell restriction |
+| `allowed-tools` separator | Both space-separated and YAML list documented as valid | Tierward standard: space-separated string |
+| `hooks` object schema | Documented but no schema reference at canonical URLs | Not used in any Tierward skill; no validation enforced until first use |
+| `shell` default | Unclear whether `bash` is implicit when field is absent | Tierward behavior: absent field means no shell restriction |
 | Combined compaction budget | 25,000 tokens combined, but behavior when exceeded is unspecified | Treat as hard fail; run tokenizer check in P1 C5 |
 
 ---

--- a/packages/cli/test/cross-llm-rubric/prompt-template.md
+++ b/packages/cli/test/cross-llm-rubric/prompt-template.md
@@ -6,7 +6,7 @@ Use this prompt with 3 different LLMs (Claude Opus, Claude Sonnet, Gemini Pro). 
 
 ## SYSTEM
 
-You are reviewing a generated `CONTEXT.md` file produced by the claude-dev-kit Context Builder.
+You are reviewing a generated `CONTEXT.md` file produced by the tierward Context Builder.
 Score each criterion **0-3**:
 
 - **0** — Wrong, contradicted by the repo, or empty/boilerplate

--- a/packages/cli/test/integration/run.js
+++ b/packages/cli/test/integration/run.js
@@ -3880,7 +3880,7 @@ async function scenarioMCPServer() {
     }
 
     const meta = parseToolReply(await client.callTool({ name: 'cdk_package_meta', arguments: {} }));
-    if (meta.name === 'mg-claude-dev-kit' && meta.cwd === dir) {
+    if (meta.name === 'tierward' && meta.cwd === dir) {
       pass('cdk_package_meta: name + cwd correct');
     } else {
       fail(`cdk_package_meta: ${JSON.stringify(meta)}`);

--- a/packages/cli/test/integration/run.js
+++ b/packages/cli/test/integration/run.js
@@ -1,5 +1,5 @@
 /**
- * claude-dev-kit - Integration test suite
+ * tierward - Integration test suite
  *
  * Tests the scaffold layer directly (bypasses Inquirer).
  * Validates file structure, placeholder resolution, and Stop hook presence
@@ -213,7 +213,7 @@ function assertNoUnfilledWizardPlaceholders(dir) {
     // for Claude to fill in pipeline.md - not actual unfilled wizard placeholders
     if (path.basename(f) === 'CONTEXT_IMPORT.md') continue;
 
-    // doc-audit's SKILL.md and PATTERNS.md enumerate the CDK placeholder tokens
+    // doc-audit's SKILL.md and PATTERNS.md enumerate the Tierward placeholder tokens
     // verbatim as part of the audit specification (D3 check). Not unfilled.
     const rel = path.relative(dir, f);
     if (rel.includes(path.join('skills', 'doc-audit'))) continue;
@@ -3819,7 +3819,7 @@ async function scenarioTeamSettings() {
 }
 
 async function scenarioMCPServer() {
-  section('CDK governance MCP server (v1.17.0): tool surface + read-only outputs');
+  section('Tierward governance MCP server (v1.17.0): tool surface + read-only outputs');
 
   const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
   const { StdioClientTransport } = await import('@modelcontextprotocol/sdk/client/stdio.js');
@@ -3983,7 +3983,7 @@ async function scenarioMCPServer() {
 
 async function main() {
   console.log();
-  console.log(c.bold('claude-dev-kit - Integration tests'));
+  console.log(c.bold('tierward - Integration tests'));
   console.log(c.dim(`Output: ${OUTPUT_DIR}`));
   console.log(c.dim(`Verbose: ${VERBOSE ? 'on' : 'off (use --verbose for full output)'}`));
 

--- a/packages/cli/test/unit/add.test.js
+++ b/packages/cli/test/unit/add.test.js
@@ -198,13 +198,13 @@ describe('upgrade - custom skill preservation', () => {
 
   before(async () => {
     await fs.remove(UPGRADE_TMP);
-    // Simulate a CDK project with a custom skill
+    // Simulate a Tierward project with a custom skill
     await fs.ensureDir(path.join(UPGRADE_TMP, '.claude', 'skills', 'custom-deploy'));
     fs.writeFileSync(
       path.join(UPGRADE_TMP, '.claude', 'skills', 'custom-deploy', 'SKILL.md'),
       '---\nname: custom-deploy\n---\nMy custom skill',
     );
-    // Also add a CDK-managed rule so upgrade has something to check
+    // Also add a Tierward-managed rule so upgrade has something to check
     await fs.ensureDir(path.join(UPGRADE_TMP, '.claude', 'rules'));
     fs.writeFileSync(path.join(UPGRADE_TMP, '.claude', 'rules', 'git.md'), 'old content');
   });


### PR DESCRIPTION
## Rebrand R1 — reversible rename `claude-dev-kit` → `tierward` (M1)

The in-repo, reversible half of the rebrand (plan: `.claude/initiatives/2026-06-16-rebrand-tierward-plan.md`). **No registry/platform cutover here** — npm publish, GitHub repo rename, and marketplace listing are the separate irreversible step, done with you after this merges.

### What changed (2 commits)
- **`fa1835d` — package identity + bin aliases.** npm name `mg-claude-dev-kit` → `tierward`; `bin` now ships **all four**: `tierward`/`tierward-mcp` (new) **and** `claude-dev-kit`/`claude-dev-kit-mcp` (kept as continuity aliases). CLI program name → `tierward`. MCP server name now read from `package.json` (no hardcoded string). `repository`/`homepage`/`bugs` → `…/tierward`.
- **`97adcdd` — reference sweep (58 files).** Ordered, scoped substitution: `mg-claude-dev-kit`→`tierward`, `claude-dev-kit`→`tierward` (commands/URLs/MCP-bin examples), `CDK`→`Tierward` (prose). Covers docs, templates (scaffold payload), src user-facing strings, README badges, drift-tracker notes, issue templates.

### Continuity preserved (intentional keeps — verified, not misses)
- **Bin aliases** `claude-dev-kit` / `claude-dev-kit-mcp` stay (existing CLI muscle-memory + wired `.mcp.json` configs keep working).
- **MCP tool names** `cdk_doctor_report`, `cdk_package_meta`, … and the `"cdk"` `.mcp.json` key — **unchanged** (API contract; the sweep only touched uppercase `\bCDK\b`).
- **Env vars** `CDK_PROJECT_ROOT`, `CDK_CONTEXT_LLM_MODEL` — unchanged (contract; `\bCDK\b` doesn't match across `_`).
- **CHANGELOG history** — untouched (go-forward only; a rename note was added to `[Unreleased]`, intro line updated).
- **Scaffold placeholder tokens** (`[TEST_COMMAND]` etc.) — unaffected (none contained "CDK").

### Deferred to cutover (NOT in this PR)
- `.github/workflows/claude-dev-kit-verify.yml` left as-is — renaming the workflow/check name risks breaking branch-protection required-checks; handle when the repo is renamed and protection is reviewed.
- npm publish of `tierward`, `npm deprecate mg-claude-dev-kit`, GitHub repo rename (+redirect), marketplace publish, social-preview image, repo About/topics.
- README hero capitalization / full rewrite → superpowers **M3** (through `/humanize`).
- Optional `TIERWARD_PROJECT_ROOT` env alias.

### Verification
- **Local: 1148 integration + 585 unit tests green**, prettier clean, `features.json`/issue-template YAML valid, drift-tracker tests green. MCP tool names + env vars confirmed intact post-sweep.
- ⚠️ **CI gap (staging-migration, parallel-thread domain):** `ci.yml` triggers on `main` only and `vscode-extension.yml` is path-filtered to the extension — so **no CI check runs the CLI suite on a `staging` PR**. The local run above is the evidence. Worth wiring a CLI workflow on `staging` separately.

### ⚠️ Sequencing for promotion
Do **not** promote `staging`→`main`/release with this merged until the cutover runs in order: publish npm `tierward` → rename repo → marketplace → `npm deprecate`. Until the repo is renamed, the `…/tierward` URLs/badges 404 (expected).

Built in isolated worktree `worktree-rebrand-m1` (R3). Draft pending your review — the rebrand is your call to land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
