### PR TITLE
fix(scaffold): update marketplace.json SHA to current main

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -31,7 +31,7 @@
         "source": "url",
         "url": "https://github.com/marcoguillermaz/tierward.git",
         "ref": "main",
-        "sha": "2eb43aebc86bba9b8b2e50491b154845da44942e"
+        "sha": "8a3195d173946cb5e0d846cfa36eab1b19efb5e4"
       }
     }
   ]


### PR DESCRIPTION
## Summary

- Update `marketplace.json` plugin source SHA from `2eb43ae` (cherry-pick commit on release branch) to `8a3195d` (current `main` HEAD, post OIDC workflow fix)

## Why

The SHA was pointing to an intermediate commit from the release branch cherry-pick. It now points to the canonical `main` HEAD so the marketplace entry resolves correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)