### PR TITLE
fix(scaffold): update marketplace.json SHA after plugin.json version sync

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -31,7 +31,7 @@
         "source": "url",
         "url": "https://github.com/marcoguillermaz/tierward.git",
         "ref": "main",
-        "sha": "27ad01d201b5fe1f50a1da6f7d71a2d3f2d85e00"
+        "sha": "3a986f02f86eff08e4ee973beaca7525f983831a"
       }
     }
   ]


### PR DESCRIPTION
## Summary

- Updates `marketplace.json` source SHA to `3a986f02f86eff08e4ee973beaca7525f983831a` (main HEAD after PR #226 merge)
- Keeps SHA pinned to the commit that includes the `plugin.json` 1.32.1 version sync

## Test plan

- [ ] `claude plugin validate` passes after merge