### PR TITLE
feat(scaffold): tier 0 imports output-style.md communication governance

### DIFF
--- a/docs/operational-guide.md
+++ b/docs/operational-guide.md
@@ -282,15 +282,16 @@ The pipeline is the sequence of phases Claude follows for every development task
 ### Tier 0 - Discovery
 
 **Use for**: teams exploring Claude Code for the first time. No pipeline knowledge required.
-**What it provides**: one constraint (tests must pass) and project context (CLAUDE.md). Nothing else.
+**What it provides**: one constraint (tests must pass), project context (CLAUDE.md), and one communication rule (output-style.md). No pipeline, no workflow rules.
 
-| File                    | Purpose                                                                         |
-| ----------------------- | ------------------------------------------------------------------------------- |
-| `CLAUDE.md`             | Project context: stack, commands, conventions. Claude reads this every session. |
-| `.claude/settings.json` | Stop hook: tests must pass before Claude declares a task complete.              |
-| `GETTING_STARTED.md`    | Step-by-step guide for the first session.                                       |
+| File                            | Purpose                                                                                  |
+| ------------------------------- | ---------------------------------------------------------------------------------------- |
+| `CLAUDE.md`                     | Project context: stack, commands, conventions. Claude reads this every session.          |
+| `.claude/settings.json`         | Stop hook: tests must pass before Claude declares a task complete.                       |
+| `.claude/rules/output-style.md` | Communication rules: answer-first, no AI-tells, hold position on evidence not pressure.  |
+| `GETTING_STARTED.md`            | Step-by-step guide for the first session.                                                |
 
-**The Stop hook is the only governance control in Tier 0** - and it's the most important one.
+**The Stop hook is the only enforcement control in Tier 0** - tests must pass before Claude can finish. The one rule file (output-style.md) shapes how Claude communicates, but it gates nothing.
 
 **After running init (Tier 0):**
 
@@ -678,7 +679,7 @@ Commit format, branch naming rules, PR conventions. Loaded for all git operation
 
 ---
 
-### .claude/rules/output-style.md (Tier M/L)
+### .claude/rules/output-style.md (all tiers)
 
 Communication rules for Claude in this project. No sycophantic openers, no AI discourse markers, plain vocabulary, directness-first, hyphen not em-dash.
 

--- a/packages/cli/src/generators/claude-md.js
+++ b/packages/cli/src/generators/claude-md.js
@@ -37,6 +37,11 @@ export async function generateClaudeMd(config, targetDir) {
   if (tier === 's' || tier === 'm' || tier === 'l') {
     content = injectRuleImports(content);
     content = injectActiveSkills(content, config);
+  } else if (tier === '0') {
+    // Tier 0 gets only the communication-governance import. The standards docs
+    // (@docs/*-standards.md) are not scaffolded for tier 0 - importing them
+    // would dangle - and there is no Active Skills section.
+    content = injectRuleImports(content, ['@.claude/rules/output-style.md']);
   }
 
   // Strip web-centric convention for projects without API routes
@@ -115,15 +120,18 @@ function buildCommandsBlock(config) {
 }
 
 /**
- * Append @-imports for the three shared rule files before the first ##-heading
- * that doesn't already have them. If they already exist, skip.
+ * Append rule @-imports after the first H1 heading. Defaults to the three
+ * shared files (S/M/L); callers pass a narrower list for leaner tiers
+ * (tier 0 imports only output-style.md). Idempotent - skips if already present.
  */
-function injectRuleImports(content) {
-  const imports = [
+function injectRuleImports(
+  content,
+  imports = [
     '@.claude/rules/output-style.md',
     '@docs/claudemd-standards.md',
     '@docs/pipeline-standards.md',
-  ];
+  ],
+) {
   // If any import already present, skip (idempotent)
   if (imports.every((i) => content.includes(i))) return content;
 

--- a/packages/cli/src/scaffold/index.js
+++ b/packages/cli/src/scaffold/index.js
@@ -26,6 +26,17 @@ async function scaffoldTier0(targetDir, config, templatesDir) {
     await fs.writeFile(destPath, interpolate(content, config));
   }
 
+  // Copy the communication-governance rule only. Tier 0 deliberately gets no
+  // workflow governance (no pipeline, git, security, or context-review rules) -
+  // output-style.md is the single behavioral rule its CLAUDE.md @-imports.
+  const outputStyleSrc = path.join(templatesDir, 'common', 'rules', 'output-style.md');
+  if (await fs.pathExists(outputStyleSrc)) {
+    const outputStyleDest = path.join(targetDir, '.claude', 'rules', 'output-style.md');
+    await fs.ensureDir(path.dirname(outputStyleDest));
+    const content = await fs.readFile(outputStyleSrc, 'utf8');
+    await fs.writeFile(outputStyleDest, interpolate(content, config));
+  }
+
   // Create session directory (used by Claude for session recovery)
   await fs.ensureDir(path.join(targetDir, '.claude', 'session'));
 }

--- a/packages/cli/src/utils/print-plan.js
+++ b/packages/cli/src/utils/print-plan.js
@@ -268,12 +268,14 @@ function getFilePlan(config) {
   const tier = (config.tier || 's').toUpperCase();
   const mode = config.mode || 'greenfield';
 
-  // Tier 0 is a minimal scaffold - no pipeline, no rules, no governance layer
+  // Tier 0 is a minimal scaffold - communication governance only
+  // (output-style.md), no pipeline or workflow rules.
   if (tier === '0') {
     return [
       'CLAUDE.md',
       'GETTING_STARTED.md',
       '.claude/settings.json',
+      '.claude/rules/output-style.md',
       '.claude/session/  (directory)',
     ];
   }

--- a/packages/cli/templates/common/rules/output-style.md
+++ b/packages/cli/templates/common/rules/output-style.md
@@ -16,6 +16,8 @@ These rules apply to every Claude response in this project, regardless of task t
 - If a request contains a factually incorrect premise, correct it first - then decide whether to satisfy the original request.
 - Do not validate wrong assumptions to seem agreeable. Agreeable but wrong is worse than useful and uncomfortable.
 - If you don't know something, say so explicitly. Never proceed with an unverified assumption without stating it is an assumption.
+- When you disagree, state the reason, the better alternative, and the concrete risk - not just the objection.
+- Change your position only when given new evidence or constraints, not under pressure alone. Insisting or repeating a request is not new evidence.
 
 ## Tone and structure
 

--- a/packages/cli/templates/tier-0/GETTING_STARTED.md
+++ b/packages/cli/templates/tier-0/GETTING_STARTED.md
@@ -81,6 +81,7 @@ These notes persist across sessions. Claude reads them every time.
 Tier 0 (what you have now) gives you the minimum viable scaffold:
 - Claude knows your project via `CLAUDE.md`
 - Tests must pass before Claude declares a task complete
+- Claude follows a small set of communication rules (`output-style.md`)
 
 When your team grows or your project complexity increases, upgrade to a higher tier:
 

--- a/packages/cli/test/integration/run.js
+++ b/packages/cli/test/integration/run.js
@@ -362,8 +362,17 @@ async function scenarioTier0() {
   assertExists(dir, '.claude/settings.json');
   assertDirExists(dir, '.claude/session');
 
-  // Tier 0 must NOT have pipeline or governance files
+  // Tier 0 gets communication governance only (output-style.md) - no workflow rules
+  assertExists(dir, '.claude/rules/output-style.md');
+  assertContains(
+    dir,
+    'CLAUDE.md',
+    '@.claude/rules/output-style.md',
+    'tier-0 CLAUDE.md imports output-style',
+  );
   assertNotExists(dir, '.claude/rules/pipeline.md');
+  assertNotExists(dir, '.claude/rules/git.md');
+  assertNotExists(dir, '.claude/rules/security.md');
   assertNotExists(dir, 'README.md');
   assertNotExists(dir, '.github');
   assertNotExists(dir, '.pre-commit-config.yaml');


### PR DESCRIPTION
## What

Tier 0 (Discovery) now scaffolds and imports `output-style.md`, so it gets the same communication-governance baseline that tiers S/M/L already have. The rule file itself also gains two posture rules, which means every tier picks them up:

- disagree with a reason, a better alternative, and the concrete risk - not a bare objection
- change position on new evidence or constraints, not under pressure

## Why

Communication governance (answer-first, no AI-tells, hold your position) is useful at every tier. Workflow governance (pipeline, branch discipline, security rules) can stay optional for early-stage work. So tier 0 gets the one communication rule and nothing else: no pipeline, no workflow rules. Its `CLAUDE.md` imports only `@.claude/rules/output-style.md`, not the S/M/L standards docs that tier 0 does not ship.

## Scope (7 files)

- `scaffold/index.js` - tier-0 copies `output-style.md` only
- `generators/claude-md.js` - tier-0 injects the single import (parametrized `injectRuleImports`)
- `print-plan.js` - dry-run lists the new file
- `templates/common/rules/output-style.md` - two new posture rules
- `templates/tier-0/GETTING_STARTED.md` - mentions the rule
- `docs/operational-guide.md` - tier-0 section and the output-style scope corrected to "all tiers"
- `test/integration/run.js` - asserts the rule is present and imported, and that tier-0 still ships no workflow rules

## Tests

- Unit: 585/585 pass
- Integration: green except 3 pre-existing failures (see below)

## A note on CI and #229

This PR targets `staging`. The integration suite in `ci.yml` only runs on PRs to `main`, so the 3 failing `claudemd-skills-directory-parity` checks (tiers s/m/l) do not run here - the only workflow on this PR is auto-merge, which skips while the PR is a draft.

Those 3 failures are a pre-existing regression on `staging`: #229 added `systematic-debugging` to the S/M/L skill templates but never registered it in `getActiveSkills()`, so `CLAUDE.md` does not list it and the parity check warns. This PR does not introduce or worsen it. It must be fixed before the next `staging` -> `main` release PR, where the integration suite gates it. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
