### PR TITLE
chore(release): sync plugin.json version to 1.32.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tierward",
   "displayName": "Tierward",
-  "version": "1.31.1",
+  "version": "1.32.1",
   "description": "Governance skills for AI-assisted development: commit enforcement, architecture compliance, security audits, code quality, and humanized prose.",
   "author": {
     "name": "Marco Guillermaz",


### PR DESCRIPTION
## Summary

- Bumps `.claude-plugin/plugin.json` version from `1.31.1` to `1.32.1` to align with the npm package release
- Required before marketplace submission — version must match the published package

## Test plan

- [ ] `claude plugin validate` passes on main after merge