### PR TITLE
ci: remove --provenance from npm-publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   publish:
@@ -28,5 +27,7 @@ jobs:
 
       - run: npm test
 
-      - name: Publish with provenance
-        run: npm publish --provenance --access public
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}


### PR DESCRIPTION
## Summary

- Removes `--provenance` flag from `npm publish` — causes E404 on PUT to registry.npmjs.org when combined with Granular Access Token
- Removes `id-token: write` permission (no longer needed without provenance)
- Adds explicit `env: NODE_AUTH_TOKEN` mapping to the publish step for clarity

## Root cause

`npm publish --provenance` modifies the PUT request to include SLSA attestation data. This appears to conflict with npm Granular Access Token auth, causing a 404 from the registry even when the token has `read and write` access for the `tierward` package. Removing `--provenance` leaves a standard `npm publish --access public` call that authenticates correctly via `NODE_AUTH_TOKEN`.

## Test plan

- [ ] Workflow runs successfully after merge (will be tested via `workflow_dispatch`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)