### PR TITLE
fix(scaffold): update marketplace.json SHA to v1.32.1 main HEAD

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -31,7 +31,7 @@
         "source": "url",
         "url": "https://github.com/marcoguillermaz/tierward.git",
         "ref": "main",
-        "sha": "8a3195d173946cb5e0d846cfa36eab1b19efb5e4"
+        "sha": "27ad01d201b5fe1f50a1da6f7d71a2d3f2d85e00"
       }
     }
   ]


### PR DESCRIPTION
## Summary

Updates `marketplace.json` SHA to `27ad01d` — the HEAD of main after v1.32.1 merged (#223).

This is the final step before marketplace submission. All 8 plugin skills now have their companion files bundled and are verified to work standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)