### PR TITLE
feat(scaffold): M2 — Tierward plugin for Claude Code marketplace

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "tierward",
+  "displayName": "Tierward",
+  "version": "1.31.1",
+  "description": "Governance skills for AI-assisted development: commit enforcement, architecture compliance, security audits, code quality, and humanized prose.",
+  "author": {
+    "name": "Marco Guillermaz",
+    "url": "https://github.com/marcoguillermaz"
+  },
+  "homepage": "https://github.com/marcoguillermaz/tierward",
+  "repository": "https://github.com/marcoguillermaz/tierward",
+  "license": "MIT",
+  "keywords": [
+    "claude",
+    "claude-code",
+    "governance",
+    "commits",
+    "audit",
+    "tierward"
+  ],
+  "defaultEnabled": true,
+  "skills": "./plugin/skills/",
+  "hooks": "./plugin/hooks/hooks.json"
+}

--- a/marketplace.json
+++ b/marketplace.json
@@ -31,7 +31,7 @@
         "source": "url",
         "url": "https://github.com/marcoguillermaz/tierward.git",
         "ref": "main",
-        "sha": "12e4ef704c0ac600cf1158ac8350f517cb579925"
+        "sha": "483c87108a2349be1c4895270162b26c1bc4c918"
       }
     }
   ]

--- a/marketplace.json
+++ b/marketplace.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "tierward",
+  "description": "Tierward governance skills for Claude Code — commit enforcement, audits, code quality.",
+  "owner": {
+    "name": "Marco Guillermaz",
+    "url": "https://github.com/marcoguillermaz"
+  },
+  "plugins": [
+    {
+      "name": "tierward",
+      "displayName": "Tierward",
+      "description": "Governance skills for AI-assisted development: /tierward:commit (Conventional Commits), /tierward:arch-audit, /tierward:security-audit, /tierward:perf-audit, /tierward:simplify, /tierward:skill-dev, /tierward:skill-security, /tierward:humanize. Includes a soft session bootstrap reminder.",
+      "author": {
+        "name": "Marco Guillermaz",
+        "url": "https://github.com/marcoguillermaz"
+      },
+      "homepage": "https://github.com/marcoguillermaz/tierward",
+      "repository": "https://github.com/marcoguillermaz/tierward",
+      "license": "MIT",
+      "keywords": [
+        "claude",
+        "claude-code",
+        "governance",
+        "commits",
+        "audit",
+        "tierward"
+      ],
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/marcoguillermaz/tierward.git",
+        "ref": "main",
+        "sha": "12e4ef704c0ac600cf1158ac8350f517cb579925"
+      }
+    }
+  ]
+}

--- a/plugin/hooks/bootstrap-soft.mjs
+++ b/plugin/hooks/bootstrap-soft.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+// UserPromptSubmit hook — soft bootstrap reminder for the Tierward plugin.
+// Injects a compact reminder about available /tierward:* skills into the
+// system context on every prompt. Non-blocking; always exits 0.
+
+async function main() {
+  let stdin = '';
+  try {
+    process.stdin.setEncoding('utf8');
+    for await (const chunk of process.stdin) stdin += chunk;
+  } catch {
+    // ignore — stdin unavailable in some environments
+  }
+
+  const reminder = [
+    'Tierward skills available in this session:',
+    '  /tierward:commit         Conventional Commits enforcer — stage changes, then invoke',
+    '  /tierward:arch-audit     Claude Code architecture compliance audit',
+    '  /tierward:security-audit Auth, input validation, secrets, HTTP headers',
+    '  /tierward:perf-audit     Bundle size, caching, N+1 queries, image optimization',
+    '  /tierward:simplify       Complexity and duplication scan on changed files',
+    '  /tierward:skill-dev      Code quality audit — coupling, dead exports, antipatterns',
+    '  /tierward:skill-security SkillSpector vulnerability scan for Claude Code skills',
+    '  /tierward:humanize       Remove AI writing patterns from prose (EN + IT)',
+  ].join('\n');
+
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'UserPromptSubmit',
+        additionalSystemPrompt: reminder,
+      },
+    }),
+  );
+
+  process.exit(0);
+}
+
+main().catch(() => process.exit(0));

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -1,0 +1,12 @@
+{
+  "UserPromptSubmit": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "node ${CLAUDE_PLUGIN_ROOT}/plugin/hooks/bootstrap-soft.mjs"
+        }
+      ]
+    }
+  ]
+}

--- a/plugin/skills/arch-audit/SKILL.md
+++ b/plugin/skills/arch-audit/SKILL.md
@@ -1,0 +1,334 @@
+---
+name: arch-audit
+description: Audit Claude Code architecture files against Anthropic docs and release notes, and verify internal ecosystem consistency. Run weekly to maintain compliance, catch new features, and keep the context system clean.
+user-invocable: true
+model: sonnet
+context: fork
+---
+
+## Step 1 - Fetch latest Anthropic documentation
+
+> **Parallelism**: Steps 1 and 2 have no data dependency. Launch the Step 1 research agent first (async), then begin Step 2 file reads in the main context immediately - do not wait for the agent to complete before reading local files.
+
+Launch a single research agent **(model: haiku)** to fetch ALL of the following URLs and extract key changes:
+
+- https://code.claude.com/docs/en/memory
+- https://code.claude.com/docs/en/settings
+- https://code.claude.com/docs/en/hooks
+- https://code.claude.com/docs/en/mcp
+- https://code.claude.com/docs/en/sub-agents
+- https://code.claude.com/docs/en/slash-commands
+- https://code.claude.com/docs/en/release-notes/overview
+- https://github.com/anthropics/claude-code/releases (latest 5 releases)
+- https://docs.anthropic.com/en/docs/about-claude/models (latest model IDs and deprecation notices)
+- https://code.claude.com/docs/en/best-practices
+
+From each Claude Code source extract: new keys/features, deprecations, breaking changes, best practice updates.
+From the models page extract: current model IDs for Opus/Sonnet/Haiku, any deprecation dates announced.
+From the prompting guide sources extract: principles for system prompt design, instruction clarity, context management, and what Anthropic explicitly discourages in long instruction files.
+
+**URL resilience**: if any URL returns 404, try the canonical base `https://code.claude.com/docs/en/` to locate the current path. Note in the report if a URL changed. Do not skip a topic because one URL failed - find the current equivalent page.
+
+**Expected current model IDs** (as of last research - verify against the models page):
+
+- Opus: `claude-opus-4-7` (released April 16, 2026 - new tokenizer, `xhigh` effort level)
+- Sonnet: `claude-sonnet-4-6`
+- Haiku: `claude-haiku-4-5-20251001`
+- Legacy (still available): `claude-opus-4-6`
+- Deprecated: `claude-3-haiku-*` and `claude-3-5-haiku-*` (retired April 19, 2026)
+- Retiring soon: `claude-sonnet-4-20250514` and `claude-opus-4-20250514` (retirement June 15, 2026)
+
+Flag any changes to this list in the report.
+
+## Step 2 - Read current architecture files (run in parallel with Step 1)
+
+Read these files in parallel while the Step 1 agent runs:
+
+- `CLAUDE.md`
+- `.claude/rules/pipeline.md`
+- `.claude/rules/context-review.md`
+- `.claude/rules/claudemd-standards.md` ← normative baseline for P1–P5 compliance checks
+- `.claude/rules/pipeline-standards.md` ← normative baseline for Step 3e pipeline compliance checks
+- `.claude/settings.json`
+- `.claude/files-guide.md`
+- `.claude/cheatsheet.md`
+- `.claude/skills/dependency-scan/SKILL.md`
+
+## Step 3 - Anthropic compliance gap analysis
+
+Compare Step 1 findings against Step 2 state. For each gap found, classify it:
+
+**AUTO-FIX** - apply directly without asking:
+
+- Deprecated keys in settings.json with a direct replacement
+- New settings keys that are clearly beneficial and low-risk (token efficiency, attribution)
+- Stale file paths or descriptions in files-guide.md
+- New hook events or agent frontmatter fields that improve existing patterns
+- Deprecated model IDs in SKILL.md files or settings.json
+
+**RECOMMEND** - list for user review, do not apply:
+
+- Structural changes (splitting files, new directories)
+- New features requiring user decision (sandbox, auto mode, new MCP servers, effort level `xhigh`)
+- New settings keys that change execution model (`autoMode`, `sandbox.*`, `tui`, `viewMode`, `availableModels`)
+- Changes that could affect existing workflow behavior
+- Anything touching the pipeline phase gates
+
+Every RECOMMEND must include: (1) specific file path(s) to modify, (2) section or line reference, (3) proposed change in one sentence. A RECOMMEND without a file target is incomplete - do not emit it.
+
+**File target map for common divergence types** - use this when classifying findings:
+
+| Divergence area                                                           | Files to update                                                                                                       | Classification                                                                        |
+| ------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Hook event name changed or deprecated                                     | `.claude/settings.json` (hook key)                                                                                    | RECOMMEND                                                                             |
+| Hook JSON response schema changed (new/removed fields)                    | `.claude/settings.json` (hook prompt inline) + `.claude/rules/prompt-quality-rubric.md` (Block output format section) | RECOMMEND                                                                             |
+| Hook prompt logic updated (trigger conditions, exclusions, bypass format) | `.claude/settings.json` (hook prompt inline) + `.claude/rules/prompt-quality-rubric.md` (matching section)            | RECOMMEND - both files always updated together; hook is authoritative, rubric follows |
+| Deprecated model ID in hook                                               | `.claude/settings.json` (`model:` field in hook entry)                                                                | AUTO-FIX                                                                              |
+| New hook event worth adding                                               | `.claude/settings.json` (new hook entry)                                                                              | RECOMMEND                                                                             |
+| Pipeline phase gate wording                                               | `.claude/rules/pipeline.md`                                                                                           | RECOMMEND                                                                             |
+| CLAUDE.md instruction addition                                            | `CLAUDE.md`                                                                                                           | RECOMMEND                                                                             |
+| Skill model ID deprecated                                                 | `.claude/skills/<name>/SKILL.md` (`model:` frontmatter)                                                               | AUTO-FIX                                                                              |
+| Skill missing `context: fork`                                             | `.claude/skills/<name>/SKILL.md` (frontmatter)                                                                        | AUTO-FIX                                                                              |
+| Skill missing `allowed-tools`                                             | `.claude/skills/<name>/SKILL.md` (frontmatter)                                                                        | AUTO-FIX                                                                              |
+| claudemd-standards.md outdated                                            | `.claude/rules/claudemd-standards.md` (relevant section + `Last verified` date)                                       | RECOMMEND                                                                             |
+| pipeline-standards.md outdated                                            | `.claude/rules/pipeline-standards.md` (relevant section + `Last verified` date)                                       | RECOMMEND                                                                             |
+
+## Step 3b - Internal ecosystem consistency checks
+
+**Execution strategy - two tiers**:
+
+- **Grep-tier** (pure pattern matching, no judgment): C2, C4, C6, C9, C10, C11, C12, C13, C14, C15, C16, C17 - batch into a **single haiku subagent** that runs all commands and returns structured pass/fail results.
+- **Judgment-tier** (require file reading + interpretation): C1, C3, C5, C7, C8 - run in main context using files already read in Step 2.
+
+**Grep-tier batch** - invoke one Agent with `model: "haiku"`, pass the table from [`BATCH_COMMANDS.md § Grep-tier batch`](BATCH_COMMANDS.md), and receive one structured result.
+
+Collect batch results, then run judgment-tier checks below. For each FAIL: classify as AUTO-FIX or RECOMMEND using the same criteria as Step 3.
+
+**C1 - Deploy information currency (CLAUDE.md)**
+Check: does the `## Tech Stack → Deploy` entry describe the actual deploy platform?
+
+**C2 - Deleted file references (all skills, cheatsheet, docs)**
+Expected: 0 matches. Any match = FAIL.
+AUTO-FIX: replace stale references → `refactoring-backlog.md` for backlog entries; remove references to deleted files.
+
+**C3 - files-guide.md: CLAUDE.local.md description is not live state**
+Check: does the CLAUDE.local.md section in files-guide.md contain specific current content descriptions (e.g. "Phase 4/5 suspended") rather than a generic description of the file's purpose?
+Expected: generic description only. Specific current content = FAIL (live state in static doc).
+
+**C4 - settings.json ↔ pipeline.md worktree symlink alignment**
+Expected: 0 matches. Any `ln -s` = FAIL (redundant, potentially conflicting with auto-symlink).
+
+**C5 - CLAUDE.md Worktree Known Pattern: reflects standard (not optional) usage**
+Check: does the "Worktree setup" Known Pattern in CLAUDE.md describe worktrees as the **standard pattern for all functional blocks** (not just parallel development)?
+Expected: language like "standard pattern for all functional blocks". Language implying optional/parallel-only = FAIL.
+
+**C6 - Phase 5b dev server prerequisite**
+Check: does Phase 5b in pipeline.md contain an explicit prerequisite to verify `[DEV_COMMAND]` is running before fixture setup?
+Expected: at least one mention. Missing = FAIL.
+
+**C7 - Cross-file path references (dead pointers)**
+For each file path mentioned in CLAUDE.md and pipeline.md that is a docs/ or .claude/ path, verify the file exists.
+Also verify directories: `docs/contracts/` and `.claude/skills/`.
+Expected: all paths resolve. Any "No such file or directory" = FAIL.
+
+**C8 - Interaction Protocol present in CLAUDE.md**
+Check: does CLAUDE.md contain a `## Interaction Protocol - Plan-then-Confirm` section with execution keywords defined?
+Expected: at least 1 match. Missing = FAIL. Run command from [`BATCH_COMMANDS.md § Judgment-tier standalone (C8)`](BATCH_COMMANDS.md).
+
+**C9 - Pipeline STOP gate integrity**
+Check: pipeline.md must contain at least 5 `*** STOP` markers (Phase 1, Phase 1.5, Phase 1.6, Phase 6, Phase 8 worktree cleanup).
+Expected: ≥ 5. Fewer = FAIL (gate was accidentally removed).
+
+**C10 - Worktree isolation rule present in Cross-Cutting**
+Check: pipeline.md Cross-Cutting Rules must contain the "Worktree isolation (hard rule)" entry prohibiting staging merges before Phase 8.
+Expected: at least 1 match. Missing = FAIL.
+
+**C11 - Cheatsheet skill registry completeness**
+Check: every directory under `.claude/skills/` must have a corresponding entry in `.claude/cheatsheet.md`.
+Expected: all lines show "OK". Any "MISSING" = FAIL.
+AUTO-FIX: add a minimal row to the "Custom Skills" table in cheatsheet.md for any missing skill.
+
+**C12 - settings.json hook integrity and hook type coverage**
+Check: `.claude/settings.json` must contain all 3 essential hooks: `SessionStart` (audit overdue reminder), `PostCompact` (CLAUDE.local.md restore reminder), `InstructionsLoaded` (debug log).
+Expected: 3 lines (SessionStart, PostCompact, InstructionsLoaded). Any missing = FAIL.
+RECOMMEND if failing - do not auto-fix (hooks require verifying intent before restoring).
+
+Additionally (judgment check in main context): verify that the hook configurations use the appropriate hook type. Claude Code supports 4 hook types - `command`, `http`, `prompt`, and `agent`. For reference:
+
+- `command` - runs a shell command, captures stdout for injection
+- `http` - calls a URL endpoint with event data as JSON body
+- `prompt` - injects a text message into the conversation
+- `agent` - spawns an agent to handle the hook event
+  Flag any hook that uses `command` type but would benefit from `prompt` type (simpler config, no shell needed for static reminders), or vice versa.
+
+Also flag any of the following new events from recent Claude Code releases that the project might benefit from adding:
+
+- `WorktreeCreate` / `WorktreeRemove` - auto-setup / teardown logic when worktrees change
+- `SubagentStart` / `SubagentStop` - logging or context injection for subagent calls
+- `PreCompact` - save critical in-progress state before context compression
+- `TaskCreated` / `TaskCompleted` - lifecycle hooks for task delegation (distinct events)
+- `FileChanged` - lint/format trigger on file write
+- `PermissionRequest` / `PermissionDenied` - permission flow interception (distinct events: request decides upfront, denied fires after rejection; return `retry: true` for alternative approach)
+- `PostToolUseFailure` - recovery logic when a tool call fails after execution
+- `Elicitation` / `ElicitationResult` - MCP server user-input request interception
+- `ConfigChange` - config source change detection
+- `CwdChanged` - working directory change handling
+- `SessionEnd` - session teardown / final logging
+- `UserPromptExpansion` - intercept prompt after macro/template expansion
+- `TeammateIdle` - multi-agent coordination (notify when a teammate agent is idle)
+- Hook type `type: "mcp_tool"` (v2.1.118+) - hooks can invoke MCP tools directly
+  These are RECOMMEND, not AUTO-FIX.
+
+Additionally, verify awareness of these recent Claude Code capabilities:
+
+- `defer` value for `permissionDecision` in PreToolUse hooks (pause and resume via `--resume`)
+- Hook output over 50K saved to disk with path + preview instead of context injection
+- `if` field for conditional hook execution using permission rule syntax
+- `once` field for single-fire hooks in skill/agent frontmatter
+- `asyncRewake` field for background hooks that wake Claude on exit code 2
+
+**C13 - context: fork on all skills**
+Check: every skill SKILL.md must declare `context: fork` so audits run in an isolated context and do not pollute the main session window.
+Expected: 0 files returned. Any returned file path = FAIL.
+AUTO-FIX: insert `context: fork` after the `model: sonnet` line in any failing skill.
+
+**C14 - CLAUDE.md is gitignored**
+Check: `CLAUDE.md` must be listed in `.gitignore` (project convention: personal CLAUDE.md is never committed - exposes internal context, causes commit history pollution).
+Expected: "PASS" (exit 0 - file is ignored). "FAIL" = FAIL.
+RECOMMEND if failing - do not auto-fix (requires user to add `CLAUDE.md` to `.gitignore` explicitly).
+
+**C15 - CLAUDE.md line budget**
+Check: CLAUDE.md must stay within 200 lines. Beyond this threshold, Anthropic's own research shows instruction adherence degrades - lower-priority rules get silently ignored (hard auto-truncation at 200 lines per Claude Code docs).
+Expected: ≤ 200. Any count above 200 = WARN.
+RECOMMEND if failing: invoke P1 and P5 to identify sections to remove or convert to `@import` references. Do not auto-fix - pruning requires judgment.
+
+**C16 - Deprecated model IDs**
+Check: no SKILL.md file or `.claude/settings.json` should reference model IDs from Claude 3 family (retired) or Claude 4.0 family (retiring June 15, 2026). Retired as of April 19, 2026: `claude-3-haiku-*`, `claude-3-5-haiku-*`. Also check for any `claude-3-opus-*`, `claude-3-sonnet-*`, `claude-sonnet-4-20250514`, or `claude-opus-4-20250514` references.
+Expected: 0 matches. Any match = FAIL.
+AUTO-FIX: replace deprecated model IDs with the current equivalents:
+
+- `claude-3-haiku-*` or `claude-3-5-haiku-*` → `claude-haiku-4-5-20251001`
+- `claude-3-opus-*` → `claude-opus-4-7`
+- `claude-3-sonnet-*` or `claude-3-5-sonnet-*` → `claude-sonnet-4-6`
+- `claude-sonnet-4-20250514` or `claude-opus-4-20250514` → respective 4.6/4.7 equivalents (retiring June 15, 2026)
+
+**C17 - `allowed-tools` frontmatter on MCP-dependent skills**
+Check: any SKILL.md that calls `mcp__*` tools in its instructions must declare those tools in `allowed-tools:` frontmatter. This ensures Claude requests the correct permissions upfront before the skill runs, preventing mid-execution permission prompts.
+Expected: 0 MISSING lines. Any match = FAIL.
+AUTO-FIX: for each failing skill, read the `mcp__*` tool names from its body and add `allowed-tools: [mcp__tool1, mcp__tool2, ...]` to its frontmatter after the `context:` line.
+
+## Step 3c/3d - Prompting Guide + token/subagent optimization
+
+See [advanced-checks.md](advanced-checks.md) for the full content of these steps. Execute them before Step 3e.
+
+- **Step 3c** - Anthropic Prompting Guide compliance against `CLAUDE.md`, `pipeline.md`, `context-review.md` + normative baseline `.claude/rules/claudemd-standards.md`. Covers P1 (content type inclusion test), P2 (instruction clarity), P3 (redundancy across instruction files), P4 (pipeline complexity proportionality), P5 (long context scannability). All judgment-based, PASS/WARN only, RECOMMEND never AUTO-FIX.
+- **Step 3d** - Token & subagent optimization. Covers T1 (research agent haiku in Step 1), T2 (Explore subagent haiku across skills), T3 (Playwright concurrency note in Phase 5d), T5 (skill model fitness table). Mix of mechanical grep and judgment.
+
+## Step 3e - Pipeline.md compliance check
+
+Using `pipeline.md` (read in Step 2) and **`.claude/rules/pipeline-standards.md`** as the normative baseline, evaluate each pipeline phase and the Fast Lane against industry standards. Classify each finding as PASS or WARN (never auto-fix pipeline content - changes require user confirmation).
+
+**Standards file currency check (run first)**: compare the `Last verified` date in `.claude/rules/pipeline-standards.md` against today's date. If > 30 days old AND Step 1 fetched material changes → flag as RECOMMEND to update the standards file.
+
+**PE1 - Phase gates integrity (S1)**
+Check: does every Phase have a verifiable STOP gate before promotion to the next phase? Phases 1, 1.5, 1.6, 6, and Phase 8 worktree cleanup must have explicit `*** STOP` markers requiring an execution keyword.
+Run: `grep -c "\*\*\* STOP" .claude/rules/pipeline.md`
+Pass: ≥5 stops, Phase 8 cleanup stop present.
+
+**PE2 - Testing pyramid compliance (S2)**
+Check: does pipeline.md define a phase ordering that enforces the pyramid (fast tests before slow)?
+Expected order: Phase 3 (vitest unit) → Phase 3b (API integration) → Phase 4 (Playwright e2e). Any inversion = WARN.
+Run: `grep -n "Phase 3\b\|Phase 3b\|Phase 4\b" .claude/rules/pipeline.md | head -10`
+
+**PE3 - Auth boundary coverage mandatory (S2)**
+Check: does Phase 3b explicitly require no-token → 401, unauthorized role → 403, valid role → 2xx for every new API route?
+Run: `grep -n "401\|403\|no.token\|unauthorized role" .claude/rules/pipeline.md`
+Expected: at least 3 matches in Phase 3b. Missing = WARN.
+
+**PE4 - Type check before commit (S3)**
+Run: `grep -n "TYPE_CHECK_COMMAND\|type.check\|tsc\|mypy\|pyright\|swiftc" .claude/rules/pipeline.md`
+Expected: ≥1 match confirming a type-check step exists in the build phase. Missing = WARN.
+
+**PE5 - Security checklist per API route (S3)**
+Check: does Phase 2 include a security checklist covering auth check, input validation, no sensitive data in responses, access control enforcement, and row-level security on new tables?
+Run: `grep -A8 "Security checklist" .claude/rules/pipeline.md | grep -c "RLS\|auth\|sensitive\|validat"`
+Expected: ≥3 matches. Missing = WARN.
+
+**PE6 - Staging-before-production (S4)**
+Check: does pipeline.md prohibit direct production deploy without staging first?
+Expected: ≥1 match enforcing the staging prerequisite. Missing = WARN.
+
+**PE7 - Migration isolation (S4)**
+Expected: ≥2 matches. Missing = WARN.
+
+**PE8 - Scope gate before implementation (S1, S5)**
+Check: does Phase 1 include both a Tier 1 / Tier 2 scope sweep AND an execution keyword gate before the dependency scan proceeds?
+Run: `grep -n "Tier 1\|Tier 2\|execution keyword" .claude/rules/pipeline.md | head -5`
+Expected: ≥2 matches in Phase 1. Missing = WARN.
+
+**PE9 - Minimal footprint / no unrequested features (S1, S3)**
+Check: does pipeline.md prohibit adding features beyond the approved plan scope?
+Run: `grep -n "unrequested\|scope creep\|approved plan\|outside.*plan" .claude/rules/pipeline.md | head -5`
+Expected: ≥1 match. Missing = WARN.
+
+**PE10 - Fast Lane escalation criteria (S6)**
+Check: does the Fast Lane define clear escalation conditions to the full pipeline?
+Run: `grep -A5 "Escalat" .claude/rules/pipeline.md | grep -c "file\|migration\|shared\|consumer"`
+Expected: ≥2 matches. Missing = WARN.
+
+**PE11 - Documentation requirements gate (S7)**
+Check: does Phase 8 require `docs/prd/prd.md` + GDoc update as a hard gate before block closure?
+Run: `grep -n "PRD.*hard gate\|PRD.*mandatory\|no exceptions.*PRD\|PRD.*no exception" .claude/rules/pipeline.md`
+Expected: ≥1 match. Missing = WARN.
+
+**PE12 - Commit discipline (S8)**
+Check: does pipeline.md specify the 3-commit block pattern (code → docs → context files)?
+Run: `grep -n "Commit 1\|Commit 2\|Commit 3\|three-commit\|3-commit" .claude/rules/pipeline.md | head -5`
+Expected: ≥2 matches. Missing = WARN.
+
+Output results in the Step 6 report under a new section:
+
+```
+### Pipeline compliance (PE1–PE12) - judgment-based, PASS/WARN only
+- PE1 Phase gates integrity: [PASS/WARN]
+- PE2 Testing pyramid order: [PASS/WARN]
+- PE3 Auth boundary coverage: [PASS/WARN]
+- PE4 TypeScript check gate: [PASS/WARN]
+- PE5 Security checklist: [PASS/WARN]
+- PE6 Staging before production: [PASS/WARN]
+- PE7 Migration isolation: [PASS/WARN]
+- PE8 Scope gate before impl: [PASS/WARN]
+- PE9 Minimal footprint: [PASS/WARN]
+- PE10 Fast Lane escalation: [PASS/WARN]
+- PE11 Documentation gate: [PASS/WARN]
+- PE12 Commit discipline: [PASS/WARN]
+```
+
+## Step H1 - Hook compliance check
+
+See [advanced-checks.md](advanced-checks.md) for the full content. Execute between Step 3e and Step 4.
+
+Summary of the sub-checks:
+
+- **H1a** - Event name currency against the official Anthropic event list (grep on `settings.json`).
+- **H1b** - JSON response field compliance for prompt-type hooks (`ok`, `reason`, `decision`, `updatedInput`).
+- **H1c** - Bypass mechanism visibility on blocking `UserPromptSubmit` hooks.
+- **H1d** - Hook type fitness (`command` vs `prompt` vs `agent`).
+- **H1e** - Rubric/hook drift between `prompt-quality-rubric.md` and inline hook logic.
+- **H1f** - New events to consider since last audit.
+
+Add results to the Step 6 report under `### Hook compliance (H1a–H1e)`.
+
+## Step 4 - Apply AUTO-FIX changes
+
+For each AUTO-FIX from Step 3, Step 3b, and Step H1: apply the change, note the file and line modified.
+
+## Step 5 - Update timestamp
+
+```bash
+date +%s > "$CLAUDE_PROJECT_DIR/.claude/session/last-arch-audit"
+```
+
+## Step 6 - Produce audit report
+
+Generate the report using the template in `${CLAUDE_SKILL_DIR}/REPORT.md`. Include all check results from Steps 3, 3b, 3c, 3d, 3e, and H1.

--- a/plugin/skills/commit/SKILL.md
+++ b/plugin/skills/commit/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: commit
+description: Classify staged changes, generate conventional commit message (type/scope/body), and execute git commit. Use after any implementation phase to commit work.
+user-invocable: true
+model: haiku
+context: fork
+---
+
+## Step 1 - Read staged changes
+
+If output is empty: respond "No staged files. Run `git add <files>` first." and stop.
+
+## Step 2 - Determine commit type
+
+Classify based on staged files:
+
+| Staged files | Type |
+|---|---|
+| Source code correcting broken behaviour | `fix` |
+| Test files only (`__tests__/`, `e2e/`, `tests/`, `test_*.py`, `*_test.go`, `*Tests.swift`, `*Test.kt`, `*Test.java`, `src/test/`) | `test` |
+| Docs only (`docs/`, `README.md`) | `docs` |
+| Context/config files (`.claude/`, `CLAUDE.md`, `MEMORY.md`, pipeline, skills, settings) | `chore` |
+| Restructuring without behaviour change | `refactor` |
+
+When code + tests are staged together, type follows the code change (`feat` or `fix`).
+
+**BREAKING CHANGE**: if a migration drops a column, renames a table, removes an API field, or changes a response shape - append `!` after type/scope AND add a `BREAKING CHANGE:` footer line explaining the impact.
+
+## Step 3 - Determine scope
+
+Derive from the primary functional area of the staged changes:
+
+- Infrastructure: `auth` · `proxy` · `db` · `api` · `email`
+- Horizontal: `ui` (UI-only, no domain logic) · `context` (pipeline.md, CLAUDE.md, skills, rules)
+- Omit scope if changes span >3 unrelated areas or are truly cross-cutting
+
+## Step 4 - Write description
+
+Rules:
+- Imperative mood: `add`, `fix`, `update`, `remove` - never past tense
+- Max 72 characters total including `type(scope): `
+- No period at end
+
+## Step 5 - Body (include when useful)
+
+Include a body when:
+- The reason for the change is non-obvious
+- A BREAKING CHANGE needs explanation
+- Phase 8 docs commit: list which doc files were updated and why
+
+Separate body from subject with a blank line.
+
+## Step 6 - Execute
+
+Output the proposed commit message, then run:
+
+```bash
+git commit -m "type(scope): subject" \
+           -m "Optional body paragraph."
+```
+
+Use multiple `-m` flags for subject + body. Never use `--amend` or `--no-verify`.
+
+---
+
+## Reference - Three-commit block pattern (S8)
+
+| Commit | Phase | Type | Scope | Content |
+|---|---|---|---|---|
+| 1 - code | Phase 3 | `feat` or `fix` | domain entity | source files + migrations + tests |
+| 2 - docs | Phase 8 | `docs` | block name | implementation-checklist, README, sitemap, db-map, contracts, PRD |
+| 3 - context | Phase 8 | `chore` | `context` | CLAUDE.md and/or MEMORY.md only if updated |

--- a/plugin/skills/humanize/SKILL.md
+++ b/plugin/skills/humanize/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: humanize
+description: >
+  Use ONLY when the user explicitly asks to humanize text, make writing sound more natural,
+  remove AI tells, or reduce robotic tone. Do NOT activate for code generation, technical
+  documentation, commit messages, SQL, JSON, API specs, or any task where the user has not
+  explicitly requested humanization. Languages in scope: Italian and English.
+user-invocable: true
+model: sonnet
+context: fork
+---
+
+# Humanize
+
+Rewrites text to remove AI-generated patterns and produce natural, human-quality prose.
+
+## Input
+
+The user provides text to humanize. They may also specify a domain:
+- `email` — transactional or relational email
+- `contratto` / `contract` — formal legal/contractual document
+- `comunicazione` / `announcement` — editorial content for an audience
+- `generico` / `generic` — default when no domain is specified
+
+If no domain is stated, default to `generico`.
+
+## Process
+
+1. Read the full input text.
+2. **If no AI patterns are detected** and the text already reads naturally for its register, return the original text unchanged. Do not force edits on already-human writing.
+3. Identify all patterns from `@references/patterns-en.md` and `@references/patterns-it.md` present in the text.
+4. Apply transformations below, calibrated to the detected language (IT / EN / mixed).
+5. Respect domain register: `email` = conversational; `contratto` = formal but not robotic; `comunicazione` = editorial voice; `generico` = match the surrounding register of the input.
+6. **For very short input (<50 words):** apply only HIGH severity vocabulary rules and obvious opener removal. Skip sentence rhythm and structural rules — insufficient text for structural variation.
+
+## Transformation rules
+
+### Sentence rhythm
+- Break uniform sentence length. Vary between short (5-8 words) and long (20-30 words) sentences within the same paragraph.
+- Add at least one sentence fragment or rhetorical one-liner per 4-5 paragraphs if appropriate to register.
+- Dissolve the "topic sentence - evidence - conclusion" paragraph template wherever it appears mechanically.
+
+### Vocabulary substitution
+- Replace every word or phrase in the HIGH severity list in `@references/patterns-en.md` and `@references/patterns-it.md`.
+- Replace MEDIUM severity items when they cluster (3+ in the same paragraph).
+- LOW severity items: replace only if removing improves the sentence, otherwise leave.
+
+### Structure
+- Remove unsolicited "Challenges" sections. Integrate genuine limitations inline if they appear.
+- Remove "In conclusion / In summary / Overall / In conclusione" openers on final paragraphs. End by saying something specific, not by repeating the beginning.
+- Remove predictable five-part essay scaffolding. Preserve the content, not the scaffold.
+- Convert mechanical bullet-point lists to prose when the items are short and connected.
+
+### Voice
+- Remove all hedging phrases from the HIGH severity list. If the underlying claim is uncertain, express uncertainty with specifics ("I don't have data on this" not "Research suggests...").
+- Remove vague attribution ("experts say", "studies show", "si ritiene che"). If there is no source, remove the claim or rephrase as the author's observation.
+- Remove balanced non-resolution ("on one hand... on the other...") when the question has a defensible answer. Take the position the evidence supports.
+- Remove unearned enthusiasm ("fascinating", "groundbreaking", "pivotal") unless the specific context justifies it.
+
+### Anti-hallucination
+- Never invent facts, statistics, sources, or arguments to replace removed AI filler.
+- If removing a vague attribution leaves a factual gap that cannot be filled from the input text alone, remove the entire claim rather than fabricating a replacement. Do not insert sources, names, or data not present in the original.
+- Technical hedging is not AI filler: preserve genuinely conditional claims ("this may improve performance under load", "depending on configuration") — these reflect real uncertainty, not AI patterns.
+
+### Italian-specific (apply when input is Italian)
+- Remove explicit subject pronouns where Italian drops them naturally ("Edoardo poi..." not "Edoardo poi lui...").
+- Replace Anglicized constructions that don't exist in natural Italian prose.
+- Fix heading capitalization to Italian convention (first word only, not per-word title case).
+- Add colons where Italian prose uses them naturally — they are frequently underused in AI-generated Italian.
+- Use impersonal "si" constructions where appropriate instead of explicit passive or explicit subject.
+
+### Punctuation
+- Replace em dashes used as generic connectors. Use commas, colons, parentheses, or rewrite the sentence.
+- Do not use ellipsis for pauses or trailing thoughts.
+- Introduce contractions (don't, isn't, it's) in English informal registers. Italian: use natural elisions.
+
+### Exclusions — never modify
+- Code blocks (fenced ``` or indented)
+- Inline code (`backtick-wrapped`)
+- JSON, YAML, frontmatter
+- Technical labels and field names
+- Quoted text (content inside quotation marks that represents a verbatim quote)
+- Proper nouns, brand names, product names
+
+## Output
+
+Return ONLY the rewritten text.
+No explanations. No list of changes made. No commentary.
+The output format (paragraphs, headers, lists) mirrors the structure of the input — do not reformat unless the input structure is itself an AI structural pattern being removed.

--- a/plugin/skills/humanize/references/patterns-en.md
+++ b/plugin/skills/humanize/references/patterns-en.md
@@ -1,0 +1,267 @@
+# AI Writing Patterns — English
+
+Source: cross-referenced GPTZero, Wikipedia Signs of AI Writing, Pangram Labs, Turnitin 2025 methodology,
+Grammarly, academic MDPI research, Twixify frequency data. Updated: 2026-03-31.
+
+Severity:
+- HIGH — strong statistical signal, 10x+ more frequent in AI text, or primary detection feature
+- MEDIUM — consistent signal, less dominant, meaningful in clusters
+- LOW — minor, only significant in combination with other indicators
+
+---
+
+## 1. Verbs
+
+### HIGH
+- delve / delve into → examine, look at, explore
+- harness → use, apply, draw on
+- leverage → use, apply
+- utilize → use
+- underscore → shows, highlights, makes clear
+- foster → build, develop, encourage
+- navigate (metaphorical) → rewrite the sentence
+- showcase → show, demonstrate, present
+- align / aligns → matches, fits, follows
+- revolutionize → change fundamentally, transform (use sparingly)
+- embark → start, begin
+- endeavor → try, work to
+- illuminate → show, reveal, clarify
+- elucidate → explain, clarify
+- impacting → affecting, changing
+- surpassing → exceeding, going beyond
+- remarked → said (use "said" or "noted" unless quoting)
+- streamline → simplify, cut down
+- elevate → improve, raise, lift
+- transcend → go beyond, exceed
+- unveil → reveal, announce, release
+
+### MEDIUM
+- facilitate → help, enable
+- commence → start, begin
+- ascertain → find out, check, determine
+- empower → let, allow, give X the ability to
+- foster → build (already HIGH but also medium in business context)
+- uncover → find, reveal
+- bolster → strengthen, support
+- underscore → already HIGH
+
+---
+
+## 2. Adjectives
+
+### HIGH
+- comprehensive → specific alternative (complete, full, detailed)
+- robust → strong, reliable, solid (or just remove)
+- innovative → specific alternative or remove
+- seamless → smooth, easy, uninterrupted
+- cutting-edge → advanced, latest, current
+- meticulous → careful, thorough, precise
+- pivotal → key, critical, defining
+- vibrant → lively, active (or specific)
+- multifaceted → complex, multi-part (or specific)
+- nuanced → specific alternative; AI claims nuance while demonstrating none
+- crucial → key, important, critical (use sparingly)
+- vital → essential, necessary (use sparingly)
+- transformative → specific alternative
+- groundbreaking → specific alternative or remove
+- holistic → complete, whole, broad
+
+### MEDIUM
+- invaluable → very useful, essential
+- profound → deep, significant
+- compelling → strong, convincing
+- dynamic → active, fast-moving (or specific)
+- intricate → complex, detailed
+- fascinating / captivating / majestic → only use if the specific context earns it
+- daunting → difficult, hard, challenging
+- ever-evolving / ever-changing → remove or rewrite with specifics
+
+---
+
+## 3. Nouns
+
+### HIGH
+- tapestry → remove or rewrite ("a tapestry of X" → just name what X is)
+- realm → area, field, domain
+- landscape (metaphorical) → field, area, state of (or remove)
+- synergy → cooperation, alignment (or specific)
+- journey (metaphorical) → process, path, experience (only if earned)
+- testament → sign, proof, evidence ("a testament to X" → "X proves / shows")
+- underpinnings → foundations, basis, core
+- paradigm → model, approach, framework (or specific)
+- interplay → relationship, interaction, tension between
+
+### MEDIUM
+- ecosystem (metaphorical) → network, system, environment
+- cornerstone → foundation, basis, key element
+- labyrinth → maze, complexity (or specific)
+- enigma → mystery, puzzle (or specific)
+- metropolis → city (unless register requires it)
+- aspect → specific alternative (usually can be deleted or replaced)
+- insight → finding, observation (avoid as generic container word)
+- complexity → specific alternative or rephrase
+
+---
+
+## 4. Adverbs and Intensifiers
+
+### HIGH
+- ultimately → remove or rewrite the sentence
+- tragically → only use if actual tragedy; otherwise remove
+- notably → remove or restructure
+
+### MEDIUM
+- crucially → key point: (use structural emphasis instead)
+- importantly (as opener) → restructure
+- essentially → remove or rewrite
+- fundamentally → remove or rewrite
+- arguably → rewrite with a position or remove
+- various / numerous / diverse → give the actual number or list them
+- significant → be specific about what makes it significant
+- notably → remove or restructure
+
+---
+
+## 5. Opening and Framing Phrases
+
+### HIGH (107x-182x AI frequency at peak)
+- "In today's fast-paced world..." → delete; start with the actual subject
+- "In today's digital age..." → same
+- "In the realm of..." → delete; name the field directly
+- "In the world of..." → same
+- "When it comes to..." → delete; restructure the sentence
+- "At its core..." → delete; state the claim directly
+- "As we explore..." → delete
+- "Let us explore..." → delete
+- "Let's dive in..." → delete
+- "It's important to note that..." → delete the phrase; the note stands on its own
+- "It's worth noting that..." → same
+- "It should be noted that..." → same
+- "It's important to remember..." → same
+- "It's crucial to understand..." → same
+- "I hope this email finds you well" → delete; start with the actual message
+- "As an AI language model..." → delete entirely
+
+---
+
+## 6. Transitional Discourse Markers
+
+### HIGH (2-5x AI frequency, academic research)
+Replace with specific logical connectors or restructure:
+- Furthermore → and, also, or restructure
+- Moreover → and, also, or restructure
+- Additionally → and, also, or delete and connect sentences
+- Consequently → so, as a result, because of this
+- First and foremost → first (or restructure)
+- Last but not least → finally, and also (or restructure)
+- In conclusion → delete; end by saying something specific
+- In summary → delete; end by saying something specific
+- Overall → delete or restructure
+- To summarize → delete
+- In essence → delete
+- Indeed → remove or rewrite
+- To recap → delete
+
+### MEDIUM
+- Notably → remove or restructure
+- Specifically → often can be deleted
+- Essentially → remove or rewrite
+- Alternatively → only use when presenting a genuine alternative
+- In contrast → only when the contrast is real and specific
+- Due to this → because of this, so
+- Given that → since, because
+
+---
+
+## 7. Closing Phrases
+
+### HIGH
+- "I hope this helps" → delete
+- "Feel free to ask..." → delete
+- "Is there anything else I can help with?" → delete
+- "Let me know if you need clarification" → delete
+- "Happy to help" / "Happy to clarify" → delete
+
+---
+
+## 8. Hedging and Vague Attribution
+
+### HIGH
+Replace by either: (a) stating the specific claim with its source, or (b) saying "I don't know" / "I don't have data on this"
+- "Research suggests..." (without citation)
+- "Studies show..." (without citation)
+- "Experts say..." (without named expert)
+- "Many experts believe..." (same)
+- "Scientists believe..." (same)
+- "It is widely accepted that..."
+- "Generally speaking..."
+- "To some extent..."
+- "From a broader perspective..."
+- "It could be argued that..."
+- "One could argue..."
+- "Some might say..."
+
+---
+
+## 9. Structural Patterns
+
+### HIGH — remove or dissolve
+- Uniform paragraph structure: every paragraph = topic sentence + evidence + wrap-up
+- "Challenges" or "Limitations" section added without being requested
+- "Future Outlook" / "Future Prospects" section (vague, speculative)
+- Conclusion that opens with "In conclusion / In summary / Overall" and repeats the intro
+- Five-part essay: intro → body × 3 → conclusion (formulaic scaffold, not organic)
+
+### HIGH — sentence structure templates to break
+- "From X to Y, [subject]..." → rewrite directly
+- "[Subject] plays a key/pivotal/significant role in..." → rewrite: say what it does
+- "Not only X, but also Y" (used as analysis substitute) → state the actual relationship
+- "[Verb]ing [phrase], the subject..." trailing participial clauses overused → vary structure
+- "While X, Y" as mechanical paragraph opener → use only when the contrast is substantive
+- Copula avoidance: "serves as," "stands as," "marks as" replacing is/are → use is/are
+
+### MEDIUM
+- Bullet-point lists where prose would flow naturally (3-4 connected short items)
+- Parallel structure forced onto items that are not logically parallel
+- Synonym cycling (using thesaurus rotations for the same noun: protagonist → key player → central figure) → pick one term and repeat it or use a pronoun
+- Section headers on short texts (under 300 words) → remove headers
+
+---
+
+## 10. Punctuation
+
+### HIGH
+- Em dash as generic connector ("The result was clear—it worked", "X—and this is critical—Y")
+  → replace with comma, colon, parentheses, or rewrite the sentence
+
+### MEDIUM
+- Zero contractions in informal English register → introduce don't, isn't, it's, you're naturally
+- Zero sentence fragments → introduce one per 4-5 paragraphs in informal register
+- 100% Oxford comma consistency → match the register (drop in informal British English)
+
+---
+
+## 11. Tone and Voice Patterns
+
+### HIGH
+- Emotional flatness / generic neutrality → inject register-appropriate specificity and voice
+- Balanced non-resolution ("on one hand / on the other") when question has a defensible answer → take the position
+- Perpetual formal register regardless of context → match the actual communication register
+- Unearned enthusiasm ("fascinating", "pivotal", "groundbreaking") for mundane subjects → remove or replace with specific observation
+
+### MEDIUM
+- No contractions in informal contexts → add naturally
+- Absence of concrete example where one would be natural → add a specific case
+- Significance inflation ("marks a pivotal moment", "represents a broader shift") → cut or be specific
+
+---
+
+## 12. Content-Level Patterns
+
+### HIGH
+- Barnum statements (so broad they apply to everything): "Communication is the foundation of any successful relationship" → either be specific or delete
+- Vague attribution replacing real evidence → cite specifically or remove the claim
+- Challenges section appearing without prompt → integrate inline or remove
+
+### MEDIUM
+- Unearned significance inflation: "marks a pivotal moment," "enduring legacy," "represents a broader shift" → be specific or cut

--- a/plugin/skills/humanize/references/patterns-it.md
+++ b/plugin/skills/humanize/references/patterns-it.md
@@ -1,0 +1,198 @@
+# Pattern AI — Italiano
+
+Fonti: AI4Business, Compilatio, Geopop, MySocialWeb, ricerca accademica MDPI 2024,
+cross-referenziati con pattern EN dove esistono equivalenti italiani. Aggiornato: 2026-03-31.
+
+Severità:
+- ALTA — segnale statistico forte, documentato come marker primario di rilevamento
+- MEDIA — segnale consistente, significativo in cluster
+- BASSA — solo in combinazione con altri indicatori
+
+---
+
+## 1. Frasi di apertura e chiusura
+
+### ALTA
+- "In conclusione, ..." come apertura del paragrafo finale → eliminare; chiudere con un'osservazione specifica
+- "È importante sottolineare che..." → eliminare la frase; l'affermazione regge da sola
+- "È fondamentale ricordare che..." → stesso pattern
+- "È necessario evidenziare che..." → stesso pattern
+- "Come abbiamo visto..." → eliminare; riprendere direttamente il punto
+- "In questo contesto, ..." come apertura generica → eliminare; partire dal soggetto
+- "Nel corso degli anni, ..." come filler temporale → eliminare o specificare l'arco temporale
+- "Nell'era digitale di oggi, ..." → eliminare; partire dall'argomento reale
+- "Nel mondo odierno, ..." → stesso pattern
+- "Cordiali saluti" preceduto da chiusure ridondanti → usare solo il saluto, senza "Spero che questa risposta sia stata utile"
+
+### MEDIA
+- "Come accennato in precedenza..." → riformulare o eliminare il rinvio
+- "Questo dimostra che..." come chiusura meccanica di paragrafo → riformulare
+- "A tal proposito, ..." come connettore automatico → eliminare o sostituire con un connettore specifico
+- "D'altra parte, ..." usato in modo ripetitivo → variare o riformulare
+
+---
+
+## 2. Vocabolario — Verbi
+
+### ALTA
+- elevare (metaforico) → migliorare, aumentare, rafforzare
+- potenziare → migliorare, rafforzare, sviluppare
+- valorizzare (generico) → specificare cosa si valorizza e come
+- ottimizzare (generico senza contesto tecnico) → migliorare, affinare
+- sfruttare (nel senso di "leverage") → usare, applicare, impiegare
+- facilitare → aiutare, permettere, rendere possibile
+- garantire (come filler) → spesso si può eliminare o riformulare
+- evidenziare → mostrare, indicare, sottolineare (ma "sottolineare" è già un marker MEDIO)
+- sottolineare (come opener) → mostrare, indicare, mettere in luce
+
+### MEDIA
+- intraprendere → iniziare, avviare, cominciare
+- approfondire → studiare, analizzare, esaminare
+- delineare → descrivere, spiegare, definire
+- riflettere (metaforico: "riflette un cambiamento") → indica, mostra, segnala
+- rappresentare (generico: "rappresenta una sfida") → è una sfida, costituisce (ma anche questo è inflazionato)
+
+---
+
+## 3. Vocabolario — Aggettivi
+
+### ALTA
+- fondamentale (come enfatizzatore generico) → specifico o eliminare
+- cruciale → chiave, importante, determinante (usare con parsimonia)
+- innovativo (senza specificare in cosa) → specifico o eliminare
+- completo / esaustivo → specifico o eliminare se ridondante
+- efficace (generico senza evidenza) → specifico o eliminare
+- significativo (senza specificare cosa lo rende tale) → specifico
+
+### MEDIA
+- robusto (in contesti non tecnici) → solido, affidabile
+- dinamico (come aggettivo decorativo) → eliminare o specificare
+- prezioso (come "prezioso contributo") → specifico o eliminare
+- versatile (senza contesto) → specifico
+
+---
+
+## 4. Vocabolario — Sostantivi
+
+### ALTA
+- sfide (sezione "Le sfide" non richiesta) → integrare inline o eliminare
+- sinergie → cooperazione, collaborazione, o specifico
+- ecosistema (metaforico) → sistema, rete, ambiente (o specifico)
+- percorso (metaforico: "il tuo percorso verso X") → processo, cammino (solo se guadagnato)
+- panorama (metaforico: "il panorama digitale") → contesto, campo, settore
+
+### MEDIA
+- paradigma → modello, approccio, schema
+- prospettiva (come contenitore generico) → specifico
+- sfida → problema, ostacolo, difficoltà (più concreto)
+- opportunità (inflazionato) → specifico su cosa e come
+
+---
+
+## 5. Connettori e marcatori discorsivi
+
+### ALTA — usati a frequenza 2-5x superiore all'italiano umano
+- Inoltre (come apertura di paragrafo automatica) → variare posizione o fondere con il paragrafo precedente
+- Pertanto → quindi, per questo, di conseguenza
+- Tuttavia (come pivot meccanico) → ma, però, al contrario (variare)
+- Infine (come opener della conclusione) → usare solo se effettivamente ultimo punto
+- In primo luogo / In secondo luogo → stile accademico; usare solo in testi che lo richiedono
+- Da un lato / Dall'altro (senza risoluzione) → prendere posizione o eliminare la falsa bilancia
+
+### MEDIA
+- Di conseguenza → quindi, per questo (più naturale)
+- A questo proposito → qui, su questo punto (più diretto)
+- In sintesi → terminare con un'affermazione specifica, non con un riassunto
+- Allo stesso modo → anche, similmente (meno formale)
+
+---
+
+## 6. Struttura grammaticale — pattern da correggere
+
+### ALTA
+**Ripetizione del soggetto esplicito**
+L'italiano drop del pronome soggetto naturalmente. L'AI lo ripete.
+- "Marco studia. Marco poi prende il libro. Marco infine..." → "Marco studia, prende il libro, infine..."
+- Correzione: eliminare il soggetto ripetuto o usare un pronome ("lui", "lei") solo quando necessario per chiarezza.
+
+**Catene di frasi SVO semplici**
+L'AI usa paratassi (frasi coordinate semplici) dove l'italiano letterario e formale usa ipotassi (subordinazione).
+- ❌ "L'azienda cresce. Il mercato si espande. I risultati migliorano."
+- ✅ "L'azienda cresce man mano che il mercato si espande, con risultati che migliorano progressivamente."
+- Attenzione: non ipercorregere in testi informali — la semplicità è appropriata in email e comunicazioni brevi.
+
+**Uso eccessivo del passivo esplicito**
+L'italiano usa il "si" impersonale/passivo naturalmente; l'AI costruisce passivi espliciti simili all'inglese.
+- ❌ "Il documento è stato redatto dall'ufficio amministrativo"
+- ✅ "L'ufficio amministrativo ha redatto il documento" o "Il documento è stato redatto" (senza agente se non necessario)
+- Introdurre costruzioni con "si" quando appropriate: "si procede", "si considera", "si verifica"
+
+**Maiuscole in stile inglese nei titoli**
+L'AI applica la capitalizzazione per parola (title case inglese) ai titoli italiani.
+- ❌ "Guida Completa Alla Gestione Dei Documenti"
+- ✅ "Guida completa alla gestione dei documenti"
+- Solo la prima parola e i nomi propri si capitalizzano nei titoli italiani.
+
+**Sottouso dei due punti**
+AI4Business documenta che "i due punti non esistono più" nei testi AI in italiano. I due punti sono naturali in italiano per introdurre enumerazioni, spiegazioni, esempi.
+- Reintrodurli dove la struttura della frase li richiede.
+
+---
+
+## 7. Anglicismi non naturali
+
+### ALTA — costruzioni che non esistono nell'italiano naturale
+- "elevare il tuo livello di conoscenza" (calco da "elevate your level") → "approfondire le tue conoscenze"
+- "navigare la complessità" → "gestire la complessità", "affrontare le difficoltà"
+- "deliverare risultati" → "produrre risultati", "ottenere risultati"
+- "fare un deep dive su X" → "analizzare X in profondità"
+- "mettere in atto le best practice" → "seguire le pratiche migliori" o specificare quali
+- "stakeholder" → portatori di interesse, parti interessate (a meno che il registro non lo richieda)
+- "onboarding" in testi non tecnici → inserimento, accoglienza, avvio
+
+---
+
+## 8. Tono e registro
+
+### ALTA
+**Registro formale indifferenziato**
+L'AI usa il registro formale-burocratico indipendentemente dal contesto. Un'email tra colleghi, una comunicazione interna e un contratto legale ricevono lo stesso tono.
+- Adattare: email interna = tono diretto e colloquiale; comunicazione editoriale = tono editoriale con personalità; contratto = formale ma non ridondante.
+
+**Falsa bilancia senza risoluzione**
+"Da un lato X, dall'altro Y" usato anche quando esiste una posizione difendibile.
+- Prendere posizione quando l'evidenza lo supporta.
+
+**Entusiasmo non guadagnato**
+"Affascinante", "straordinario", "rivoluzionario" applicati a soggetti ordinari.
+- Usare solo quando il contesto specifico lo giustifica con evidenza concreta.
+
+### MEDIA
+**Tono neutro impersonale dove è attesa la voce**
+Nei testi editoriali e nelle comunicazioni, l'assenza di voce e personalità è un segnale. Aggiungere prospettiva specifica, opinione fondata, o almeno un'osservazione non ovvia.
+
+---
+
+## 9. Pattern strutturali
+
+### ALTA
+- Struttura "Introduzione - Sviluppo - Sfide - Prospettive future - Conclusione" applicata meccanicamente
+- Paragrafi di lunghezza identica con struttura identica (frase topic + sviluppo + chiusura)
+- Sezione "Sfide" o "Limitazioni" aggiunta senza essere richiesta
+- Conclusione che inizia con "In conclusione / In sintesi / Per riassumere" e ripete l'introduzione
+
+### MEDIA
+- Elenchi puntati dove la prosa sarebbe naturale (3-4 elementi brevi e connessi)
+- Intestazioni in testi brevi (sotto 250 parole) → rimuovere le intestazioni
+- Struttura parallela forzata su elementi che non sono logicamente paralleli
+
+---
+
+## 10. Punteggiatura
+
+### ALTA
+- Trattino em come connettore generico → sostituire con virgola, due punti, parentesi, o riscrivere
+
+### MEDIA
+- Assenza di contrazioni naturali italiane (dell', all', nell', sull') → reintrodurle dove appropriate
+- Puntini di sospensione (...) per pause drammatiche → eliminare; riscrivere la frase

--- a/plugin/skills/perf-audit/SKILL.md
+++ b/plugin/skills/perf-audit/SKILL.md
@@ -1,0 +1,332 @@
+---
+name: perf-audit
+description: Performance audit: bundle size, lazy loading, data fetching, caching, N+1 queries, image optimization. Native mode checks memory, I/O, launch weight, energy.
+user-invocable: true
+model: sonnet
+context: fork
+argument-hint: [target:section:<section>|target:page:<route>|mode:audit|mode:apply]
+---
+
+## Configuration (adapt before first run)
+
+> Replace these placeholders:
+> - `[FRAMEWORK]` - e.g. `Next.js App Router`, `Remix`, `SvelteKit`, `plain React`
+> - `[SITEMAP_OR_ROUTE_LIST]` - e.g. `docs/sitemap.md`
+> - `[API_ROUTES_PATH]` - e.g. `routes/`, `src/handlers/`, `api/`
+> - `[BUNDLE_TOOL]` - e.g. `@next/bundle-analyzer`, `vite-bundle-visualizer`, `webpack-bundle-analyzer`
+> - Note: if this is a **public-facing** app, remove the "Out of scope" restriction on Core Web Vitals
+
+## Applicability check
+
+Before any other step: read `CLAUDE.md` and check the Framework and Language fields.
+
+- If the project is a **web application** (Framework is NOT `N/A - native app` and NOT `N/A - no web frontend`): proceed to **Step 1 - Web Performance Audit** (Steps 1–5).
+- If the project is a **native or backend-only application** (Framework is `N/A - native app` or `N/A - no web frontend`): skip Steps 1–5 and proceed directly to **Step 6 - Native/Backend Performance Audit**.
+
+
+
+## Context and scope
+
+**In scope**: bundle composition, server/client component boundaries, dynamic rendering triggers, lazy loading, data fetching efficiency (caching, parallelism, N+1), re-render patterns, image optimization. For native stacks: algorithmic complexity, stack-specific hot-path patterns, memory management, launch weight, energy impact, binary size.
+**Out of scope**: SEO, CWV as ranking signals, `robots.txt`, `sitemap.xml`, OG tags, Lighthouse site audit, accessibility (→ `/ui-audit`), DB schema (→ `/skill-db`).
+**Default mode**: audit (report only, no code changes). `mode:apply` makes focused non-breaking fixes.
+
+**CWV reference (informational only - not primary deliverable for this internal app):**
+
+| Metric | Good | Needs work | Poor | Primary cause |
+|---|---|---|---|---|
+| LCP | ≤ 2.5s | 2.5–4s | > 4s | Slow server response, render-blocking resources |
+| CLS | ≤ 0.1 | 0.1–0.25 | > 0.25 | Unsized images, dynamic content above fold |
+| INP | ≤ 200ms | 200–500ms | > 500ms | Blocking JS on event handlers |
+
+Source: web.dev/articles/vitals. Use these thresholds only as triage anchors - not as primary deliverables.
+
+---
+
+## Step 0 - Target resolution
+
+Parse `$ARGUMENTS` for `target:` and `mode:` tokens.
+
+**Operating modes:**
+| Mode | Behavior |
+|---|---|
+| `mode:audit` (default) | Report only - no code changes |
+| `mode:apply` | Apply focused, non-breaking fixes (lazy loading wrappers, `Promise.all` parallelization). Describe each change before applying. |
+
+**Target resolution:**
+| Pattern | Meaning |
+|---|---|
+| `target:page:/dashboard` | Focus on the dashboard and its component tree (example) |
+| No argument | **Full audit - ALL page files + layout files + lib files + API routes from sitemap.md. Maximum depth.** |
+
+**STRICT PARSING - mandatory**: derive target ONLY from the explicit text in `$ARGUMENTS`. Do NOT infer target from conversation context, recent work, active block names, or project memory. If `$ARGUMENTS` contains no `target:` token → full audit across ALL files from sitemap.md at maximum depth. When a target IS provided → act with maximum depth and completeness on that specific scope only.
+
+Announce: `Running perf-audit - scope: [FULL | target: <resolved>] - mode: [audit | apply]`
+Apply the target filter to the file list in Step 1.
+
+---
+
+## Step 1 - Build file inventory
+
+- All page/view files in scope
+- All heavy components (those with chart, calendar, data table, rich text editor - high rendering cost)
+- All layout/shell files (always include regardless of target - critical for B1 Flag B and B8)
+- All service/data-access files directly called from page/component files - exclude pure utility files with no DB calls
+- Framework configuration file (e.g. `next.config.ts`, `vite.config.ts`, `nuxt.config.ts`, `webpack.config.js`)
+
+Read `docs/refactoring-backlog.md` - note existing `PERF-` entries to avoid duplicates.
+
+---
+
+## Step 2 - Server/Client boundary checks (Explore agent)
+
+Launch a **single Explore subagent** (model: haiku) with all page, component, and lib files from Step 1:
+
+"Run all 9 checks below. For each: state total match count, list every match as `file:line - excerpt`, and state PASS or FAIL. Adapt grep patterns to the project's framework - the concepts are universal, the specific APIs vary.
+
+**CHECK B1 - Unnecessary client-side rendering scope**
+Find components or pages marked for client-side rendering that do not actually use browser APIs (event handlers, state, refs, browser-only hooks).
+- For SSR frameworks (Next.js, Nuxt, SvelteKit): grep for client-side directives (`'use client'`, `<script>` with `client:only`, etc.) and check if the file uses any browser-specific API.
+- Flag A: any client-marked file that uses NONE of: state management, event handlers, refs, or browser APIs. It may be renderable on the server.
+- Flag B: any client-marked layout or provider file that imports 5+ child components - if only a small interactive portion requires client rendering, extracting it into an island would let the layout render on the server.
+
+**CHECK B2 - Heavy libraries in client bundle**
+Grep for imports of known-heavy libraries in client-rendered files. Flag any imports of libraries that do NOT need browser APIs and could run server-side:
+- Document processing libraries (PDF, XLSX, etc.) - typically server-only
+- Rich text editors - acceptable in client IF interactive; flag if read-only render
+- Chart libraries - acceptable in client if interactive; flag if static data-display only
+- Any library > ~50KB that has a server-side equivalent
+Flag: each import with the library name and whether a server-side pattern exists.
+
+**CHECK B3 - Client-side data fetching that defeats server rendering**
+Find client-rendered components that fetch data in lifecycle hooks (e.g. `useEffect`, `onMounted`, `onMount`) instead of using server-side data loading.
+Flag: data fetching in client lifecycle hooks - these defeat server rendering and add a loading waterfall. Use server-side data loading with streaming/suspense, or a client-side cache library with proper revalidation.
+
+**CHECK B4 - Unstable callback references defeating memoization**
+Find inline arrow functions passed as props to memoized child components. Inline functions create new references on every parent render, defeating memoization.
+Flag: each case. Skip native HTML element event handlers - frameworks batch these internally.
+
+**CHECK B5 - Sequential await waterfall**
+Pattern: two or more consecutive `await` calls for independent data sources in the same async function.
+Grep in server-rendered files or API routes: lines matching `const .* = await` that appear consecutively (within 5 lines of each other) without the first result being an input to the second call.
+Flag: each pair of sequential awaits that could be parallelised with `Promise.all` (or equivalent).
+Example of violation: `const a = await getA(); const b = await getB();` where b doesn't depend on a.
+
+**CHECK B6 - Missing caching on repeated server-side queries**
+Find data fetches that run on every request without caching in server-rendered components.
+Grep in server-rendered files for database query calls - check if they use any caching mechanism (framework cache, memoization, or explicit cache headers).
+Flag: uncached queries in layout-level or frequently-visited components (e.g. navigation data, user profile). These execute on every page visit.
+
+**CHECK B7 - Images without explicit dimensions (CLS risk)**
+Find image elements (framework image component or native `<img>`) without width/height or fill/cover constraints.
+Flag: each unsized image. Without dimensions, the browser cannot reserve layout space - content shifts when the image loads, causing CLS violations.
+
+**CHECK B8 - Accidental dynamic rendering triggers**
+Find patterns that force dynamic rendering at the layout level, opting entire route subtrees out of static generation:
+- Request-scoped APIs (cookies, headers, session) called in layout files
+- Explicit force-dynamic configuration in page/layout files
+- No-cache directives in layout-level data fetches
+Flag: each occurrence. Verify from context whether intentional (auth-dependent, real-time data) or avoidable with proper caching or component restructuring.
+
+**CHECK B9 - Missing lazy loading for heavy client components**
+Find imports of heavy libraries (rich text editors, chart libraries, complex UI components) that are statically imported without lazy loading.
+Flag: any file where a heavy component is eagerly imported without using the framework's dynamic/lazy import mechanism (e.g. `React.lazy`, `next/dynamic`, `defineAsyncComponent`, dynamic `import()`)."
+
+---
+
+## Step 3 - Bundle composition check (main context)
+
+Read the framework configuration file (e.g. `next.config.ts`, `vite.config.ts`, `webpack.config.js`, `nuxt.config.ts`).
+
+**P1 - Bundle analyzer availability**
+Check if a bundle analyzer is configured or available for the project's build tool:
+- Webpack: `webpack-bundle-analyzer` or `@next/bundle-analyzer`
+- Vite: `rollup-plugin-visualizer`
+- Next.js 16+: `npx next experimental-analyze` (built-in)
+- Other: check for any bundle analysis tooling in devDependencies
+If no analyzer is configured or documented, flag as Medium - developers cannot easily audit bundle composition.
+
+**P2 - Server-only package exclusion**
+Check if the framework configuration excludes heavy server-only packages from the client bundle.
+Identify packages in the project that should never be client-bundled (e.g. PDF processors, XLSX generators, database drivers, file system utilities).
+Flag: any heavy server-only package not explicitly excluded from client bundling.
+
+**P3 - Tree-shaking optimization for large libraries**
+Check if the build configuration optimizes imports for large libraries with many exports where only a subset is used (e.g. icon libraries with hundreds of icons, utility libraries like lodash).
+Note: some frameworks automatically optimize certain packages (check the framework docs). If a library is already auto-optimized by the build tool, note as PASS.
+Flag: any package with 100+ exports where only a subset is used, not covered by the build tool's tree-shaking or import optimization.
+
+---
+
+## Step 4 - API query efficiency (Explore agent - separate pass)
+
+"Run these 3 checks. Adapt grep patterns to the project's database client or ORM:
+
+**CHECK Q1 - Unbounded queries (no limit on large-growth tables)**
+Flag: each collection query without pagination bounds. Exception: export routes that intentionally fetch all for CSV/XLSX - verify from context.
+
+**CHECK Q2 - Select * (over-fetching columns)**
+Grep for select-all patterns in route handlers (e.g. `.select('*')`, `SELECT *`, `.findAll()` without field projection, `.all()` without `only()`).
+Flag: each match. Fetching all columns is a performance and security risk - columns with large values (e.g. `body`, `content`, blob URLs) are sent over the wire unnecessarily.
+
+**CHECK Q3 - N+1 patterns**
+Pattern A: database query calls inside `.map(`, `for`, or `forEach` loops.
+Pattern B: sequential `await` with a DB client call inside a loop body.
+Flag: each match. N+1 on a list endpoint means N DB queries for an N-item list - use batch queries or embedded/eager loading instead."
+
+---
+
+## Step 5 - Produce report and update backlog
+
+Generate the report using the template in `${CLAUDE_SKILL_DIR}/REPORT.md` (Web Audit section). Apply the severity guide and backlog writing rules from the same file.
+
+---
+
+## Execution notes
+
+- In `mode:audit` (default): do NOT make any code changes - report only. After producing the report, ask: "Should I implement the High/Critical priority optimisations?"
+- In `mode:apply`: apply only the fixes listed in Quick wins (isolated, non-breaking). Describe each change before writing it. Do not apply Strategic refactors without explicit user confirmation. Do NOT ask the closing question - the user already expressed intent via `mode:apply`.
+- Check CLAUDE.md "Known Patterns" for intentionally configured server-external packages, client-side component exclusions, or layout-level client directives before flagging them.
+
+---
+
+## Step 6 - Native/Backend Performance Audit
+
+**This path runs for non-web projects only.** Web projects use Steps 1–5 above.
+
+### Profiling tools
+
+**Primary tool**: [PERF_TOOL]
+**Profile command**: `[PROFILER_COMMAND]`
+
+Run the profiler on the main execution path. Identify the top 5 hotspots by CPU time and the top 5 by memory allocation. If profiling data is not available, proceed with static analysis and recommend running the profiler.
+
+---
+
+### Step 6a - Algorithmic and resource checks (Explore agent)
+
+Launch a **single Explore subagent** (model: haiku) with all source files from the project:
+
+"Run these 4 checks on the provided source files. For each: state total match count, list every match as `file:line - excerpt`, and state PASS or FAIL.
+
+**CHECK NP1 - Nested iteration on collections**
+Grep for nested loops (for/while/map/forEach inside another loop body) operating on collections or arrays.
+Flag: O(n²) or worse complexity. Exclude small fixed-size iterations (< 10 items known at compile time).
+
+**CHECK NP2 - Memory allocation in hot paths**
+Flag:
+- Object/string/array/buffer creation inside loops (new allocation per iteration)
+- Unbounded caches or collections that grow without eviction
+- Missing cleanup of heavyweight resources (file handles, DB connections, network sockets)
+
+**CHECK NP3 - I/O bottleneck patterns**
+Flag:
+- Synchronous file I/O on the main/UI thread
+- Sequential network calls that could be parallelized
+- Unbuffered reads/writes on large files
+- Missing timeout on network or IPC operations
+
+**CHECK NP4 - Concurrency inefficiency**
+Flag:
+- Thread/goroutine/task creation inside loops without pooling
+- Shared mutable state without synchronization primitives
+- Blocking calls on async/concurrent paths
+- Missing cancellation support on long-running operations"
+
+---
+
+### Step 6b - Stack-specific checks (main context)
+
+Read the 10 largest source files by line count. Apply the checks relevant to the project language. Each check includes grep patterns - run them, then read flagged files for context.
+
+**Swift**:
+- Main-thread work: grep for `DispatchQueue.main.sync` outside UI layer files - synchronous dispatch on main blocks the UI. Also grep for `URLSession.shared.data` without `Task { }` wrapper in non-async contexts.
+- Image downsampling: grep for `UIImage(named:` or `NSImage(named:` in collection view / table view code - flag if no `preparingThumbnail` or `CGImageSource` downsampling nearby.
+- Core Data batch size: grep for `NSFetchRequest` - flag if `fetchBatchSize` is 0 or not set (default fetches all objects into memory).
+- Retain cycles: grep for closures capturing `self` - flag `{ self.` or `{ [self]` without `[weak self]` in long-lived contexts (completion handlers, observers, timers).
+- Allocation spikes: grep for object creation inside `for`/`while` loops (e.g. `= String(`, `= Data(`, `= NSMutableAttributedString(`).
+
+**Kotlin**:
+- Main-thread DB: grep for `Room` or `SQLite` calls outside `Dispatchers.IO` or `withContext(Dispatchers.IO)`.
+- RecyclerView recycling: grep for `onBindViewHolder` - flag if view inflation (`inflate(`) happens inside bind instead of `onCreateViewHolder`.
+- Bitmap memory: grep for `BitmapFactory.decode` - flag if no `inSampleSize` option is set (loads full-resolution bitmaps).
+- Coroutine leaks: grep for `GlobalScope.launch` - flag each occurrence (no lifecycle-aware cancellation).
+- StrictMode: grep for `StrictMode` in Application class - flag if absent in debug build (disk/network violations on main thread go undetected).
+
+**Rust**:
+- Unnecessary clone: grep for `.clone()` - flag if the value is only read after cloning (borrow would suffice).
+- Hot-path allocation: grep for `Vec::new()`, `String::new()`, `Box::new(` inside loop bodies - flag if the allocation could be hoisted or reused.
+- Dynamic dispatch: grep for `Box<dyn` - flag if the trait has a single implementor (generics avoid vtable overhead).
+- Missing inline: grep for `pub fn` in hot-path modules with body < 5 lines - consider `#[inline]` for small frequently-called functions.
+
+**Go**:
+- Goroutine creation in loops: grep for `go func` or `go ` inside `for` - flag if no semaphore/pool limits the concurrency.
+- Channel sizing: grep for `make(chan` - flag unbuffered channels (`make(chan T)`) in producer-consumer patterns (causes blocking).
+- Defer in loops: grep for `defer` inside `for` - deferred calls accumulate until the function returns, not the loop iteration.
+- Escape analysis: recommend running `go build -gcflags='-m' 2>&1 | grep 'escapes to heap'` on hot-path packages.
+
+**Python**:
+- Regex in loops: grep for `re.compile` or `re.search`/`re.match` with literal pattern inside `for`/`while` - flag if pattern is constant (compile once outside loop).
+- List vs generator: grep for list comprehensions `[... for ... in ...]` passed to `sum(`, `max(`, `min(`, `any(`, `all(` - generator expression avoids materializing the full list.
+- Deep copies: grep for `copy.deepcopy` - flag in hot paths (extremely expensive).
+- GIL contention: grep for `threading.Thread` doing CPU-bound work - flag (use `multiprocessing` or `concurrent.futures.ProcessPoolExecutor` instead).
+
+**Ruby**:
+- N+1 queries: grep for `.each` followed by association access (e.g. `user.company`) - flag if no `.includes(` or `.eager_load(` on the parent query.
+- String allocation: grep for string interpolation `"#{` inside loops - flag if the string could be built with `StringIO` or array join.
+- GC pressure: grep for `.map { |x| x.` patterns creating intermediate arrays - flag if `.lazy.map` or `.each_with_object` would avoid allocation.
+
+**Java**:
+- Autoboxing: grep for `Integer`, `Long`, `Double` in loop variable declarations - flag (use primitive types `int`, `long`, `double`).
+- String concat in loops: grep for `+=` on String variables inside loops - flag (use `StringBuilder`).
+- Connection pool: grep for `DriverManager.getConnection` - flag if no connection pool (HikariCP, c3p0) is configured.
+- Stream overhead: grep for `.stream().` on small collections (< 10 items) - traditional loop may be faster due to stream pipeline overhead.
+
+**dotnet**:
+- LINQ allocations: grep for `.Select(`, `.Where(`, `.ToList()` chains - flag if intermediate `.ToList()` materializes unnecessarily before final consumption.
+- String concatenation: grep for `+=` on string inside loops - flag (use `StringBuilder` or `string.Join`).
+- LOH fragmentation: grep for `new byte[` with size > 85000 - flag (Large Object Heap allocations are expensive to collect).
+- Async overhead: grep for `async` methods that contain only a single `await` with no branching - flag as candidates for removing async wrapper (avoids state machine overhead).
+
+---
+
+### Step 6c - Resource footprint checks (main context)
+
+**CHECK NR1 - Launch / startup weight**
+Identify the application entry point:
+- Swift: `@main` struct or `AppDelegate.didFinishLaunchingWithOptions`
+- Kotlin: `Application.onCreate` or `MainActivity.onCreate`
+- Rust/Go/Python/Ruby/Java/dotnet: `main()` function or entry module
+
+Grep for heavy operations in the entry point: database initialization, network calls, large file reads, complex object graph construction. Flag any operation that could be deferred (lazy initialization) or moved to a background thread/task.
+
+**CHECK NR2 - Memory management patterns**
+- Swift: grep for missing `autoreleasepool` in batch processing loops. Grep for `NSCache` or `Dictionary` used as cache without size limit.
+- Kotlin: grep for `static` or `companion object` holding Activity/Context references (memory leak). Check `onDestroy` for missing listener/observer cleanup.
+- Rust: grep for `Vec` that grows via `push` in a loop without `with_capacity` pre-allocation.
+- Go: grep for `sync.Map` or map growth without periodic cleanup - flag unbounded maps.
+- All: grep for large static/global collections that persist for the process lifetime.
+
+**CHECK NR3 - Energy and background patterns** (mobile stacks only)
+- Swift: grep for `Timer.scheduledTimer` or `DispatchSource.makeTimerSource` - flag if no `tolerance` set (tight timers prevent CPU sleep). Grep for `CLLocationManager` with `startUpdatingLocation` - flag if `startMonitoringSignificantLocationChanges` would suffice.
+- Kotlin: grep for `AlarmManager.setRepeating` or `Handler.postDelayed` in loops - flag excessive wake-ups. Grep for `LocationRequest` with high frequency updates.
+- Flag: any background polling pattern (repeated network calls on a timer) that could use push notifications or event-driven updates instead.
+
+**CHECK NR4 - Binary / artifact size**
+- Grep for large embedded assets in source directories (images > 1MB, bundled databases, embedded fonts). Flag if assets could be downloaded on demand.
+- Swift: check for `DEBUG` conditional code that may leak into release builds (grep for `#if DEBUG` blocks containing large test fixtures or mock data).
+- Kotlin: check for `debugImplementation` dependencies accidentally in `implementation` (grep `build.gradle` for heavy debug-only libraries in the wrong configuration).
+- All: grep for unused imports at module/package level - flag files importing modules they don't use (increases link time and potentially binary size).
+
+---
+
+### Step 6d - Produce report and update backlog
+
+Generate the report using the template in `${CLAUDE_SKILL_DIR}/REPORT.md` (Native Audit section). Apply the severity guide and backlog writing rules from the same file.
+
+---
+
+### Native audit - execution notes
+
+- In `mode:audit` (default): report only. After report, ask: "Should I implement the High/Critical priority optimisations?"
+- In `mode:apply`: apply only Quick wins. Describe each change before writing.

--- a/plugin/skills/security-audit/SKILL.md
+++ b/plugin/skills/security-audit/SKILL.md
@@ -1,0 +1,362 @@
+---
+name: security-audit
+description: Security audit: auth/authz on API routes, input validation, RLS policies, response shape review, secret exposure, HTTP headers. Native mode checks entitlements and Keychain. MCP-aware (v1.20+): when `mcp-nvd` server is wired, Step 3c queries live CVE data instead of static `npm audit` / `pip-audit` snapshots; falls back to local audit commands when MCP unreachable.
+user-invocable: true
+model: sonnet
+context: fork
+argument-hint: [target:page:<route>|target:role:<role>|target:section:<section>]
+allowed-tools: Bash Read Glob Grep WebFetch Agent mcp__mcp-nvd__get_cve mcp__mcp-nvd__search_cve
+---
+
+## Configuration (adapt before first run)
+
+> Replace these placeholders:
+> - `[SITEMAP_OR_ROUTE_LIST]` - file listing all API routes with method, path, roles, and grouping - e.g. `docs/sitemap.md`, `docs/routes.md`. If not configured, the skill discovers routes by scanning the project's route handler directories. Announce the discovered routes before proceeding.
+
+**Scope**: API routes, middleware/proxy, row-level access control policies, data validation, response shapes, environment variables, database configuration, dependencies. For native stacks: secrets management, platform security (Keychain/Keystore/entitlements), input validation, signing credentials, sensitive data protection.
+**Out of scope**: SEO, robots.txt, public crawlability, OpenGraph, sitemap.xml.
+**Do NOT make code changes. Audit only.**
+**All findings go to `docs/refactoring-backlog.md`.**
+
+---
+
+## Applicability check
+
+Before any other step: read `CLAUDE.md` and check the Framework and Language fields.
+
+- **Web or API project** (Framework is NOT `N/A - native app`, OR route handler directories exist): proceed to **Step 0** - full web audit (Steps 0–5) + Step 3e if the language is non-JS.
+- **Native with API** (Framework is `N/A - native app` AND route handler directories exist): proceed to **Step 0** - full web audit (Steps 0–5) + Step 3e (native checks run in addition to web checks).
+- **Native only** (Framework is `N/A - native app` AND no route handler directories): skip Steps 0–5. Proceed directly to **Step 3e** (native-only audit). Then skip to **Step 6** for the report.
+
+Announce the execution path: `Running security-audit - mode: [WEB | WEB+NATIVE | NATIVE-ONLY]`
+
+---
+
+## Step 0 - Target resolution
+
+Parse `$ARGUMENTS` for a `target:` token.
+
+| Pattern | Meaning |
+|---|---|
+| `target:role:admin` | Focus on admin routes |
+| `target:section:export` | Focus on all export/bulk-data routes |
+| `target:section:<other>` | Read `[SITEMAP_OR_ROUTE_LIST]` - find rows matching the section keyword, resolve to API routes and related route files |
+| No argument | Full audit - all API routes |
+
+Announce: `Running security-audit - scope: [FULL | target: <resolved>]`
+Apply the target filter to the route inventory built in Step 1.
+
+---
+
+## Step 1 - Build API route inventory
+
+Also read:
+- Auth helper files (e.g. `lib/auth.ts`, `utils/auth.py`) - understand session/token helpers
+- `docs/refactoring-backlog.md` - avoid duplicates
+
+Output: complete list of API routes grouped by:
+- **Public** (no auth required)
+- **Protected** (auth required, any role)
+- **Role-specific** (grouped by functional section per `[SITEMAP_OR_ROUTE_LIST]`)
+- **Export routes** (bulk data endpoints returning CSV or XLSX)
+
+Apply target scope from Step 0 before proceeding.
+
+---
+
+## Step 2 - Auth, authorization, and injection checks (Explore agent)
+
+Launch a **single Explore subagent** (model: haiku) with the full route file list. Read `${CLAUDE_SKILL_DIR}/PATTERNS.md` for stack-specific grep patterns used across all checks.
+
+**CHECK A1 - Missing auth check at route entry**
+Pattern: route handler function body does NOT contain any auth verification call within the first 20 lines.
+Grep: for each route file, check if any auth pattern from PATTERNS.md → A1 appears within the first 20 lines of the handler function. Flag any route file where none appear.
+Note: service-role-only routes must still verify the caller's role - a privileged client alone is not an auth check.
+
+**CHECK A2 - Role check present for admin routes**
+Flag: any admin route without an explicit role assertion.
+
+**CHECK A3 - Input validation on request body, path params, and query params**
+Pattern A (body): route files handling POST/PUT/PATCH must validate the request body using a validation library before processing.
+Grep: in all write route files, check for validation patterns from PATTERNS.md → A3.
+Flag: any write route without validation on the request body.
+Flag: raw path params fed into DB queries without format validation - an invalid format causes a DB error, leaking implementation details.
+Pattern C (query params): grep all route files for user-provided query parameters whose return value is used in DB filter calls without an explicit allowlist or schema validation.
+Flag: unvalidated query params used as DB filter inputs.
+
+**CHECK A4 - Raw user input in SQL/queries**
+Pattern: template literals or string concatenation used to build database queries with user-provided values.
+Grep: string interpolation or concatenation in query construction - see PATTERNS.md → A4 for stack-specific patterns.
+Flag: any query built with string concatenation from user input. Use parameterized queries instead.
+
+**CHECK A5 - Sensitive fields in API responses**
+Pattern: API routes returning full objects that may include sensitive fields.
+Grep: routes selecting all columns (see PATTERNS.md → A5) AND returning the full result to the client without explicit field filtering.
+
+**CHECK A6 - Cron/job routes missing secret check**
+Flag: any job/cron route that does NOT verify a shared secret or API key before execution.
+
+**CHECK A7 - Export routes missing role check**
+Scope: any route file whose path contains 'export' or that returns `Content-Type: text/csv` or `application/vnd.openxmlformats`.
+Grep: files containing `text/csv|Content-Disposition.*attachment|application/vnd.openxml`.
+Flag: any export route without an explicit role assertion.
+
+**CHECK A8 - Client-exposed environment variable secret leak**
+Scope: all source files and `.env*` files.
+Pattern: environment variables with client-side prefixes (see PATTERNS.md → A8 for framework prefix list) whose names contain secret-like suffixes (`KEY`, `SECRET`, `TOKEN`, `PASSWORD`).
+Flag: any client-prefixed variable that contains a secret-like suffix. These variables are inlined into the client bundle and visible to all users.
+Note: public API URLs and non-secret anon keys are expected - exclude those.
+
+**CHECK A9 - Privileged credentials in client-side code**
+Scope: all client-side source files (see PATTERNS.md → A9 for client-side markers per framework).
+Pattern: grep for privileged credential references (see PATTERNS.md → A9 for credential patterns).
+Flag: any match. Privileged credentials bypass access control - their presence in client-side code exposes them to every user.
+
+**CHECK A10 - Public URL for private storage assets**
+Scope: all route files and utility files that handle file/document/attachment operations.
+Pattern: public URL generation (see PATTERNS.md → A10) in files that handle private assets (documents, contracts, receipts).
+Flag: any public URL call for a private asset. Private assets must use signed/temporary URLs with a TTL.
+Note: explicitly public storage (avatars, public uploads) is expected - exclude those.
+
+**CHECK A11 - Open redirect**
+Pattern: redirect calls where the URL argument derives from user-controlled input (query params, request body, path params) without an explicit allowlist check.
+Flag: any redirect where the target URL is constructed from user-controlled input.
+
+**CHECK A12 - Mass assignment**
+Scope: all route files handling POST/PUT/PATCH.
+Pattern: find where the raw request body object is passed wholesale to a DB write operation without explicit field destructuring or schema validation first.
+Flag: any route where the raw body is inserted/updated directly.
+Note: routes that validate through a schema before inserting are safe - exclude those.
+
+**CHECK A13 - Horizontal access control / IDOR**
+For each dynamic route:
+Step 1 - identify how the caller's identity is resolved (grep for auth patterns from PATTERNS.md → A1).
+Step 2 - verify that the DB query filters by the caller's identity or scope, not just by the URL parameter alone.
+Insecure pattern: filtering only by the requested ID without verifying ownership - any authenticated user can access any record by guessing IDs.
+Flag: each route where ownership/scope is not enforced server-side in the query.
+
+**CHECK A14 - State machine enforcement on transition routes**
+For each status-changing route:
+Step 1 - verify the route reads the CURRENT state from the DB before applying the transition (grep for a SELECT/read query before the UPDATE in the same handler).
+Flag: any transition route that does NOT verify current state server-side before applying the update. Skipping a required intermediate state is both a business logic violation and a potential abuse path."
+
+---
+
+## Step 3 - Response shape review (main context)
+
+For the 10 most-used API routes (identified from `[SITEMAP_OR_ROUTE_LIST]`):
+
+**R1 - Sensitive field exposure**
+Identify fields containing PII, financial data, or credentials (e.g. tax IDs, bank account numbers, password flags). Verify these are NOT returned to non-admin/non-owner callers.
+
+**R2 - Financial/restricted data exposure**
+Verify that financial records, compensation data, or other restricted entities are not exposed beyond their authorized audience.
+
+**R3 - Error message verbosity**
+Scan 5 route handlers for error handling blocks. Verify internal error messages (DB errors, stack traces) are NOT forwarded to the client response.
+Expected: generic error messages returned to client - never raw error details that may contain schema or internal state information.
+
+**R4 - Domain data scoping**
+Users can only see records scoped to their ownership or authorized scope (via ownership checks, row-level policies, or equivalent access control).
+
+**R5 - Rate limiting on high-value endpoints**
+- Any export route (bulk data)
+- Any bulk-action route
+Note: absence of rate limiting is a Medium finding for an internal app - flag it, don't treat as Critical.
+
+---
+
+## Step 3b - Database security advisors *(if available)*
+
+If your database platform provides automated security advisors (e.g. Supabase Security Advisors via MCP, AWS RDS recommendations), run them and include results:
+
+For each finding returned:
+- Error/critical level → **Critical** finding
+- Warning level → **High** finding
+- Info level → **Low** / informational
+
+Include the full list in the report output. Do not suppress any result.
+If no automated advisors are available, skip this step and note it in the report.
+
+---
+
+## Step 3c - Dependency CVE audit
+
+**Pinned MCP server (v1.20+): `mcp-nvd`** ([github.com/marcoeg/mcp-nvd](https://github.com/marcoeg/mcp-nvd)) — exposes the NVD CVE database via two tools: `mcp__mcp-nvd__get_cve` (lookup by CVE ID) and `mcp__mcp-nvd__search_cve` (keyword + product search). Wire it up in `~/.claude/.mcp.json` or project-scoped `.mcp.json` with the user's NVD API key.
+
+### Step 3c.A — MCP-aware path (when available)
+
+If the `mcp-nvd` MCP tools are available in the current session (frontmatter declares them, server reachable):
+
+1. For each direct production dependency in the project's manifest, call `mcp__mcp-nvd__search_cve` with the package name + ecosystem tag.
+2. For each result, capture: CVE ID, severity (CVSS v3), affected version range, fixed version, publication date.
+3. Cross-reference against the manifest version. Skip CVEs with `affected_version_max < installed_version`.
+
+The MCP path returns CVEs as fresh as the NVD feed (typically < 24h lag) instead of the local audit cache (typically ≥ 1 release behind).
+
+### Step 3c.B — Fallback path (MCP unavailable)
+
+If `mcp-nvd` is not configured or returns an error, fall back to local audit commands. Print explicitly: `"⚠ mcp-nvd unavailable, falling back to local audit (snapshot may be stale)."`
+
+Run the appropriate dependency audit for the project's package manager:
+- Node.js: `npm audit --json --omit=dev` or `yarn audit --json`
+- Python: `pip-audit` or `safety check`
+- Ruby: `bundle-audit check`
+- Go: `govulncheck ./...`
+- Rust: `cargo audit`
+- Java/Kotlin: `mvn dependency-check:check` or `./gradlew dependencyCheckAnalyze`
+- .NET: `dotnet list package --vulnerable`
+- Swift: check Package.resolved for known CVEs
+
+### Step 3c.C — Severity classification (both paths)
+
+For each finding, record:
+- Package name and affected version range
+- CVE ID (if available)
+- Brief description
+- Whether a fix is available
+
+Flag any `critical` CVE in a production dependency as a **Critical** finding.
+Flag any `high` CVE as a **High** finding.
+`moderate` and `low` → note in report but do not add to backlog unless directly exploitable in this app's context.
+
+If both the MCP path and the fallback audit command are unavailable, note it explicitly in the report and skip — do not silently proceed without dependency CVE coverage.
+
+---
+
+## Step 3d - Row-level access control completeness check
+
+Complement Step 3b (DB advisors) with a grep-based check on migration or schema files.
+
+**RLS-1 - Tables without row-level access control**
+Grep migration/schema files for table creation statements. For each table, check if row-level access control is enabled (e.g. `ENABLE ROW LEVEL SECURITY` in PostgreSQL, application-level guards in other stacks).
+Flag: any table storing user-scoped data where row-level access control is absent.
+Note: tables with only service-role access (e.g. internal log tables) may legitimately skip this - verify from context.
+
+**RLS-2 - Access control enabled but no policies**
+For each table with row-level access control enabled, verify that at least one access policy exists.
+Flag: any table with access control enabled but zero policies. This can cause silent empty results, masking bugs.
+
+**RLS-3 - Missing write-side policy checks**
+For databases with row-level policies: verify that INSERT/UPDATE policies include write-side checks (e.g. `WITH CHECK` in PostgreSQL).
+Flag: policies that control reads but not writes - this allows inserting/updating rows the user cannot see.
+
+---
+
+## Step 3e - Native application security checks
+
+**This step runs only when the project uses a native or non-web stack** (check CLAUDE.md Language field: Swift, Kotlin, Rust, Go, Python, Ruby, Java, C#). For web-only projects (Node.js/TypeScript with a web frontend), skip to Step 4.
+
+These checks supplement the API-level checks in Step 2. They audit the application's own security posture beyond its HTTP surface.
+
+### Stack-specific security checklist
+
+[SECURITY_CHECKLIST_ITEMS]
+
+### NS1 - Secrets management audit
+Grep all source files for patterns that indicate hardcoded secrets:
+- String literals containing `password`, `secret`, `token`, `key`, `api_key` (case-insensitive)
+- Base64-encoded strings longer than 40 characters in source (potential embedded credentials)
+- Configuration files committed to git that contain non-placeholder secret values
+
+Flag: each hardcoded secret. Secrets must come from environment variables, platform keychain, or a secrets manager.
+
+### NS2 - Dependency vulnerability scan
+Run the same dependency audit as Step 3c (adapt the command to the native stack's package manager).
+Flag: Critical/High CVEs as Critical/High findings. Medium/Low CVEs noted in report.
+
+### NS3 - Input validation on external boundaries
+For each entry point (CLI args, file parsing, IPC, network input, URL schemes, deep links, clipboard data):
+- Verify input is validated/sanitized before use
+- Check for path traversal in file operations (user input in file paths)
+- Check for command injection (user input passed to shell execution or subprocess)
+- Check for buffer overflow risk in languages without bounds checking
+
+Flag: each unvalidated external input.
+
+### NS4 - Platform security checks
+Execute each item from the stack-specific checklist above as a targeted grep/read check. See PATTERNS.md → NS4 for per-language grep patterns and flag conditions.
+
+Flag: each violation with severity based on exploitability.
+
+### NS5 - Sensitive data protection
+- Verify sensitive data written to disk uses platform encryption (see PATTERNS.md → NS4 for platform-specific mechanisms)
+- Check that temporary files with sensitive content are deleted after use
+- Verify no sensitive data in logs (grep for log/print statements near secret/token/password handling)
+- Check that error messages do not expose internal state or stack traces to users
+
+Flag: each unprotected sensitive data path.
+
+### NS6 - Code signing and distribution
+- No signing credentials, provisioning profiles, or keystores committed to repository (grep for `.p12`, `.mobileprovision`, `.keystore`, `.jks`, `.pem`, `.key` in tracked files)
+- No disabled code signing workarounds in build config
+- CI/CD signing credentials sourced from environment variables or secure storage, not checked-in files
+
+Flag: each signing credential in repository as Critical.
+
+---
+
+## Step 4 - HTTP security headers check
+
+**Static check**: read the server/framework configuration file (e.g. `next.config.ts`, `nginx.conf`, `helmet()` config). Verify these headers are configured:
+
+| Header | Expected | Risk if missing |
+|---|---|---|
+| `X-Frame-Options` | `DENY` or `SAMEORIGIN` | Clickjacking |
+| `X-Content-Type-Options` | `nosniff` | MIME sniffing |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` | Referrer data leakage |
+| `Content-Security-Policy` | Present (even permissive) | XSS escalation |
+| `Permissions-Policy` | camera/mic/geolocation denied | Feature abuse |
+
+**Live check** (staging): curl the staging URL and compare actual headers received vs configuration. A header present in config but absent in the response indicates a misconfiguration.
+
+Flag: any header present in config but absent in live response - this means the config is ineffective.
+
+---
+
+## Step 5 - Proxy / middleware check
+
+- API routes are not accessible without a valid session token (no CORS bypass path)
+- Auth-gated redirects (e.g. password change, onboarding) are enforced at the server/proxy level, not just client-side
+- Public route whitelists are narrow - specific paths only, not wildcard prefixes that could expose other routes
+- Each whitelisted path has a comment explaining why it is public
+- The proxy does not trust any header that could be forged by the client to bypass auth (e.g. `X-User-Role`, `X-Is-Admin`)
+
+---
+
+## Step 6 - Produce report and update backlog
+
+### Output format
+
+Generate the report using the template in `${CLAUDE_SKILL_DIR}/REPORT.md`. Apply the severity guide from the same file.
+
+### Backlog decision gate
+
+Present all findings with severity Medium or above as a numbered decision list, sorted Critical → High → Medium:
+
+```
+Found N findings at Medium or above. Which to add to backlog?
+
+[1] [CRITICAL] SEC-? - route/file - one-line description
+[2] [HIGH]     SEC-? - route/file - one-line description
+[3] [MEDIUM]   SEC-? - route/file - one-line description
+...
+
+Reply with numbers to include (e.g. "1 2 4"), "all", or "none".
+```
+
+**Wait for explicit user response before writing anything.**
+
+Then write ONLY the approved entries to `docs/refactoring-backlog.md`:
+- Assign ID: `SEC-[n]`
+- Add to priority index
+- Add full detail section with exploit scenario and recommended fix
+
+---
+
+## Execution notes
+
+- Do NOT modify any route, config, or migration file.
+- SEO, robots.txt, meta tags, sitemaps, and public indexing are explicitly OUT OF SCOPE.
+- **Server-side form actions**: if the framework supports server-side form actions (e.g. Next.js Server Actions, SvelteKit form actions, Remix actions), treat them as directly-reachable POST endpoints and audit with the same auth/authz/validation checks. Note as N/A if absent.
+- After the report, ask: "Should I implement the Critical/High fixes identified?"

--- a/plugin/skills/simplify/SKILL.md
+++ b/plugin/skills/simplify/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: simplify
+description: Scan changed files for complexity patterns: deep nesting, local duplication, dead code, magic values, conditional simplification. Apply minimal safe refactors to improve readability.
+user-invocable: true
+model: haiku
+context: fork
+---
+
+## Applicability
+
+Run on files changed in the current block after writing (Phase 2). Skip for trivial 1-file changes with <20 lines modified.
+
+**Input**: the user invokes `/simplify` optionally followed by file paths. If no paths given, use `git diff --name-only HEAD` to find changed files. Filter to source files only (skip config, docs, generated files).
+
+---
+
+## Step 1 - Scan each file for simplification opportunities
+
+For every source file in scope, check these 6 patterns:
+
+### S1 - Early returns
+Nested `if/else` where the `else` (or `if`) branch is a short return, throw, or continue. Invert the condition and return early to flatten the block.
+
+### S2 - Nesting depth
+Any block nested >3 levels deep. Extract the inner logic into a named function, or apply guard clauses (S1) to reduce depth.
+
+### S3 - Local duplication
+Two or more blocks within the same file that repeat the same logic (>3 lines identical or near-identical). Extract into a local helper.
+
+### S4 - Conditional simplification
+- Ternaries nested inside ternaries
+- Boolean expressions that can collapse (`if (x) return true; return false;` → `return x;`)
+- Switch/match with identical arms that can be merged
+
+### S5 - Dead code
+- Unreachable code after return/throw/break
+- Commented-out code blocks (>3 lines)
+- Unused local variables, parameters, or imports (only flag if confidence is high)
+
+### S6 - Magic values
+Repeated literal values (strings, numbers) used >2 times in the same file. Extract to a named constant at file/module scope.
+
+---
+
+## Step 2 - Apply fixes
+
+For each finding:
+1. Apply the simplification directly using the Edit tool.
+2. Keep changes minimal - do not restructure surrounding code.
+3. Preserve existing tests - if a rename would break imports, skip it.
+
+---
+
+## Step 3 - Summary
+
+Output a compact summary:
+
+```
+/simplify - [N] files scanned, [M] changes applied
+
+| File | Change | Pattern |
+|---|---|---|
+| path/to/file.ext | description of change | S1/S2/S3/S4/S5/S6 |
+```
+
+If no changes needed: `/simplify - [N] files scanned, all clean ✓`

--- a/plugin/skills/skill-dev/SKILL.md
+++ b/plugin/skills/skill-dev/SKILL.md
@@ -1,0 +1,368 @@
+---
+name: skill-dev
+description: Code quality audit: detect cross-module coupling, N+1 queries, dead exports, antipatterns, over-large components. Cross-checks against refactoring backlog.
+user-invocable: true
+model: sonnet
+context: fork
+---
+
+## Configuration (adapt before first run)
+
+> Replace these placeholders:
+> - `[LINT_COMMAND]` - project's lint command - e.g. `eslint .`, `ruff check`, `cargo clippy`, `go vet ./...`, `swiftlint lint`, `rubocop`, `dotnet format --verify-no-changes`. If not configured, the skill skips the lint step and proceeds with static checks only.
+
+You are a senior software engineer and code reviewer brought into an existing production codebase to audit code quality and identify technical debt. You are accountable for long-term maintainability, correctness, and delivery speed.
+
+**Operating mode for this skill**: Audit only - no code changes. Anchor every finding to concrete file paths and code evidence. Do not inflate severity. Distinguish facts from inferences.
+
+Do not optimize for theoretical purity. Optimize for pragmatic, production-grade engineering decisions.
+
+**Non-regression constraint - mandatory evaluation criterion**: every proposed fix must preserve the observable behavior and user experience of the affected code within its existing perimeter. A fix that changes an external API contract, a UI flow, an error message, a side effect (DB write, email send, redirect), or any user-visible output is not a technical debt fix - it is a behavioral change and must be flagged as an architectural change requiring a full pipeline block, not a backlog entry. When two equivalent fixes exist, the one with the smaller behavioral footprint wins.
+
+**Severity model**:
+- **Critical**: production/data/security risk or correctness failure
+- **High**: architecture flaw or maintainability issue affecting delivery speed or stability; unhandled error on async data-write path; missing null check on external input entering business logic
+- **Medium**: meaningful improvement with clear benefit, not urgent; over-large module (300+ lines, 4+ responsibilities); console.log in production code
+- **Low**: TODO comments; consolidation opportunities; magic enum strings already covered by type definitions
+
+---
+
+## Applicability check
+
+Before Step 0: check `CLAUDE.md` for the Framework and Language fields.
+
+**Component UI frameworks** (Next.js, React, Vue, Svelte, Angular, or any stack with a client-side component architecture): run all checks D1-D10, J1-J5 - proceed to Step 0.
+
+**Server-rendered web frameworks** (Django, Rails, Laravel, Flask, Express without a frontend component framework, Phoenix, or any web framework without client-side components): several checks target component-framework patterns. Proceed to Step 0 with these adjustments:
+
+Skip entirely:
+- CHECK D2 - Duplicated inline color/status maps (component framework only)
+- CHECK D9 - Lifecycle/side-effect antipatterns (component UI frameworks only)
+- CHECK J3 - Client/server boundary placement (SSR component frameworks only - e.g. Next.js, Nuxt)
+
+Run with adaptation:
+- CHECK D1 - Adapt from component imports to module/app imports for the project's framework
+- CHECK D4 - Adapt "dead exports" to the language's public API surface (see PATTERNS.md → D4)
+- CHECK D8 - Use the language-specific suppression patterns (see PATTERNS.md → D8)
+
+Run as-is (stack-agnostic):
+- CHECK D3 (N+1 - adapt to the project's ORM, see PATTERNS.md → D3), D5, D6, D7, D10
+- CHECK J1 (over-large modules), J2 (data clumps), J4 (utility consolidation - adapt directory name), J5 (typed languages only)
+
+Run additionally (language-specific - CHECK DL1).
+
+**Native or backend-only stacks** (Swift, Kotlin, Rust, Go, .NET/C#, Java, Python without a web frontend): Proceed to Step 0 with these adjustments:
+
+Skip entirely:
+- CHECK D1 - Cross-module import patterns (web frameworks only)
+- CHECK D2 - Duplicated inline color/status maps (component framework only)
+- CHECK D3 - ORM/client N+1 fetch patterns (ORM-specific - run if your project uses an ORM)
+- CHECK D8 - Type safety suppressions - Pattern A (directive suppressions) is covered by DL1. For typed native languages (Swift, Kotlin, Rust, Go, .NET): still run Pattern C (floating promises/unhandled async) if applicable.
+- CHECK D9 - Lifecycle/side-effect antipatterns (UI frameworks only)
+- CHECK J3 - Client/server boundary placement (SSR frameworks only)
+
+Run with adaptation:
+- CHECK D4 - Adapt "dead exports" to the language's public API surface (see language note in D4)
+
+Run as-is (stack-agnostic):
+- CHECK D5 (duplicated validation logic), D6 (magic strings/numbers), D7 (TODO/FIXME/HACK)
+- CHECK D10 (empty catch blocks, debug output in production)
+- CHECK J1 (over-large modules), J2 (data clumps), J4 (utility consolidation - adapt directory name to your project's equivalent), J5 (typed languages only)
+
+Run additionally (language-specific - CHECK DL1).
+
+**Language-specific checks (DL1)** - run for server-rendered web and native/backend stacks. See PATTERNS.md → DL1 for per-language grep patterns, lint commands, and flag conditions.
+
+**Lint command**: `[LINT_COMMAND]` - run before the audit if available. Include lint output summary in the report.
+
+Announce skipped checks and reason at the top of the audit report.
+
+---
+
+## Step 0 - Target resolution
+
+Parse `$ARGUMENTS` for a `target:` token.
+
+| Pattern | Meaning |
+|---|---|
+| `target:section:<name>` | Focus on a specific feature area - e.g. `target:section:auth`, `target:section:billing`, `target:section:dashboard`. Any section name matching a module/directory in the project is valid. |
+| No argument | **Full audit - the ENTIRE codebase: all page files, all components, all lib/ files, all API routes, all types. Build from sitemap.md + filesystem scan of components/ and lib/. Maximum depth.** |
+
+**STRICT PARSING - mandatory**: derive target ONLY from the explicit text in `$ARGUMENTS`. Do NOT infer target from conversation context, recent work, active block names, or project memory. If `$ARGUMENTS` contains no `target:` token → full codebase audit at maximum depth. When a target IS provided → act with maximum depth and completeness on that specific scope only.
+
+Announce: `Running skill-dev - scope: [FULL | target: <resolved>]`
+Apply the target filter to the file list in Step 1.
+
+`docs/sitemap.md` is the authoritative inventory when present. Build the file list from it - do NOT scan the filesystem freely. If `docs/sitemap.md` does not exist (e.g. native or CLI projects), build the file list from a filesystem scan of the project's source directories as identified in `CLAUDE.md` Tech Stack and Key Commands sections.
+
+---
+
+## Step 1 - Read structural guides
+
+Read in order:
+1. `docs/refactoring-backlog.md` - read in full if it exists. If the file does not exist, skip deduplication and debt-density checks (treat as empty backlog). Use it for two purposes:
+   - **Deduplication**: do not re-report a finding already present (including resolved ✅ entries - resolved entries confirm a fix was applied, not that the pattern cannot recur elsewhere).
+   - **Debt density context**: for each module/file in the target list, count how many existing open entries it has. A module with 3+ open entries is a **high-debt zone** - new findings there carry elevated priority regardless of check category, because accumulated debt signals systemic fragility, not isolated issues.
+
+Output: (a) structured file list, (b) high-debt zone map (module → open entry count). Do not proceed until both files are read.
+
+---
+
+## Step 2 - Launch Explore agent in background
+
+**Launch immediately with `run_in_background: true`, then proceed to Step 3 without waiting.**
+
+Pass the full file list from Step 1 to a Haiku Explore agent. **Before copying the prompt below**: remove any checks marked "Skip entirely" in the Applicability section for the detected stack category. Only include checks that are "Run as-is" or "Run with adaptation" for this project. Do not send skipped checks to the subagent.
+
+"Read `${CLAUDE_SKILL_DIR}/PATTERNS.md` for stack-specific grep patterns. Run the checks below on ONLY the files provided. For each check: state total match count, list every match as `file:line - excerpt`, and state PASS or FAIL.
+
+**CHECK D1 - Cross-module direct imports (coupling)**
+Pattern: modules importing directly from other feature modules instead of going through a shared layer (e.g. `features/admin/` importing from `features/billing/`).
+Grep across source files for imports that cross feature boundaries - any import referencing a different feature subfolder. For each match, flag it if the importing module's feature area differs from the imported module's feature area AND the import does not go through a shared `lib/`, `utils/`, or `common/` layer.
+Expected: flag each cross-feature import as an explicit coupling.
+
+**CHECK D2 - Duplicated inline status/color maps**
+Pattern: object literals mapping status strings to CSS classes or style tokens (e.g. `{ PENDING: 'warning-class', APPROVED: 'success-class' }`).
+Flag: any file with this pattern NOT already importing from a shared status-badge or style-maps utility.
+Expected: all status-to-style maps centralised in a single utility.
+
+**CHECK D3 - N+1 fetch patterns in components and API routes**
+Pattern A: any database query call inside a `.map(`, `for (`, `forEach(`, or `for...of` loop. See PATTERNS.md → D3 for DB client method patterns per ORM.
+Grep for your project's DB client method pattern - then check if it appears inside an iteration block.
+Flag ALL matches - any database query inside a loop is a potential N+1.
+Pattern B: sequential `await` calls to the DB client inside a loop body.
+Flag: each match with file:line.
+
+**CHECK D4 - Dead public API surface (sampled: 5 largest files)**
+*This is a sampled check - not exhaustive. Mark all findings as `(sampled)`. A full dead-export audit requires a dedicated tool such as `knip`.*
+Pattern: publicly accessible symbols that are never referenced elsewhere. See PATTERNS.md → D4 for per-language public symbol patterns.
+For the 5 largest source files by line count: grep each public symbol across all other files.
+Flag: symbols with 0 consumers outside their own file.
+
+**CHECK D5 - Duplicated validation logic**
+Pattern: the same field validation appearing in more than one API route handler or controller.
+Flag: identical guard patterns in 3+ routes that are not using a shared validation schema or utility.
+
+**CHECK D6 - Magic strings and magic numbers**
+*Magic strings* - state machine values hardcoded as string literals in source files:
+Grep across source files (not test files, not type definitions):
+Flag: any string literal that should reference a shared enum/constant.
+Grep for numeric literals that look like business constants (rates, limits, TTL durations) - exclude lines matching: `PORT=|timeout|delay|setTimeout|setInterval|HTTP_STATUS|ms\b|px\b`.
+Expected: 0 unextracted magic numbers in business logic paths.
+
+**CHECK D7 - TODO/FIXME/HACK comments**
+Grep: `\bTODO\b|\bFIXME\b|\bHACK\b|\bXXX\b` across all files in scope.
+Flag: each match with context.
+
+**CHECK D8 - Type safety suppressions** *(typed languages only - skip for dynamically typed languages)*
+See PATTERNS.md → D8 for per-language suppression patterns, untyped escape hatches, and floating promise detection.
+Pattern A - Directive suppressions: grep for the language's type safety suppression directives. Highest severity for blanket suppressions (file-level or undescribed).
+Pattern B - Untyped escape hatches (TypeScript): grep for explicit `any` usage in non-test source files. Exclude generated type files, vendor types, and explicit exemptions in CLAUDE.md Known Patterns.
+Pattern C - Floating promises: grep for async calls that appear as bare statements without `await`, `void`, `return`, or error handling. These are silent fire-and-forget calls.
+
+**CHECK D9 - Lifecycle/side-effect antipatterns** *(UI frameworks only - see PATTERNS.md → D9 for framework-specific hooks. Skip for non-UI projects.)*
+Pattern A - Derived state stored in state + updated via lifecycle hook:
+Flag components where a side-effect hook's only purpose is to sync derived state - the value is computable during render/init.
+Pattern B - Event handler logic inside lifecycle hooks:
+Flag any lifecycle hook whose body contains navigation, toasts, or notifications - these belong in event handlers, not effects.
+Pattern C - Missing cleanup or dependency tracking:
+Flag side-effect hooks with no dependency specification (runs on every render) or missing cleanup for subscriptions/timers.
+Expected: 0 matches for A and C. B requires judgment.
+
+**CHECK D10 - Empty catch blocks and debug output in production**
+Pattern A - Empty or near-empty catch blocks:
+Grep for catch blocks that swallow errors silently or log them without recovery or user feedback.
+Flag: catch blocks with empty bodies, comment-only bodies, or log-only bodies without error recovery.
+Pattern B - Debug output in production:
+Grep for debug/logging statements in source directories (excluding test files). See PATTERNS.md → D10 for per-language debug output patterns.
+Debug-level logging in catch blocks is acceptable only if also returning an error response."
+
+---
+
+## Step 3 - Structural judgment checks (runs in parallel with Step 2)
+
+**Begin immediately after launching the Step 2 agent - do not wait for it.**
+
+**J1 - Over-large components**
+Flag components that are:
+- Over 300 lines AND have 4+ distinct responsibilities (fetch, state, form handling, display)
+- Exhibit "divergent change" - compensation logic AND display logic in the same file
+- Exhibit "feature envy" - a component that uses more data/methods from another domain than its own
+
+**J2 - Data clumps and parameter threading**
+
+Check A - Data clumps: flag any function, method, or component that receives 4+ parameters that always travel together across 3+ call sites. These grouped parameters should be extracted into a named struct, type, or configuration object.
+Grep for function/method signatures with 4+ parameters. Cross-reference: if the same group appears in 3+ locations, it is a data clump.
+
+Check B - Deep parameter threading (prop drilling in UI frameworks, parameter passing in backend/native): flag cases where a value is passed through 3+ intermediate layers without being used by the intermediaries. The value originates at layer N and is consumed at layer N+3 or deeper, with layers N+1 and N+2 only forwarding it.
+For UI frameworks: trace props from parent to grandchild components. For backend/native: trace constructor or method parameters through call chains.
+
+Flag each match with: file path, parameter group or threaded value, depth of threading, and suggested refactor (extract type, use context/DI, or restructure call chain).
+
+**J3 - Client/server boundary placement** *(frameworks with client/server split only - e.g. Next.js, Nuxt, SvelteKit. Skip for SPAs, backends, and native apps.)*
+
+Read the main layout and the 5 most-visited page files from `[SITEMAP_OR_ROUTE_LIST]`.
+
+Check 1 - Client-side directive at page/layout level when only a subcomponent needs it.
+
+Check 2 - Context/state providers placed too high in the component tree, preventing server-side optimization of child subtrees.
+
+Check 3 - Server secrets imported into client-side files. Grep for client-marked files importing modules that access server-only environment variables.
+
+Check 4 - Missing server-side directive on server actions or mutations.
+
+Flag each issue with: file path, current placement, recommended refactor.
+
+**J4 - Shared utility consolidation**
+Read the shared utilities directory listing (`lib/`, `utils/`, `helpers/`, or equivalent). Flag any utilities with overlapping purposes (e.g. two date formatting helpers, two notification builder functions, any constant or mapping object defined independently in 2+ files without being extracted to a shared location).
+Do not re-report overlaps already in `docs/refactoring-backlog.md`.
+
+**J5 - Type definition consolidation** *(typed languages only)*
+Read the shared types file (e.g. `lib/types.ts`, `types/`, or equivalent). Flag:
+- Types defined inline in source files that are used in 3+ places (should live in a shared types file)
+- Response types that duplicate auto-generated types (should extend the generated types instead)
+- Inheritance chains where the parent type is never used independently (prefer composition or a union type)
+
+---
+
+## Step 3b - Hotspot priority (churn × debt)
+
+Skip this step if the project is not a Git repository. Otherwise compute a remediation priority matrix that intersects per-file debt count with code churn — the file the team has touched the most and that also has the most findings is what to fix first.
+
+**Churn signal**:
+```bash
+git log --since="6.months.ago" --numstat --pretty=tformat: -- <project source paths> 2>/dev/null \
+  | awk '$3 != "" && $3 !~ /^node_modules/ && $3 !~ /^vendor/ && $3 !~ /^dist/ && $3 !~ /^build/ {print $3}' \
+  | sort | uniq -c | sort -rn | head -50
+```
+
+For each unique file in the union of (Step 2 D1–D10 matches, Step 3 J1–J5 matches), record:
+- `debt_count` — number of distinct findings across D1–D10 and J1–J5 that point at this file
+- `churn` — number of commits touching this file in the last 6 months (from the command above; cap to recent activity, not whole history)
+
+**Priority matrix**:
+
+| Quadrant | debt_count | churn | Priority |
+|---|---|---|---|
+| Q1 — Hot mess | ≥ 3 | top 25% of churn | **P1 — fix first** (read often, high debt) |
+| Q2 — Stable rot | ≥ 3 | bottom 50% of churn | P2 — schedule (low traffic, but real debt) |
+| Q3 — Flaky frontier | 1–2 | top 25% of churn | P2 — watch (read often, low debt today, may grow) |
+| Q4 — Cold corner | 1–2 | bottom 50% of churn | P3 — backlog only (low traffic + low debt) |
+
+The point is to **rank backlog work by leverage**, not to add findings. Files in Q1 are the same files Step 2/3 already flagged — Step 3b only re-orders them.
+
+**Configuration**: the 6-month window is the universal default. For very young projects (< 6 months of history), the window collapses to "all available history" automatically (`git log --since` simply returns everything if the repository is younger). For long-lived monorepos where 6 months is too noisy, set a `# skill-dev: hotspot_window=N.months.ago` comment in the project's `CLAUDE.md` (consumed by future iterations of this skill — for v1.22 the window is hard-coded).
+
+The hotspot table goes in the report between "Findings requiring action" and "Backlog decision gate". It does not gate the backlog: every finding above Low severity still goes through Step 4 unchanged.
+
+## Step 4 - Wait for Step 2 agent, then produce combined report
+
+**Wait for the Step 2 Explore agent to complete before proceeding.**
+
+Cross-check all findings from Step 2 (D1–D10) and Step 3 (J1–J5) against `docs/refactoring-backlog.md`. Exclude any finding already documented.
+
+For remaining findings, apply severity modifiers in this exact order:
+1. **Base severity** - assign from the check category using the Severity guide at the bottom of this step.
+2. **Debt-density escalation** - if the finding's file/module is in the high-debt zone (3+ open entries in `docs/refactoring-backlog.md`), escalate by one level (Low → Medium, Medium → High, High → Critical). Document: `"Debt-density escalation: N open entries in this module."` Do not escalate above Critical.
+3. **Regression risk downgrade** - if the `Regression risk` field is Behavior-adjacent, downgrade the severity by one level from the value produced in step 2. The final severity after both modifiers is what gets written to the backlog.
+
+### Output format
+
+```
+## Skill-Dev Audit - [today's date in YYYY-MM-DD format]
+### Scope: [N] files from sitemap.md
+### Sources: Refactoring.Guru smells taxonomy, language-specific lint rules, framework composition patterns
+
+### Pattern Checks (Explore agent)
+| # | Check | Matches | Severity | Verdict |
+|---|---|---|---|---|
+| D1 | Cross-module coupling | N | Medium | ✅/⚠️ |
+| D2 | Duplicated color maps | N | Medium | ✅/⚠️ |
+| D3 | N+1 fetch patterns | N | High | ✅/⚠️ |
+| D4 | Dead public API surface (sampled - 5 largest files) | N | Low | ✅/⚠️ |
+| D5 | Duplicated validation | N | Medium | ✅/⚠️ |
+| D6 | Magic strings + numbers | N | Medium | ✅/⚠️ |
+| D7 | TODO/FIXME comments | N | Low | ✅/⚠️ |
+| D8 | Type safety suppressions + floating promises | N | High | ✅/⚠️ |
+| D9 | Lifecycle/side-effect antipatterns | N | Medium | ✅/⚠️ |
+| D10 | Empty catch + debug output | N | Medium | ✅/⚠️ |
+
+### Language-Specific Checks (server-rendered web and native/backend stacks)
+| # | Check | Matches | Severity | Verdict |
+|---|---|---|---|---|
+| DL1 | Language-specific lint + analysis | N | Medium | ✅/⚠️ |
+
+### Structural Checks
+| # | Check | Verdict | Notes |
+|---|---|---|---|
+| J1 | Over-large components | ✅/⚠️ | |
+| J2 | Prop drilling + data clumps | ✅/⚠️ | |
+| J3 | Client/server boundary | ✅/⚠️ | |
+| J4 | lib/ consolidation | ✅/⚠️ | |
+| J5 | Type definition consolidation | ✅/⚠️ | |
+
+### Findings requiring action ([N] total)
+[Sorted Critical → High → Medium → Low]
+[file:line - check# - final-severity - issue - suggested fix for each]
+
+### Hotspot priority (churn × debt) — top 10
+| File | debt_count | churn (6mo) | Quadrant | Priority |
+|---|---|---|---|---|
+| path/to/file.ts | N | N | Q1 / Q2 / Q3 / Q4 | P1 / P2 / P3 |
+[10 rows max, sorted: Q1 first by debt_count desc, then Q2, then Q3, then Q4]
+
+If the project is not a Git repository or has < 5 files with both debt and churn, omit this table and note "Hotspot table skipped: insufficient signal."
+```
+
+### Backlog decision gate
+
+Present all findings with final severity Medium or above as a numbered decision list, sorted Critical → High → Medium:
+
+```
+Found N findings at Medium or above. Which to add to backlog?
+
+[1] [CRITICAL] DEV-? - file:line - one-line description
+[2] [HIGH]     DEV-? - file:line - one-line description
+[3] [MEDIUM]   DEV-? - file:line - one-line description
+...
+
+Reply with numbers to include (e.g. "1 2 4"), "all", or "none".
+```
+
+**Wait for explicit user response before writing anything.**
+
+Then write ONLY the approved entries to `docs/refactoring-backlog.md`.
+- Check existing entries first to avoid duplicates - assign `DEV-[n]` incrementing from the last DEV entry.
+- Add row to the Priority Index table.
+- Add full detail section using the format:
+
+```
+### [ID] - [Title]
+**Skill**: /skill-dev
+**Severity**: Critical | High | Medium | Low
+**File(s)**: path/to/file.ts:line
+**Finding**: concrete description anchored to file:line evidence
+**Suggested fix**: smallest behavior-preserving change
+**Regression risk**: Behavior-preserving | Behavior-adjacent (see constraint above)
+**Debt context**: [N open entries in this module - debt-density escalation applied | No prior debt]
+**Added**: [today's date in YYYY-MM-DD format]
+```
+
+Each entry **must** include a `Regression risk` field:
+- **Behavior-preserving** (pure refactoring - no change to external contracts, UI, DB writes, emails, redirects): proceed at the assigned severity.
+- **Behavior-adjacent** (fix touches a path that could affect observable output): downgrade severity by one level AND add the note `"Requires dedicated pipeline block - not a fast-lane fix."`. List the existing automated tests that cover the affected path - if none exist, add `"No coverage - regression risk is unverifiable without adding tests first."` and treat as Critical regardless of check category.
+- If the fix cannot be proven behavior-preserving from static analysis alone: default to behavior-adjacent.
+
+### Severity guide
+
+- **Critical**: type-safety suppression on a security/data path (see PATTERNS.md → D8 for per-language directives); N+1 in a hot path (list page, dashboard, frequently-called API); floating promise or fire-and-forget async on an auth or data-write handler; force unwrap on external input (see PATTERNS.md → DL1)
+- **High**: untyped escape hatch in shared utilities; dead public symbol in shared lib; empty catch on DB write; unhandled error on async data-write path
+- **Medium**: over-large module >300 lines with 4+ responsibilities (J1); magic business-rule numbers (D6); debug output in production (see PATTERNS.md → D10); data clumps >3 always-grouped parameters (J2)
+- **Low**: TODO comments; minor coupling; consolidation opportunities; magic enum strings already covered by type definitions; D4 sampled dead public symbols
+
+---
+
+## Execution notes
+
+- Do NOT make any code changes.
+- After producing the report, ask: "Should I implement the High/Critical priority fixes identified?"

--- a/plugin/skills/skill-security/SKILL.md
+++ b/plugin/skills/skill-security/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: skill-security
+description: Security scan for Claude Code skills using SkillSpector. Detects 64 vulnerability patterns — prompt injection, data exfiltration, MCP tool poisoning, supply chain, taint tracking, and more — before a skill is installed. Requires Python 3.12+ with `pip install skillspector`, or Docker as a fallback.
+user-invocable: true
+model: sonnet
+context: fork
+effort: medium
+argument-hint: [<path>|--llm]
+---
+
+**Scope**: scan a skill package (SKILL.md + any associated scripts) for security vulnerabilities before installation. Covers 64 patterns across 16 categories using SkillSpector (NVIDIA, Apache 2.0).
+
+**Out of scope**: application security audits (use `/security-audit` instead), scanning the project's own source code, fixing identified vulnerabilities.
+
+**Do NOT modify any file during the scan.**
+
+---
+
+## Step 0 — Preflight: verify SkillSpector availability
+
+Check availability in this order and announce which execution path will be used:
+
+### Path A — SkillSpector (pip)
+
+```bash
+python3 --version 2>&1 | head -1
+pip show skillspector 2>&1 | grep -E "^(Name|Version):"
+```
+
+If both return successfully (Python 3.12+ AND skillspector installed): proceed with **Path A**. Announce: `Using SkillSpector [version] via pip`.
+
+### Path B — Docker fallback
+
+If Path A is not available:
+
+```bash
+docker --version 2>&1 | head -1
+docker image ls skillspector 2>&1 | grep -c skillspector
+```
+
+If Docker is available: instruct the user to build the image if not already built:
+
+```
+Docker image not found. Build it with:
+  git clone https://github.com/NVIDIA/skillspector.git /tmp/skillspector
+  docker build -t skillspector /tmp/skillspector
+Then re-run this skill.
+```
+
+If the image exists: proceed with **Path B**. Announce: `Using SkillSpector via Docker`.
+
+### Neither available
+
+If neither Path A nor Path B is usable, stop and output:
+
+```
+SkillSpector is not available. Install it with one of:
+
+  pip install skillspector          # requires Python 3.12+
+  pipx install skillspector         # isolated install
+
+Or build the Docker image:
+  git clone https://github.com/NVIDIA/skillspector.git /tmp/skillspector
+  docker build -t skillspector /tmp/skillspector
+
+Then re-run: /skill-security [path]
+```
+
+Do not proceed further.
+
+---
+
+## Step 1 — Resolve scan target
+
+Parse `$ARGUMENTS` for a path and the `--llm` flag.
+
+| Argument pattern | Scan target | LLM mode |
+|---|---|---|
+| (none) | Current directory (`.`) | disabled |
+| `./path/to/skill/` | Specified directory | disabled |
+| `./SKILL.md` | Specified file | disabled |
+| `--llm` | Current directory | enabled |
+| `./path/to/skill/ --llm` | Specified directory | enabled |
+
+After resolving the path, verify it exists:
+
+```bash
+ls -la <resolved_path> 2>&1 | head -5
+```
+
+If the path does not exist: stop with `Target not found: <path>. Pass a valid skill directory or SKILL.md file.`
+
+Announce: `Scanning: <resolved_path> | LLM analysis: [enabled|disabled]`
+
+---
+
+## Step 2 — Execute static scan
+
+Run the static scan (no LLM) using the available execution path. Capture JSON output for structured parsing.
+
+### Path A (pip)
+
+```bash
+skillspector scan <resolved_path> --no-llm --format json 2>&1
+```
+
+### Path B (Docker)
+
+```bash
+docker run --rm -v "$PWD:/scan" skillspector scan <resolved_path> --no-llm --format json 2>&1
+```
+
+If the command exits with code 2 (error): report the stderr output and stop. A code 1 means risk_score > 50 and is expected — do not treat it as an error.
+
+Store the JSON output for Step 4 parsing.
+
+---
+
+## Step 3 — LLM analysis (opt-in)
+
+**Only run this step if `--llm` was passed in $ARGUMENTS.**
+
+Check if an LLM provider credential is available:
+
+```bash
+echo ${ANTHROPIC_API_KEY:+set} ${OPENAI_API_KEY:+set} 2>/dev/null
+```
+
+If `ANTHROPIC_API_KEY` is set:
+
+```bash
+SKILLSPECTOR_PROVIDER=anthropic skillspector scan <resolved_path> --format json 2>&1
+```
+
+If `OPENAI_API_KEY` is set (and no Anthropic key):
+
+```bash
+SKILLSPECTOR_PROVIDER=openai skillspector scan <resolved_path> --format json 2>&1
+```
+
+If no key is found: output a warning and proceed with the static-only results from Step 2:
+
+```
+⚠  --llm requested but no API key found.
+   Set ANTHROPIC_API_KEY or OPENAI_API_KEY and re-run to enable semantic analysis.
+   Showing static-only results (precision may be lower).
+```
+
+Replace the Step 2 JSON output with the LLM-enhanced JSON if the LLM scan succeeded.
+
+---
+
+## Step 4 — Present report
+
+Parse the JSON output and present the report in this format. Use the actual values from the JSON fields `risk_score`, `risk_severity`, `risk_recommendation`, and `filtered_findings` (or `findings` if `filtered_findings` is absent).
+
+---
+
+```
+## Skill Security Report
+
+Skill:       <basename of resolved_path>
+Source:      <resolved_path>
+Analysis:    [Static only | Static + LLM (claude-opus-4-6)]
+
+Risk Score:  <risk_score>/100
+Severity:    <risk_severity>
+Verdict:     <risk_recommendation>
+```
+
+### Severity badge
+
+| risk_severity | Display |
+|---|---|
+| LOW | `✅ LOW — SAFE TO INSTALL` |
+| MEDIUM | `⚠️  MEDIUM — REVIEW BEFORE INSTALLING` |
+| HIGH | `🔴 HIGH — DO NOT INSTALL` |
+| CRITICAL | `🚨 CRITICAL — DO NOT INSTALL` |
+
+### Findings (group by severity: CRITICAL → HIGH → MEDIUM → LOW)
+
+For each finding in the JSON array, output:
+
+```
+[SEVERITY] <rule_id> — <message>
+  Location:    <file>:<start_line>
+  Confidence:  <confidence as percentage>%
+  Finding:     <finding (matched snippet, if present)>
+  Explanation: <explanation>
+  Remediation: <remediation>
+```
+
+If there are zero findings: output `No security issues detected.`
+
+### Score breakdown
+
+Explain the score only when risk_score > 0:
+
+```
+Score breakdown:
+  CRITICAL issues × 50pts: <count>
+  HIGH issues × 25pts:     <count>
+  MEDIUM issues × 10pts:   <count>
+  LOW issues × 5pts:       <count>
+  Script multiplier (1.3×): [applied|not applied]
+```
+
+---
+
+### Closing
+
+If `risk_recommendation` is `DO NOT INSTALL`:
+
+```
+⛔ This skill has a risk score of <risk_score>/100 and should NOT be installed.
+   Address all CRITICAL and HIGH findings before using it.
+```
+
+If `risk_recommendation` is `CAUTION`:
+
+```
+⚠️  Review the findings above before installing this skill.
+   Run with --llm for deeper semantic analysis (reduces false positives to ~13%).
+```
+
+If `risk_recommendation` is `SAFE`:
+
+```
+✅ This skill passed the security scan. Safe to install.
+   Tip: run with --llm for semantic analysis if the skill includes executable code.
+```


### PR DESCRIPTION
## Summary

- Adds `.claude-plugin/plugin.json` manifest — plugin name `tierward`, skills at `./plugin/skills/`, hooks at `./plugin/hooks/hooks.json`
- Adds `plugin/skills/` with 8 governance skills (tier-S set + humanize): `commit`, `arch-audit`, `perf-audit`, `security-audit`, `simplify`, `skill-dev`, `skill-security`, `humanize`
- Adds `plugin/hooks/bootstrap-soft.mjs` — `UserPromptSubmit` hook that injects a compact one-line reminder of available `/tierward:*` skills into every session's system context
- Adds `marketplace.json` for private marketplace support: `claude plugin marketplace add marcoguillermaz/tierward`

## Coexistence model

CLI scaffolds `.claude/` (unnamespaced `/commit`, `/arch-audit`…). Plugin distributes the same skills namespaced (`/tierward:commit`, `/tierward:arch-audit`…) to any project without `npx tierward init`. No write to the user's `.claude/` directory — zero conflicts.

## Validation

`claude plugin validate .` → `✔ Validation passed`

1148 integration tests + 585 unit tests green locally.

## Install (after merge to main + SHA update)

```bash
claude plugin marketplace add marcoguillermaz/tierward
claude plugin install tierward@tierward
```

## Test plan

- [ ] `claude plugin validate .` in repo root — should pass
- [ ] `claude plugin install tierward@tierward` in a test project
- [ ] Verify `/tierward:commit` is available in a Claude Code session
- [ ] Verify bootstrap-soft hook emits the reminder on first prompt
- [ ] Verify no conflict with a project that has scaffolded `.claude/skills/commit/`

## Notes

- `marketplace.json` SHA is pinned to commit `f5730b0` (the plugin introduction commit). Update to merge commit SHA after staging → main promotion.
- Community marketplace submission (platform.claude.com/plugins/submit) is a follow-up step after merge.
- M3 (README rewrite via `/humanize`) is gated on this PR merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)