### PR TITLE
chore(release): v1.32.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.32.1] — 2026-06-18
+
+### Fixed
+
+- **Plugin skill companion files.** Seven companion files (`REPORT.md`, `PATTERNS.md`, `BATCH_COMMANDS.md`, `advanced-checks.md`) were missing from the plugin `skills/` directories — only `SKILL.md` files had been copied from the tier-s/tier-m templates. This caused `/tierward:arch-audit`, `/tierward:security-audit`, `/tierward:perf-audit`, and `/tierward:skill-dev` to reference files that did not exist. All companion files are now bundled with the plugin. (#222)
+- **`/tierward:arch-audit` non-invasive guard.** Step 5 (timestamp write) now runs conditionally — it only writes `.claude/session/last-arch-audit` when that directory already exists, preserving the plugin's non-invasive promise in projects without a CDK scaffold. (#222)
+
+---
+
 ## [1.32.0] — 2026-06-18
 
 ### Added

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tierward",
-  "version": "1.32.0",
+  "version": "1.32.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tierward",
-      "version": "1.32.0",
+      "version": "1.32.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tierward",
-  "version": "1.32.0",
+  "version": "1.32.1",
   "description": "Scaffold for legible, reviewable AI-assisted development",
   "type": "module",
   "bin": {

--- a/plugin/skills/arch-audit/BATCH_COMMANDS.md
+++ b/plugin/skills/arch-audit/BATCH_COMMANDS.md
@@ -1,0 +1,29 @@
+# Arch-Audit Batch Commands
+
+Exact commands for Step 3b consistency checks. Stored here to keep the SKILL.md body free of implementation patterns (body purity rule).
+
+## Grep-tier batch (haiku subagent)
+
+Pass this entire table to the haiku subagent in Step 3b. Receive one structured pass/fail result per row.
+
+| Check | Command | Pass condition |
+| ----- | ------- | -------------- |
+| C4    | `grep -n "ln -s" .claude/rules/pipeline.md` | 0 matches |
+| C6    | `grep -A3 "Phase 5b" .claude/rules/pipeline.md \| grep -i "dev\|server\|localhost"` | ≥1 match |
+| C9    | `grep -c "\*\*\* STOP" .claude/rules/pipeline.md` | ≥5 |
+| C10   | `grep -n "Worktree isolation" .claude/rules/pipeline.md` | ≥1 match |
+| C11   | `for skill_dir in .claude/skills/*/; do name=$(basename "$skill_dir"); grep -q "$name" .claude/cheatsheet.md && echo "OK: $name" \|\| echo "MISSING: $name"; done` | 0 MISSING lines |
+| C12   | `grep -o "SessionStart\|PostCompact\|InstructionsLoaded" .claude/settings.json \| sort -u` | 3 lines |
+| C13   | `grep -rL --include="SKILL.md" "context: fork" .claude/skills/` | 0 files returned |
+| C14   | `git check-ignore -q CLAUDE.md && echo "PASS" \|\| echo "FAIL"` | PASS |
+| C15   | `wc -l CLAUDE.md \| awk '{print $1}'` | ≤200 |
+| C16   | `grep -rn "claude-3-haiku\|claude-3-5-haiku\|claude-3-opus\|claude-3-sonnet\|claude-3-5-sonnet\|claude-sonnet-4-20250514\|claude-opus-4-20250514" .claude/skills/ .claude/settings.json` | 0 matches |
+| C17   | `for f in .claude/skills/*/SKILL.md; do name=$(basename $(dirname "$f")); [ "$name" = "arch-audit" ] && continue; if grep -q "mcp__" "$f" && ! grep -q "^allowed-tools:" "$f"; then echo "MISSING allowed-tools: $f"; fi; done` | 0 MISSING lines |
+
+## Judgment-tier standalone (C8)
+
+**C8** — not in the batch above because it requires reading the output in context:
+
+`grep -n "Interaction Protocol" CLAUDE.md`
+
+Pass: ≥1 match. Missing = FAIL.

--- a/plugin/skills/arch-audit/REPORT.md
+++ b/plugin/skills/arch-audit/REPORT.md
@@ -1,0 +1,86 @@
+# Arch Audit - Report Template
+
+```
+## Arch Audit - [DATE]
+### Claude Code version checked: [version from changelog/releases]
+### Current model IDs verified: Opus=[id] · Sonnet=[id] · Haiku=[id]
+
+### Auto-fixed ([N] changes)
+- [file]: [what changed and why]
+
+### Recommendations ([N] items)
+- [Priority: High/Medium/Low] [description] - [why it matters]
+
+### Decision guide
+
+For each item in Recommendations above, output one decision card in this format:
+
+**[Priority] - [Short title]**
+- **Benefit if applied**: concrete outcome in one sentence (measurable or observable)
+- **Cost / effort**: what it takes to implement - file count, phase required, risk of regression
+- **Verdict**: one of:
+  - `Apply now` - clear win, low risk, fits current phase
+  - `Defer` - valid but not urgent; include a trigger condition (e.g. "apply when pipeline grows beyond N phases")
+  - `Skip` - recommendation is technically valid but does not apply to this project's actual usage patterns; explain why
+
+### Compliant (no action needed)
+- [area]: [brief confirmation]
+
+### Ecosystem consistency (C1-C17) - grep-tier via haiku batch, judgment-tier in main context
+- C1 Deploy currency: [PASS/FAIL]
+- C2 Skill output refs: [PASS/FAIL - batch]
+- C3 files-guide static: [PASS/FAIL]
+- C4 Symlink alignment: [PASS/FAIL - batch]
+- C5 Worktree standard: [PASS/FAIL]
+- C6 Dev server prereq: [PASS/FAIL - batch]
+- C7 Dead path refs: [PASS/FAIL - list any missing paths]
+- C8 Interaction Protocol: [PASS/FAIL]
+- C9 STOP gate count: [PASS/FAIL - actual count - batch]
+- C10 Worktree isolation: [PASS/FAIL - batch]
+- C11 Cheatsheet coverage: [PASS/FAIL - list missing skills if any - batch]
+- C12 Hook integrity: [PASS/FAIL - list missing hooks if any + new events worth adding]
+- C13 context:fork coverage: [PASS/FAIL - list missing skills if any - batch]
+- C14 CLAUDE.md gitignored: [PASS/FAIL - batch]
+- C15 CLAUDE.md line budget: [PASS/WARN - actual line count - batch]
+- C16 Deprecated model IDs: [PASS/FAIL - list any found - batch]
+- C17 allowed-tools frontmatter: [PASS/FAIL - list missing skills if any - batch]
+
+### Prompting compliance (P1-P5) - judgment-based, PASS/WARN only
+- P1 CLAUDE.md content type: [PASS/WARN - list any sections failing Anthropic's inclusion test]
+- P2 Instruction clarity: [PASS/WARN - list any vague or unmeasurable directives]
+- P3 Structural redundancy: [PASS/WARN - list any rules duplicated across files]
+- P4 Pipeline complexity: [PASS/WARN - list any phases with unclear value]
+- P5 Long context structure: [PASS/WARN - list any scannability or positioning issues]
+
+### Token & subagent optimization (T1-T5)
+- T1 Research agent model: [PASS/FAIL - haiku specified in Step 1]
+- T2 Explore subagent model: [PASS/FAIL - all haiku, list any missing]
+- T3 Phase 5d Playwright concurrency: [PASS/WARN]
+- T5 Skill model fitness: [PASS/FAIL/WARN - list any mismatches]
+
+### Pipeline compliance (PE1-PE12) - judgment-based, PASS/WARN only
+- PE1 Phase gates integrity: [PASS/WARN]
+- PE2 Testing pyramid order: [PASS/WARN]
+- PE3 Auth boundary coverage: [PASS/WARN]
+- PE4 Type check gate: [PASS/WARN]
+- PE5 Security checklist: [PASS/WARN]
+- PE6 Staging before production: [PASS/WARN]
+- PE7 Migration isolation: [PASS/WARN]
+- PE8 Scope gate before impl: [PASS/WARN]
+- PE9 Minimal footprint: [PASS/WARN]
+- PE10 Fast Lane escalation: [PASS/WARN]
+- PE11 Documentation gate: [PASS/WARN]
+- PE12 Commit discipline: [PASS/WARN]
+
+### Hook compliance (H1a-H1f)
+- H1a Event name currency: [PASS/FAIL - list unknown events if any]
+- H1b JSON response fields: [PASS/FAIL - list non-compliant fields if any]
+- H1c Bypass visibility: [PASS/FAIL - list hooks missing bypass guidance]
+- H1d Hook type fitness: [PASS/WARN - list command->prompt candidates]
+- H1e Rubric-hook drift: [PASS/FAIL - list any T3 or format divergences found]
+- H1f New events: [list relevant new events, or "none since last audit"]
+
+### Next audit due: [DATE + 7 days]
+```
+
+If no gaps are found: output "Architecture fully compliant as of [DATE]. No changes needed." and still update the timestamp.

--- a/plugin/skills/arch-audit/SKILL.md
+++ b/plugin/skills/arch-audit/SKILL.md
@@ -325,8 +325,10 @@ For each AUTO-FIX from Step 3, Step 3b, and Step H1: apply the change, note the 
 
 ## Step 5 - Update timestamp
 
+Only run if the directory already exists (CDK-scaffolded projects):
+
 ```bash
-date +%s > "$CLAUDE_PROJECT_DIR/.claude/session/last-arch-audit"
+[ -d "$CLAUDE_PROJECT_DIR/.claude/session" ] && date +%s > "$CLAUDE_PROJECT_DIR/.claude/session/last-arch-audit"
 ```
 
 ## Step 6 - Produce audit report

--- a/plugin/skills/arch-audit/advanced-checks.md
+++ b/plugin/skills/arch-audit/advanced-checks.md
@@ -1,0 +1,173 @@
+# Advanced compliance checks
+
+Reference file for `arch-audit`. Contains Step 3c (Anthropic Prompting Guide compliance), Step 3d (Token & subagent optimization), and Step H1 (Hook compliance). Extracted from `SKILL.md` to respect the Anthropic best-practice budget of ≤ 500 lines per skill body. Load this file when executing the corresponding steps; otherwise the content costs zero tokens.
+
+## Step 3c - Anthropic Prompting Guide compliance
+
+Using the prompting guide content fetched in Step 1 **and the normative baseline in `.claude/rules/claudemd-standards.md`** (read in Step 2), evaluate `CLAUDE.md`, `pipeline.md`, and `context-review.md` against best practices. The standards file is the local stable reference - use it as the primary benchmark; live-fetched docs confirm it's still current. These checks are judgment-based - classify each as PASS or WARN (not hard FAIL), and always RECOMMEND, never auto-fix.
+
+**Standards file currency check (run first)**: compare the `Last verified` date in `.claude/rules/claudemd-standards.md` against today's date. If > 30 days old AND Step 1 fetched new material changes → flag as RECOMMEND to update the standards file. If ≤ 30 days → skip.
+
+**P1 - CLAUDE.md content type (Anthropic's inclusion test)**
+Anthropic's rule: CLAUDE.md should contain ONLY non-obvious information Claude cannot infer by reading the code. Apply Anthropic's own test to every section: _"Would removing this cause Claude to make mistakes?"_
+
+Flag as WARN if a section:
+
+- Describes what a file does structurally (e.g. "file X handles Y") without explaining a non-obvious constraint - Claude can read the code
+- States a standard convention Claude already knows without a project-specific reason
+- Contains tutorial-style explanations of concepts (React, TypeScript, SQL) that Claude understands natively
+- Describes current session state or temporary phase status (this belongs in CLAUDE.local.md or MEMORY.md)
+
+Report: list any sections that fail the test with a suggested action (remove, condense, or move to a more appropriate file).
+
+**P2 - Instruction clarity and actionability**
+Anthropic's guidance: instructions must be specific, actionable, and unambiguous. A vague rule gives Claude discretion where a concrete rule would remove ambiguity.
+
+Flag as WARN:
+
+- Directives with no measurable outcome ("be thorough", "be careful", "verify appropriately")
+- Instructions that say "ensure X" without specifying how to verify X
+- Rules with implicit scope ("update relevant files") where an explicit list would prevent errors
+
+Report: flagged instances with suggested sharper wording.
+
+**P3 - Structural redundancy across instruction files**
+Redundancy dilutes attention. If a rule appears in both CLAUDE.md and pipeline.md with no clear canonical source, Claude may apply it inconsistently - or the longer file may suppress the shorter one.
+
+Check: read "Known Patterns" in CLAUDE.md and "Cross-Cutting Rules" in pipeline.md side-by-side. Also check for overlap between context-review.md checks and arch-audit C1–C17.
+
+Flag as WARN: any rule stated substantively in two files where one should be canonical.
+
+Report: duplicates with a recommendation on which file is the correct owner.
+
+**P4 - Pipeline complexity proportionality**
+Anthropic's principle: instruction complexity should be proportional to the actual risk and value it protects against. Over-specified pipelines make Claude slower and more likely to get stuck on process rather than output.
+
+Evaluate:
+
+- Are there phases (or sub-phases) whose STOP gate catches errors that have actually occurred in practice? Or are they theoretical?
+- Does the Fast Lane meaningfully simplify, or does it mostly duplicate the full pipeline?
+- Are there context-review checks (C1–C12) that have never caught a real issue - suggesting they address a risk that doesn't materialize?
+- Does the total length of pipeline.md + context-review.md stay within a range where Claude can hold the key constraints in working context?
+
+Report: any phase or check that appears to add friction without demonstrated value → RECOMMEND for review or consolidation. Note: do NOT recommend removing STOP gates without strong evidence of zero value - gates protect against irreversible actions.
+
+**P5 - Long context structure and scannability**
+Anthropic guidance for long system prompts: critical rules should be visually distinct and easy to locate. Recency and position matter - Claude gives more weight to recent context.
+
+Check:
+
+- Are the most-critical, most-referenced rules (RBAC, worktree isolation, migration isolation, environment isolation) marked as CRITICAL or placed at the top of their sections?
+- Is CLAUDE.md structured so Claude can find a rule without reading the entire file?
+- Are there sections that are rarely referenced but consume significant token space in every context window?
+
+Report: structural improvements for scannability → RECOMMEND.
+
+## Step 3d - Token & subagent optimization checks
+
+These checks audit the project's own efficiency at model selection and subagent delegation. Regressions here increase cost and latency without improving output quality. Judgment-based where noted; mechanical checks reuse the grep-tier haiku batch from Step 3b.
+
+**T1 - Research agent model in arch-audit Step 1**
+Check: does the Step 1 instruction in this SKILL.md specify `model: haiku` for the research agent?
+Batch command: `grep -n "model.*haiku\|haiku.*model" .claude/skills/arch-audit/SKILL.md`
+Expected: at least 1 match in the Step 1 section. Missing = FAIL.
+AUTO-FIX: add `(model: haiku)` to the research agent invocation in Step 1.
+
+**T2 - Haiku model on all Explore subagents across skills**
+Check: every "Launch ... Explore subagent" instruction in all SKILL.md files must explicitly name `model: haiku`.
+Batch command: `grep -rn "Explore subagent" .claude/skills/*/SKILL.md | grep -v "model.*haiku\|haiku"`
+Expected: 0 matches (all invocations already name haiku). Any match = FAIL.
+AUTO-FIX: append `(model: haiku)` to the invocation description in each failing line.
+
+**T3 - Phase 5d Playwright concurrency note**
+Check: does pipeline.md Phase 5d document that `/ui-audit` (static, no Playwright by default) can run concurrently with Playwright-based skills, and that `/visual-audit`, `/ux-audit`, `/responsive-audit` must run sequentially (shared MCP Playwright session)?
+Batch command: `grep -A30 "Phase 5d" .claude/rules/pipeline.md | grep -i "concurrent\|parallel\|sequenti\|playwright.*conflict\|conflict.*playwright"`
+Expected: at least 1 match. Missing = WARN.
+RECOMMEND if failing: add a note to Phase 5d: "Run `/ui-audit` concurrently with the first Playwright skill launch. Run `/visual-audit` → `/ux-audit` → `/responsive-audit` sequentially - they share the MCP Playwright session and cannot run in parallel."
+
+Batch commands:
+Expected: ≥1 match in each file. Missing from either = FAIL.
+
+**T5 - Skill model fitness (judgment)**
+For each skill, verify `model:` frontmatter fits the task's reasoning requirement:
+
+- `model: haiku` appropriate for: mechanical structural checks, pure grep/pattern matching, URL text extraction, formatting validation
+- `model: sonnet` appropriate for: cross-file judgment, complex analysis, fix application, multi-dimension scoring
+- `model: opus` appropriate for: screenshot-based visual reasoning, multi-role journey simulation, live aesthetic scoring - requires vision + deep analysis
+
+Current expected state:
+| Skill | Expected | Rationale |
+|---|---|---|
+| arch-audit | sonnet | Complex judgment, cross-doc analysis, AUTO-FIX application |
+| ui-audit | sonnet | Design system judgment, visual compliance scoring |
+| ux-audit | opus | Multi-flow simulation + live screenshot analysis - visual reasoning requires Opus |
+| visual-audit | opus | 7-dimension aesthetic scoring + screenshot analysis - visual reasoning requires Opus |
+| security-audit | sonnet | Exploit reasoning, authorization analysis |
+| api-design | sonnet | REST pattern judgment + internal haiku Explore agent |
+| perf-audit | sonnet | Bundle analysis, server/client boundary judgment + internal haiku Explore agent |
+| skill-dev | sonnet | Coupling/abstraction judgment + internal haiku Explore agent |
+| skill-db | opus | Deep schema normalization + RLS policy reasoning requires Opus - internal haiku Explore agent for dep scan |
+| responsive-audit | opus | Multi-viewport screenshot judgment - visual reasoning requires Opus |
+
+Batch command: `grep -A1 "^name:" .claude/skills/*/SKILL.md | grep "model:"` - compare each result against the table above.
+FAIL: any skill using `model: haiku` as top-level model (only Explore _subagents within_ skills should use haiku, not the skill itself).
+WARN: any skill using `model: opus` **unless** it is one of the intentional Opus skills: `visual-audit`, `ux-audit`, `responsive-audit` (screenshot-based visual reasoning) or `skill-db` (deep schema normalization + RLS policy reasoning). All other skills should use sonnet.
+
+## Step H1 - Hook compliance check
+
+Using hook documentation fetched in Step 1 (`https://code.claude.com/docs/en/hooks`) and `settings.json` read in Step 2, verify the project's hook configuration against current Anthropic spec.
+
+**H1a - Event name currency**
+Check: every event name in `settings.json` hooks matches the current official event list.
+Run: `grep -o '"SessionStart"\|"SessionEnd"\|"UserPromptSubmit"\|"UserPromptExpansion"\|"PreToolUse"\|"PostToolUse"\|"PostToolUseFailure"\|"Stop"\|"StopFailure"\|"PermissionRequest"\|"PermissionDenied"\|"SubagentStart"\|"SubagentStop"\|"TaskCreated"\|"TaskCompleted"\|"TeammateIdle"\|"FileChanged"\|"CwdChanged"\|"ConfigChange"\|"PreCompact"\|"PostCompact"\|"InstructionsLoaded"\|"Notification"\|"Elicitation"\|"ElicitationResult"\|"WorktreeCreate"\|"WorktreeRemove"' .claude/settings.json | sort -u`
+Pass: all events appear in the Step 1 documentation. Any unrecognized event → RECOMMEND removal or rename.
+
+**H1b - JSON response field compliance (prompt hooks)**
+For each hook with `"type": "prompt"` in settings.json: check that response fields (`ok`, `reason`, `decision`, `updatedInput`) match the documented schema.
+Source: Step 1 hooks doc content.
+If divergence found → RECOMMEND (never AUTO-FIX): specify both files that need updating:
+
+- `.claude/settings.json` - the hook prompt inline text (authoritative)
+- `.claude/rules/prompt-quality-rubric.md` - the "Block output format" section (documentation, follows the hook)
+
+**H1c - Bypass mechanism visibility**
+Check: every `UserPromptSubmit` hook with `type: prompt` that can return a blocking response (`ok: false`) must include bypass instructions in the `reason` field.
+Fail → RECOMMEND update to add bypass instructions.
+
+**H1d - Hook type fitness**
+For each hook, verify `type` matches intent:
+
+- `command` - shell execution, dynamic state (git, files, env)
+- `prompt` - static/contextual text injection, no shell needed
+- `agent` - multi-step async logic
+  Flag as RECOMMEND (not AUTO-FIX) any `command` hook that only outputs static text and could be simplified to `prompt`.
+
+**H1e - Rubric-hook drift check**
+Check: `.claude/rules/prompt-quality-rubric.md` must stay in sync with the inline logic in the `UserPromptSubmit` prompt hooks in `settings.json`. Drift = the rubric documents behavior that the hook no longer implements (or vice versa).
+
+Run these two greps and compare results:
+
+- T3 wildcards in rubric: `grep "T3" .claude/rules/prompt-quality-rubric.md`
+- T3 wildcards in hook: `grep "T3" .claude/settings.json`
+
+Also check output format sync:
+
+- Rubric block format: `grep -A5 "Block output format" .claude/rules/prompt-quality-rubric.md`
+- Hook output format: look for the `If a trigger matches` instruction in the settings.json hook prompt
+
+Pass: T3 wildcard lists match; rubric output format matches hook output format structure.
+Fail → AUTO-FIX: update the rubric to match the hook (hook is authoritative - rubric is documentation). Update `Last updated` date in rubric.
+
+**H1f - New events to consider**
+
+Add results to Step 6 report under:
+
+```
+### Hook compliance (H1a–H1e)
+- H1a Event name currency: [PASS/FAIL - list unknown events if any]
+- H1b JSON response fields: [PASS/FAIL - list non-compliant fields if any]
+- H1c Bypass visibility: [PASS/FAIL - list hooks missing bypass guidance]
+- H1d Hook type fitness: [PASS/WARN - list command→prompt candidates]
+- H1e Rubric-hook drift: [PASS/FAIL - list any T3 or format divergences found]
+- H1f New events: [list relevant new events, or "none since last audit"]
+```

--- a/plugin/skills/perf-audit/REPORT.md
+++ b/plugin/skills/perf-audit/REPORT.md
@@ -1,0 +1,185 @@
+# Perf Audit - Report Template
+
+## Web Audit - Report Template
+
+```
+## Perf Audit - [DATE] - [SCOPE] - mode: [audit | apply]
+### Sources: framework docs, web.dev/vitals, build tool docs
+
+### Executive summary
+- [2-8 bullets: one per Critical/High finding or notable PASS. Lead with the most impactful issue.]
+
+### Scope reviewed
+- Routes/components scanned: [N files]
+- Config files: framework config [present/absent]
+- Bundle evidence: bundle analyzer [configured / not configured]
+- Assumptions: [any scope limitations, e.g. "layout files excluded from B8 - none found"]
+
+### Core Web Vitals thresholds (reference)
+| Metric | Good | Needs work | Poor | Primary cause |
+|---|---|---|---|---|
+| LCP | ≤ 2.5s | 2.5–4s | > 4s | Slow server response, render-blocking resources |
+| CLS | ≤ 0.1 | 0.1–0.25 | > 0.25 | Unsized images, dynamic content above fold |
+| INP | ≤ 200ms | 200–500ms | > 500ms | Blocking JS on event handlers |
+
+### Server/Client Boundary
+| # | Check | Matches | Severity | Verdict |
+|---|---|---|---|---|
+| B1 | Unnecessary client-side rendering scope | N | Medium | ✅/⚠️ |
+| B2 | Heavy libraries in client bundle | N | High | ✅/⚠️ |
+| B3 | Client-side data fetching | N | High | ✅/⚠️ |
+| B4 | Unstable callbacks on memo'd children | N | Low | ✅/⚠️ |
+| B5 | Sequential await waterfall | N | High | ✅/⚠️ |
+| B6 | Uncached server queries | N | Medium | ✅/⚠️ |
+| B7 | Images without dimensions (CLS) | N | Medium | ✅/⚠️ |
+| B8 | Dynamic rendering triggers | N | High | ✅/⚠️ |
+| B9 | Missing lazy loading for heavy components | N | Medium | ✅/⚠️ |
+
+### Bundle Composition
+| # | Check | Verdict | Notes |
+|---|---|---|---|
+| P1 | Bundle analyzer availability | ✅/⚠️ | [which tool] |
+| P2 | Server-only package exclusion | ✅/⚠️ | [missing packages if any] |
+| P3 | Tree-shaking optimization | ✅/⚠️ | [large library status] |
+
+### API Query Efficiency
+| # | Check | Matches | Verdict |
+|---|---|---|---|
+| Q1 | Unbounded queries | N | ✅/⚠️ |
+| Q2 | Select * | N | ✅/⚠️ |
+| Q3 | N+1 patterns | N | ✅/⚠️ |
+
+### Performance maturity assessment
+| Dimension | Score | Notes |
+|---|---|---|
+| Boundary discipline (B1, B2, B9) | 🟢/🟡/🔴 | [summary] |
+| Client bundle health (P1, P2, P3) | 🟢/🟡/🔴 | [summary] |
+| Data-fetching quality (B3, B5, B6) | 🟢/🟡/🔴 | [summary] |
+| Async/query efficiency (Q1, Q2, Q3) | 🟢/🟡/🔴 | [summary] |
+| Rendering efficiency (B4, B8) | 🟢/🟡/🔴 | [summary] |
+| Image / layout stability (B7) | 🟢/🟡/🔴 | [summary] |
+Scoring: 🟢 = 0 High/Critical findings · 🟡 = 1-2 Medium findings · 🔴 = any High or Critical finding
+
+### Findings requiring action ([N] total)
+[Sorted Critical → High → Medium → Low]
+Format: `[SEVERITY] file:line - check# - issue - impact - suggested fix`
+
+### Quick wins (implement in < 1 hour each)
+[findings that are isolated, low-risk, and self-contained - e.g. add Promise.all, add lazy/dynamic wrapper]
+
+### Strategic refactors (require planning)
+[findings that affect multiple files or need architectural decisions - e.g. move data fetch to server-rendered path, extract client island from layout]
+
+### Validation checklist
+After applying fixes, verify:
+- [ ] Pages that had B5 waterfall: add timing log to confirm parallel fetch time ≤ slowest single fetch
+```
+
+---
+
+## Web Audit - Backlog writing rules
+
+Present all findings with severity Medium or above as a numbered decision list, sorted Critical → High → Medium:
+
+```
+Found N findings at Medium or above. Which to add to backlog?
+
+[1] [CRITICAL] PERF-? - file:line - one-line description
+[2] [HIGH]     PERF-? - file:line - one-line description
+[3] [MEDIUM]   PERF-? - file:line - one-line description
+...
+
+Reply with numbers to include (e.g. "1 2 4"), "all", or "none".
+```
+
+**Wait for explicit user response before writing anything.**
+
+Then write ONLY the approved entries to `docs/refactoring-backlog.md`:
+- Assign ID: `PERF-[n]` (increment from last PERF entry)
+- Add row to the priority index table with columns: `| PERF-N | check# | file:line | Severity | Description |`
+- Add full detail section: `### PERF-N - [check label]` with sub-sections: **File**, **Issue**, **Impact**, **Suggested fix**
+
+---
+
+## Web Audit - Severity guide
+
+- **Critical**: N+1 in dashboard/list endpoints under heavy load (Q3); heavy server-only library discovered in client bundle (B2)
+- **High**: Sequential await waterfall with >500ms combined latency risk (B5); client-side data fetching on a primary route (B3); unbounded query on large-growth table (Q1); request-scoped API in a layout causing route tree force-dynamic (B8)
+- **Medium**: Uncached layout-level server queries called on every page load (B6); select-all on tables with large-text columns (Q2); unsized images (B7 - CLS risk); tree-shaking not configured for large libraries (P3); unnecessary client-side rendering scope (B1); missing lazy loading on heavy components (B9)
+- **Low**: Unstable callbacks on memoized children (B4); minor code-splitting opportunities; bundle analyzer not configured (P1)
+
+---
+
+## Native Audit - Report Template
+
+```
+## Perf Audit - [DATE] - [SCOPE] - mode: [audit | apply]
+### Sources: platform profiling documentation, language performance guides
+
+### Executive summary
+- [2-8 bullets: one per Critical/High finding or notable PASS]
+
+### Scope reviewed
+- Source files scanned: [N files]
+- Profiling tool: [PERF_TOOL]
+- Profile data: [available / not available - recommend running profiler]
+
+### Algorithmic & Resource Checks
+| # | Check | Matches | Severity | Verdict |
+|---|---|---|---|---|
+| NP1 | Nested iteration on collections | N | High | ✅/⚠️ |
+| NP2 | Memory allocation in hot paths | N | Medium | ✅/⚠️ |
+| NP3 | I/O bottleneck patterns | N | High | ✅/⚠️ |
+| NP4 | Concurrency inefficiency | N | Medium | ✅/⚠️ |
+
+### Stack-Specific Checks
+| Check | Verdict | Notes |
+|---|---|---|
+| [check name per 6b] | ✅/⚠️ | [details] |
+
+### Resource Footprint Checks
+| # | Check | Matches | Severity | Verdict |
+|---|---|---|---|---|
+| NR1 | Launch / startup weight | N | High | ✅/⚠️ |
+| NR2 | Memory management patterns | N | Medium | ✅/⚠️ |
+| NR3 | Energy / background patterns | N | Medium | ✅/⚠️ |
+| NR4 | Binary / artifact size | N | Low | ✅/⚠️ |
+
+### Findings requiring action ([N] total)
+[Sorted Critical → High → Medium → Low]
+Format: `[SEVERITY] file:line - check# - issue - impact - suggested fix`
+
+### Quick wins
+[isolated, low-risk, self-contained fixes]
+
+### Strategic refactors
+[multi-file changes or architectural decisions needed]
+```
+
+---
+
+## Native Audit - Backlog writing rules
+
+Present all findings with severity Medium or above:
+
+```
+Found N findings at Medium or above. Which to add to backlog?
+
+[1] [HIGH]     PERF-? - file:line - one-line description
+[2] [MEDIUM]   PERF-? - file:line - one-line description
+
+Reply with numbers to include (e.g. "1 2 4"), "all", or "none".
+```
+
+**Wait for explicit user response before writing anything.**
+
+Then write approved entries to `docs/refactoring-backlog.md` using the same ID format (`PERF-[n]`).
+
+---
+
+## Native Audit - Severity guide
+
+- **Critical**: O(n²+) in a hot path processing user-visible data; memory leak causing OOM on long sessions; main-thread blocking > 1s; Activity/Context leak via static reference (Kotlin)
+- **High**: synchronous I/O blocking UI/main thread (NP3); sequential network calls with >500ms combined latency; goroutine/thread/coroutine leak; unbounded collection growth (NR2); heavy initialization in app entry point delaying launch (NR1); GlobalScope.launch without lifecycle cancellation
+- **Medium**: unnecessary allocations in moderate-frequency paths (NP2); missing cancellation on background tasks; suboptimal data structure choice; missing resource cleanup; excessive timer/location wake-ups (NR3); retain cycles in closures; regex compilation in loops
+- **Low**: minor allocation optimization; style-level concurrency improvement; profiler not configured; binary size overhead from unused assets (NR4); missing `#[inline]` on small functions

--- a/plugin/skills/security-audit/PATTERNS.md
+++ b/plugin/skills/security-audit/PATTERNS.md
@@ -1,0 +1,222 @@
+# Security Audit - Stack Patterns
+
+Reference file for `/security-audit`. Contains grep patterns per check, organized by stack.
+The executing agent reads this file at the start of Step 2 and Step 3e. For each check, select the patterns matching the detected stack. If no exact match, use Generic.
+
+---
+
+## A1 - Auth verification patterns
+
+Grep for these within the first 20 lines of each route handler.
+
+| Stack | Patterns |
+|---|---|
+| Node.js (Express/Fastify) | `getSession\|getUser\|req.user\|req.session\|auth()\|currentUser` |
+| Next.js | `getServerSession\|auth()\|getUser\|currentUser\|cookies().get` |
+| Django | `request.user\|login_required\|permission_required\|IsAuthenticated` |
+| Rails | `current_user\|authenticate_user!\|before_action :authenticate` |
+| Laravel | `Auth::user()\|auth()->user()\|$request->user()\|middleware('auth')` |
+| Flask | `current_user\|login_required\|flask_login\|g.user` |
+| Go | `r.Context().Value\|middleware.Auth\|session.Get\|claims.` |
+| Swift (Vapor) | `req.auth.require\|req.auth.get\|guardMiddleware` |
+| Kotlin (Ktor) | `call.principal\|authenticate\|call.sessions.get` |
+| Java (Spring) | `@PreAuthorize\|SecurityContextHolder\|@Secured\|Principal` |
+| .NET | `[Authorize]\|User.Identity\|HttpContext.User\|ClaimsPrincipal` |
+| Ruby (Sinatra) | `session[:user]\|env['warden']\|current_user` |
+| Generic | `auth\|session\|token\|currentUser\|current_user\|getUser\|get_user` |
+
+---
+
+## A3 - Validation library patterns
+
+Grep for these in write route handlers (POST/PUT/PATCH).
+
+| Stack | Validation call | Schema declaration |
+|---|---|---|
+| Node.js (Zod) | `safeParse\|\.parse(` | `z\.object\|z\.string` |
+| Node.js (Joi) | `validate(\|Joi\.object` | `Joi\.string\|Joi\.number` |
+| Node.js (class-validator) | `validate(\|plainToInstance` | `@IsString\|@IsNumber\|@IsNotEmpty` |
+| Django / DRF | `is_valid()\|serializer\.validate` | `Serializer\|Form\.is_valid` |
+| Rails | `params\.require\|params\.permit` | `validates\|validate` |
+| Laravel | `$request->validate\|Validator::make` | `FormRequest\|rules()` |
+| Flask (Marshmallow) | `schema\.load(\|schema\.dump(` | `Schema\|fields\.` |
+| Go | `Validate(\|binding:"required"` | `validator\.New()` |
+| Swift (Vapor) | `try req.content.decode\|Validatable` | `validations()` |
+| Kotlin (Ktor) | `call.receive<\|validate {` | `@field:NotBlank\|@field:Size` |
+| Java (Spring) | `@Valid\|BindingResult\|@Validated` | `@NotNull\|@Size\|@Pattern` |
+| .NET | `ModelState.IsValid\|[Required]` | `FluentValidation\|DataAnnotations` |
+| Generic | `validate\|parse\|sanitize\|schema\|is_valid` |
+
+---
+
+## A4 - SQL injection / query interpolation patterns
+
+Grep for unsafe query construction.
+
+| Stack | Unsafe patterns |
+|---|---|
+| Node.js (template literals) | `` `SELECT.*\$\{`` , `` `INSERT.*\$\{`` , `.where('col = ' + val)` |
+| Python (f-strings) | `f"SELECT.*{` , `f"INSERT.*{` , `"SELECT.*" %` , `"SELECT.*".format(` |
+| Ruby (interpolation) | `"SELECT.*#{` , `.where("col = #{` |
+| Go | `fmt.Sprintf("SELECT.*%s` , `"SELECT.*" +` |
+| Java | `"SELECT.*" +` , `String.format("SELECT.*%s` |
+| PHP/Laravel | `DB::raw(".*$` , `"SELECT.*" . $` |
+| Generic | `SELECT.*\+\|INSERT.*\+\|UPDATE.*\+\|DELETE.*\+` (string concat in queries) |
+
+---
+
+## A5 - Select-all / over-fetch patterns
+
+Grep for routes returning full objects without field filtering.
+
+| Stack | Select-all patterns |
+|---|---|
+| SQL (any) | `SELECT \*` |
+| Supabase JS | `.select('*')\|.select(\`*\`)` |
+| Prisma | `findMany()\|findFirst()\|findUnique()` (without explicit `select:`) |
+| Django ORM | `.all()\|.values()\|.filter(` (without `.only(` or `.values(` with fields) |
+| SQLAlchemy | `session.query(Model).all()\|select(Model)` |
+| ActiveRecord | `.all\|.find(\|.where(` (without `.select(`) |
+| Sequelize | `.findAll()\|.findOne()` (without `attributes:`) |
+| Drizzle | `select()\|.from(` (without explicit column list) |
+| Go (sqlx) | `Select(&\|Get(&` (check if struct has sensitive fields) |
+| Generic | `SELECT \*\|findAll\|find_all\|\.all()` |
+
+---
+
+## A8 - Client-exposed environment variable prefixes
+
+These framework prefixes inline env vars into the client bundle. Grep `.env*` files and source for these prefixes combined with secret-like suffixes.
+
+| Framework | Client prefix |
+|---|---|
+| Next.js | `NEXT_PUBLIC_` |
+| Vite / SvelteKit / Nuxt 3 | `VITE_` |
+| Create React App | `REACT_APP_` |
+| Nuxt 2 | `NUXT_ENV_` |
+| Angular | Env vars in `environment.ts` (no prefix convention - check `environment.prod.ts`) |
+| Expo / React Native | `EXPO_PUBLIC_` |
+| Flutter | Dart env via `--dart-define` (no prefix - check `main.dart` for hardcoded values) |
+| Generic | Any env var embedded in client-facing source files |
+
+Secret-like suffixes to flag: `KEY`, `SECRET`, `TOKEN`, `PASSWORD`, `CREDENTIALS`, `PRIVATE`.
+
+---
+
+## A9 - Client-side file markers + privileged credential patterns
+
+### Client-side markers (how to identify client-rendered files)
+
+| Stack | Marker |
+|---|---|
+| Next.js | `'use client'` directive |
+| Nuxt | `<script setup>` in pages (auto-client) |
+| SvelteKit | files in `src/routes/` without `+page.server` |
+| Angular | files in `src/app/` (all client-rendered by default) |
+| React SPA | all `.tsx`/`.jsx` files (no SSR) |
+| Native | N/A (no client/server split) |
+
+### Privileged credential references
+
+| Category | Patterns |
+|---|---|
+| Supabase | `SERVICE_ROLE\|service_role\|serviceRoleKey\|supabase_service_role` |
+| Firebase | `FIREBASE_ADMIN\|admin\.initializeApp\|admin\.auth()` |
+| AWS | `AWS_SECRET_ACCESS_KEY\|secretAccessKey` |
+| Generic | `ADMIN_KEY\|MASTER_KEY\|masterKey\|PRIVATE_KEY\|server_secret` |
+
+---
+
+## A10 - Public URL patterns for storage assets
+
+| Stack | Public URL pattern |
+|---|---|
+| Supabase Storage | `getPublicUrl\|createSignedUrl` (flag `getPublicUrl` on private assets) |
+| AWS S3 | `s3.getSignedUrl\|getObject\|putObject` (flag direct S3 URL construction without signing) |
+| GCS | `storage.googleapis.com\|getSignedUrl\|generateSignedUrl` |
+| Azure Blob | `generateBlobSASQueryParameters\|blob.url` |
+| Cloudflare R2 | `getPresignedUrl\|createSignedUrl` |
+| Generic | Direct URL construction for storage assets without a signing/TTL mechanism |
+
+---
+
+## A13 - Identity resolution patterns
+
+Reuse A1 patterns. Grep for the auth verification call to determine how the caller's identity is resolved.
+
+---
+
+## NS4 - Platform-specific security checks
+
+### Swift (iOS / macOS)
+
+| Check | Grep pattern | Flag condition |
+|---|---|---|
+| Keychain vs UserDefaults | `UserDefaults.*password\|UserDefaults.*token\|UserDefaults.*secret\|UserDefaults.*key` | Secrets stored in UserDefaults instead of Keychain |
+| ATS exceptions | `NSAppTransportSecurity.*NSAllowsArbitraryLoads` in Info.plist | ATS disabled without justification |
+| Data Protection | `FileProtectionType\|NSFileProtection` | Sensitive files without Data Protection |
+| Entitlements | `.entitlements` file entries | Any entitlement not justified by feature |
+| Hardened Runtime | `com.apple.security.cs.disable-library-validation` | Hardened Runtime exceptions |
+| TCC descriptions | `NS.*UsageDescription` in Info.plist | Missing usage description for protected resources |
+
+### Kotlin (Android)
+
+| Check | Grep pattern | Flag condition |
+|---|---|---|
+| Keystore vs SharedPreferences | `SharedPreferences.*password\|SharedPreferences.*token\|SharedPreferences.*secret` | Secrets in SharedPreferences instead of Keystore |
+| Certificate pinning | `network-security-config\|CertificatePinner` | Missing certificate pinning config |
+| ProGuard/R8 | `minifyEnabled\s+true\|isMinifyEnabled\s*=\s*true` in build.gradle | ProGuard/R8 disabled for release |
+| ContentProvider export | `exported="true"` in AndroidManifest.xml | ContentProvider exported without auth |
+| WebView JS | `setJavaScriptEnabled(true)` | JavaScript enabled in WebView by default |
+
+### Rust
+
+| Check | Grep pattern | Flag condition |
+|---|---|---|
+| Unsafe blocks | `unsafe\s*\{` | Missing safety justification comment |
+| FFI boundaries | `extern "C"\|#\[no_mangle\]` | Missing input validation at FFI boundary |
+| Constant-time comparison | `==.*secret\|==.*token\|==.*password` | Direct equality for secrets (use `constant_time_eq`) |
+
+### Go
+
+| Check | Grep pattern | Flag condition |
+|---|---|---|
+| SQL injection | `fmt.Sprintf.*SELECT\|fmt.Sprintf.*INSERT\|"SELECT.*" +` | String concatenation in SQL queries |
+| Context cancellation | `context.Background()\|context.TODO()` in request handlers | Missing context propagation |
+| Crypto stdlib | `crypto/md5\|crypto/sha1\|crypto/des` | Weak crypto algorithms |
+
+### Python
+
+| Check | Grep pattern | Flag condition |
+|---|---|---|
+| SQL injection | `f"SELECT.*{\|f"INSERT.*{\|"SELECT.*" %\|cursor.execute.*%` | f-strings or % formatting in SQL |
+| Subprocess injection | `subprocess.*shell=True\|os.system(\|os.popen(` | User input in shell commands |
+| Pickle on untrusted | `pickle.load\|pickle.loads` | Pickle on external/untrusted data |
+| SSRF | `requests.get(\|urllib.*urlopen(` with user-controlled URL | URL from user input without allowlist |
+
+### Ruby
+
+| Check | Grep pattern | Flag condition |
+|---|---|---|
+| Strong parameters | `params\[` without `params.require` or `params.permit` | Unfiltered params access |
+| CSRF protection | `skip_before_action :verify_authenticity_token` | CSRF protection disabled |
+| SQL interpolation | `.where(".*#{` | String interpolation in where() |
+| Cookie settings | `secure:\s*false\|httponly:\s*false` | Insecure cookie settings |
+
+### Java
+
+| Check | Grep pattern | Flag condition |
+|---|---|---|
+| Deserialization | `ObjectInputStream\|readObject()` | Deserialization of untrusted data |
+| PreparedStatement | `Statement.*execute\|createStatement` (not `PreparedStatement`) | Non-parameterized SQL |
+| XXE prevention | `DocumentBuilderFactory\|SAXParserFactory` without `setFeature.*disallow-doctype-decl` | XML parsing without XXE prevention |
+| SecureRandom | `new Random()\|Math.random()` in security context | Weak RNG for security operations |
+
+### .NET
+
+| Check | Grep pattern | Flag condition |
+|---|---|---|
+| Secret storage | `appsettings.*password\|appsettings.*secret\|appsettings.*connectionstring` (case-insensitive) | Secrets in appsettings.json instead of Secret Manager/Key Vault |
+| Anti-forgery | `[IgnoreAntiforgeryToken]\|ValidateAntiForgeryToken` absence | Missing anti-forgery on form endpoints |
+| HTTPS enforcement | `UseHttpsRedirection` absence in `Program.cs` | HTTPS not enforced |
+| Error details | `UseDeveloperExceptionPage` in production config | Stack traces exposed in production |

--- a/plugin/skills/security-audit/REPORT.md
+++ b/plugin/skills/security-audit/REPORT.md
@@ -1,0 +1,125 @@
+# security-audit - Report Template
+
+Generate the report using this template. Fill each section with findings from Steps 2-5.
+
+```
+## Security Audit - [DATE] - [TARGET]
+
+### Executive summary
+- [2-8 bullets: lead with the most critical risk. One bullet per Critical/High finding or notable PASS cluster. Be specific - name the route, table, or pattern.]
+
+### Scope reviewed
+- Routes / entry points: [N routes, list categories]
+- Validation layer: schema validation in [N] route files
+- DB/access control layer: [N] migration files + DB advisors (if available)
+- Headers: server config + live curl on staging
+- Assumptions: [e.g. "No server-side form actions - N/A"]
+
+### Security maturity assessment
+| Dimension | Rating | Notes |
+|---|---|---|
+| Auth coverage | low/medium/high | [summary] |
+| Authorization quality (RBAC + ownership) | low/medium/high | [summary] |
+| Input validation coverage | low/medium/high | [summary] |
+| Data exposure control | low/medium/high | [summary] |
+| RLS / row isolation | low/medium/high | [summary] |
+| Config hardening (headers, proxy) | low/medium/high | [summary] |
+| Release readiness | low/medium/high | [summary] |
+
+### Auth & Authorization (API routes)
+| # | Check | Routes flagged | Severity | Verdict |
+|---|---|---|---|---|
+| A1 | Missing auth check | N | Critical | ✅/❌ |
+| A2 | Missing role check (admin routes) | N | Critical | ✅/❌ |
+| A3 | Missing input validation (body/params/query) | N | High | ✅/❌ |
+| A4 | Raw input in queries | N | Critical | ✅/❌ |
+| A5 | Sensitive fields in responses | N | High | ✅/❌ |
+| A6 | Cron routes missing secret | N | Critical | ✅/❌ |
+| A7 | Export routes missing role check | N | High | ✅/❌ |
+| A8 | Client-exposed env var secret leak | N | Critical | ✅/❌ |
+| A9 | Privileged credentials in client code | N | Critical | ✅/❌ |
+| A10 | Public URL on private storage asset | N | High | ✅/❌ |
+| A11 | Open redirect | N | High | ✅/❌ |
+| A12 | Mass assignment | N | High | ✅/❌ |
+| A13 | Horizontal AC / IDOR (dynamic routes) | N | High | ✅/❌ |
+| A14 | State machine enforcement | N | High | ✅/❌ |
+
+### Response Shape Review
+| # | Check | Verdict | Notes |
+|---|---|---|---|
+| R1 | Sensitive field exposure (PII, financial) | ✅/❌ | |
+| R2 | Restricted data exposure | ✅/❌ | |
+| R3 | Error message verbosity | ✅/❌ | |
+| R5 | Rate limiting on high-value endpoints | ✅/❌ | |
+
+### RLS - Code-level check
+| # | Check | Tables flagged | Verdict |
+|---|---|---|---|
+| RLS-1 | Tables without row-level access control | N | ✅/❌ |
+| RLS-2 | Access control enabled but zero policies | N | ✅/❌ |
+| RLS-3 | Write-side policy checks missing | N | ✅/❌ |
+
+### Native Application Security (if applicable)
+| # | Check | Matches | Severity | Verdict |
+|---|---|---|---|---|
+| NS1 | Hardcoded secrets | N | Critical | ✅/❌ |
+| NS2 | Dependency vulnerabilities | N | High | ✅/❌ |
+| NS3 | Unvalidated external input | N | High | ✅/❌ |
+| NS4 | Platform security (stack-specific) | N | varies | ✅/❌ |
+| NS5 | Sensitive data protection | N | High | ✅/❌ |
+| NS6 | Code signing credentials in repo | N | Critical | ✅/❌ |
+
+### Database Security Advisors (if available)
+| Level | Count | Items |
+|---|---|---|
+| error (Critical) | N | [list] |
+| warning (High) | N | [list] |
+| info (Low) | N | [list] |
+
+### Dependency CVEs
+| Package | Version | Severity | CVE | Fix available |
+|---|---|---|---|---|
+| [name] | [range] | critical/high | [id] | yes/no |
+
+### HTTP Headers
+| Header | In config | In live response | Verdict |
+|---|---|---|---|
+| X-Frame-Options | ✅/❌ | ✅/❌ | ✅/❌ |
+| X-Content-Type-Options | ✅/❌ | ✅/❌ | ✅/❌ |
+| Referrer-Policy | ✅/❌ | ✅/❌ | ✅/❌ |
+| Content-Security-Policy | ✅/❌ | ✅/❌ | ✅/❌ |
+| Permissions-Policy | ✅/❌ | ✅/❌ | ✅/❌ |
+
+### Proxy / Middleware
+| Check | Verdict | Notes |
+|---|---|---|
+| API protected behind auth layer | ✅/❌ | |
+| Auth-gated redirects server-side (not client-side) | ✅/❌ | |
+| Public route whitelist is narrow (no wildcard) | ✅/❌ | |
+| No forgeable bypass header trusted | ✅/❌ | |
+
+### Prioritized findings (Critical → High → Medium → Low)
+Format: `[SEVERITY] route/file:line - check# - issue - exploit path - recommended fix - effort`
+
+### Quick wins
+[findings that are isolated, low-risk fixes - e.g. add ownership filter, add validation enum on query param, add write-side policy check]
+
+### Strategic refactors
+[findings requiring broader changes - e.g. state machine enforcement across all transition routes, centralized response serializers, access control policy overhaul]
+
+### Validation checklist
+After applying fixes, verify:
+- [ ] Unauthenticated request (no token) to each fixed route → 401
+- [ ] Horizontal AC: request with valid token but different owner's ID → 403 or 404
+- [ ] State machine: request with invalid transition on current state → 422
+- [ ] Path param validation: request with invalid ID format → 400
+- [ ] Row-level access: unprivileged query on fixed tables → 0 rows (not error)
+- [ ] DB advisors re-run after schema changes → 0 critical-level items
+```
+
+## Severity guide
+
+- **Critical**: unauthenticated route exposing or modifying data; row-level access bypass; privileged credentials in client code; client-exposed env var secret; cron route with no secret check; raw input in queries; DB advisor critical-level finding; table missing row-level access control on sensitive data (RLS-1); hardcoded secrets in source code (NS1); signing credentials committed to repo (NS6); unsafe block without safety justification in Rust (NS4)
+- **High**: admin route without role check; sensitive PII/financial field exposed to non-owner; export route without role check; public URL on private storage asset; open redirect; mass assignment; horizontal AC / IDOR on sensitive records (A13); state machine bypass on financial/status transitions (A14); missing write-side policy checks (RLS-3); DB advisor warning-level finding; critical/high CVE in production dependency (NS2); unvalidated external input at system boundary (NS3); sensitive data written without platform encryption (NS5); disabled code signing (NS6)
+- **Medium**: missing validation on write route body; unvalidated path param or query param used in DB filter (A3); error message leaking DB internals; missing security header; no rate limiting on high-value endpoints; access control enabled but zero policies (RLS-2); sensitive data in log output (NS5)
+- **Low**: header best-practice gap; informational DB advisor finding; moderate/low CVE not directly exploitable; state machine bypass on low-risk status fields

--- a/plugin/skills/skill-dev/PATTERNS.md
+++ b/plugin/skills/skill-dev/PATTERNS.md
@@ -1,0 +1,175 @@
+# Code Quality Audit - Stack Patterns
+
+Reference file for `/skill-dev`. Contains language-specific and framework-specific grep patterns.
+The executing agent reads this file at the start of Step 2. Select patterns matching the detected stack. Checks without a matching pattern produce `N/A - skipped for <stack>`.
+
+---
+
+## DL1 - Language-specific lint and analysis checks
+
+### Swift
+
+| Check | Grep pattern | Flag condition |
+|---|---|---|
+| Force unwrap | `!` on optionals outside `guard`/`if let` | Crash risk on nil |
+| SwiftLint patterns | Run `swiftlint lint` if available | Any warning/error |
+| Retain cycle risk | `{ self.` or `{ [self]` without `[weak self]` | In closures stored by long-lived objects (completion handlers, observers, timers) |
+
+### Kotlin
+
+| Check | Grep pattern | Flag condition |
+|---|---|---|
+| Null safety violations | `!!` operator | Crash risk on null |
+| Detekt patterns | Run `detekt` if available | Any warning/error |
+| Coroutine scope leaks | `GlobalScope.launch`, `GlobalScope.async` | No lifecycle-aware cancellation |
+
+### Rust
+
+| Check | Grep pattern | Flag condition |
+|---|---|---|
+| Clippy warnings | `cargo clippy -- -W clippy::all` | Any warning |
+| Unnecessary clone | `.clone()` where value is only read after | Borrow would suffice |
+| Complex lifetimes | Lifetime annotations with 3+ parameters | Consider simplification or `Arc`/`Rc` |
+| Unwrap in production | `unwrap()` outside test files | Panic risk on Err/None |
+
+### Go
+
+| Check | Grep pattern | Flag condition |
+|---|---|---|
+| Go vet | `go vet ./...` | Any finding |
+| Unchecked errors | `errcheck` - return values of error-returning functions ignored | Silent failure |
+| Staticcheck | `staticcheck ./...` | Any finding |
+| Naked goroutines | `go func` or `go ` inside loops without context cancellation | Goroutine leak risk |
+
+### Python
+
+| Check | Grep pattern | Flag condition |
+|---|---|---|
+| Type hint coverage | Public functions (`def [^_]`) without type annotations | Missing return type or parameter types |
+| Ruff/Pylint | Run `ruff check` or `pylint` if available | Any warning/error |
+| Bare except | `except:` without exception type | Catches KeyboardInterrupt, SystemExit |
+| Mutable default args | `def \w+\(.*=\s*(\[\]|\{\}|set\(\))` | Shared mutable default between calls |
+
+### Ruby
+
+| Check | Grep pattern | Flag condition |
+|---|---|---|
+| Rubocop patterns | Run `rubocop` if available | Any warning/error |
+| Method length | Methods > 25 lines | Extract into smaller methods |
+| Frozen string literal | Missing `# frozen_string_literal: true` at file top | Performance and mutation risk |
+
+### Java
+
+| Check | Grep pattern | Flag condition |
+|---|---|---|
+| SpotBugs patterns | Run `spotbugs` if available | Any finding |
+| Unchecked casts | `(Type)` cast without `instanceof` check | ClassCastException risk |
+| Empty catch swallowing | `catch\s*\(\w+\s+\w+\)\s*\{\s*\}` on checked exceptions | Silent failure on recoverable errors |
+| Raw types | Generic types used without type parameters | Type safety loss |
+
+### .NET
+
+| Check | Grep pattern | Flag condition |
+|---|---|---|
+| Nullable warnings | `#nullable disable` or missing nullable annotations on public APIs | Null safety regression |
+| IDisposable leak | `new \w+` on IDisposable types without `using` | Resource leak |
+| Async void | `async void` methods (except event handlers) | Unobservable exceptions |
+
+---
+
+## D3 - Database query call patterns
+
+| ORM / Client | Query method pattern |
+|---|---|
+| SQL (generic) | `.query(`, `.execute(`, `.raw(` |
+| Supabase JS | `.from(`, `.select(`, `.insert(`, `.update(`, `.delete(`, `.rpc(` |
+| Prisma | `.findMany(`, `.findFirst(`, `.findUnique(`, `.create(`, `.update(`, `.delete(` |
+| Drizzle | `.select(`, `.insert(`, `.update(`, `.delete(`, `.from(` |
+| Sequelize | `.findAll(`, `.findOne(`, `.create(`, `.update(`, `.destroy(` |
+| TypeORM | `.find(`, `.findOne(`, `.save(`, `.remove(` |
+| Django ORM | `.filter(`, `.get(`, `.all()`, `.create(`, `.update(`, `.delete(` |
+| SQLAlchemy | `session.query(`, `session.execute(`, `.filter(`, `.all()` |
+| ActiveRecord | `.where(`, `.find(`, `.find_by(`, `.all`, `.create(`, `.update(` |
+| Eloquent | `::where(`, `::find(`, `::all()`, `::create(` |
+| Go (sqlx/pgx) | `.Query(`, `.QueryRow(`, `.Exec(`, `.Get(`, `.Select(` |
+| Rust (sqlx) | `sqlx::query(`, `sqlx::query_as(`, `.fetch(`, `.fetch_one(` |
+| Swift (Core Data) | `NSFetchRequest`, `.fetch(`, `NSManagedObjectContext` |
+| Swift (GRDB) | `.fetchAll(`, `.fetchOne(`, `.execute(` |
+| Kotlin (Room) | `@Query`, `.dao.` method calls |
+
+---
+
+## D4 - Public API surface patterns (per language)
+
+| Language | Public symbol pattern | Description |
+|---|---|---|
+| TypeScript / JavaScript | `export (function\|const\|type\|interface\|class)` | Exported declarations |
+| Python | `def [^_]\w+\(` and `class [^_]\w+` at module level | Public functions/classes (no `_` prefix) |
+| Swift | `public \|open ` declarations | Public/open access control |
+| Go | Capitalized identifiers: `func [A-Z]`, `type [A-Z]`, `var [A-Z]` | Exported identifiers |
+| Kotlin | `fun \|val \|var \|class ` without `private\|internal` modifier | Default-public declarations |
+| Rust | `pub fn \|pub struct \|pub enum \|pub trait ` | Public items |
+| Java | `public (class\|interface\|void\|static\|\w+)` | Public declarations |
+| .NET | `public (class\|interface\|void\|static\|\w+)` | Public declarations |
+| Ruby | `def \w+` at class level (no convention for private beyond `private` keyword) | Default-public methods |
+
+---
+
+## D8 - Type safety suppression patterns
+
+### Pattern A - Directive suppressions
+
+| Language | Suppression pattern | Severity note |
+|---|---|---|
+| TypeScript | `@ts-ignore` | Highest - silences all errors |
+| TypeScript | `@ts-expect-error` | Acceptable only with description comment |
+| TypeScript | `@ts-nocheck` | File-level suppression - always flag |
+| Python | `# type: ignore` | Suppresses mypy/pyright checks |
+| Java / Kotlin | `@SuppressWarnings` | Flag with specific warning type |
+| Rust | `unsafe` blocks | Flag unless justified in comment |
+| Go | `// nolint` | Suppresses linter checks |
+| .NET | `#pragma warning disable` | Flag with specific warning code |
+
+### Pattern B - Untyped escape hatches (TypeScript-specific)
+
+| Pattern | Context |
+|---|---|
+| `:\s*any\b` | Type annotation as `any` |
+| `as\s+any\b` | Type assertion to `any` |
+| `<any>` | Generic type parameter as `any` |
+| `Promise<any>` | Untyped promise |
+
+Exclude: generated type files, vendor types, explicit exemptions in CLAUDE.md Known Patterns.
+
+### Pattern C - Floating promises
+
+Grep for async calls (DB queries, route navigation, API calls) that appear as bare statements without `await`, `void`, `return`, or error handling. These are silent fire-and-forget calls.
+
+---
+
+## D9 - Lifecycle/side-effect hook patterns
+
+| Framework | Lifecycle hooks |
+|---|---|
+| React | `useEffect(` |
+| Vue | `onMounted(`, `watch(`, `watchEffect(` |
+| Svelte | `onMount(`, `$:` (reactive statements) |
+| Angular | `ngOnInit(`, `ngOnChanges(`, `ngAfterViewInit(` |
+| Swift (SwiftUI) | `.onAppear(`, `.task(`, `.onChange(` |
+| Kotlin (Compose) | `LaunchedEffect(`, `DisposableEffect(`, `SideEffect(` |
+
+---
+
+## D10 - Debug output patterns
+
+| Language | Debug output pattern |
+|---|---|
+| TypeScript / JavaScript | `console.log(`, `console.debug(`, `console.info(`, `console.warn(`, `console.error(` |
+| Python | `print(` (at statement level, not inside format strings) |
+| Swift | `print(` |
+| Rust | `println!(`, `dbg!(`, `eprintln!(` |
+| Go | `fmt.Println(`, `fmt.Printf(`, `fmt.Print(`, `log.Println(` |
+| Ruby | `puts `, `p `, `pp ` |
+| Java | `System.out.println(`, `System.err.println(` |
+| Kotlin | `println(`, `print(` |
+| .NET | `Console.WriteLine(`, `Console.Write(`, `Debug.WriteLine(` |


### PR DESCRIPTION
## Summary

- Cherry-picks fix(plugin) #222 onto main base (companion files for plugin skills)
- Bumps version to 1.32.1
- Updates CHANGELOG with v1.32.1 entry

## Changes included

- 7 missing companion files added to `plugin/skills/` (arch-audit, perf-audit, security-audit, skill-dev)
- `arch-audit` Step 5 made conditional — non-invasive on non-CDK projects

## Test plan

- [ ] CI green
- [ ] After merge: update `marketplace.json` SHA to new main HEAD
- [ ] Publish GitHub Release v1.32.1 to trigger npm publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)