### PR TITLE
chore(ci): switch npm publish to OIDC trusted publisher

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   publish:
@@ -29,5 +30,3 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}


### PR DESCRIPTION
## Summary

- Add `id-token: write` permission to use npm OIDC Trusted Publisher
- Remove `NODE_AUTH_TOKEN` — not needed with OIDC authentication
- npm now authenticates automatically via the configured Trusted Publisher (`marcoguillermaz/Tierward` → `npm-publish.yml`)

## Why

The granular access token was returning 404 on `npm publish`. npm's OIDC Trusted Publisher bypasses token management entirely: GitHub Actions exchanges an OIDC token for a temporary publish credential automatically.

## Test plan

- [ ] Trigger `workflow_dispatch` from `main` after merge
- [ ] Confirm `tierward@1.32.0` appears on npmjs.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)