### PR TITLE
feat(scaffold): output-style language invariant + doctor validates it on tier 0

### DIFF
--- a/docs/operational-guide.md
+++ b/docs/operational-guide.md
@@ -1239,7 +1239,7 @@ Runs 29 checks:
 9. Stop hook is configured with a non-empty command
 10. Stop hook command has no unfilled `[TEST_COMMAND]` placeholder
 11. `.github/CODEOWNERS` covers `.claude/`
-12. `.claude/rules/output-style.md` present (Tier M/L - warn if missing)
+12. `.claude/rules/output-style.md` present (all tiers, including Tier 0 - warn if missing)
 13. `docs/claudemd-standards.md` present (Tier M/L - warn if missing)
 14. `docs/pipeline-standards.md` present (Tier M/L - warn if missing)
 15. `.claude/skills/commit/` present (Tier M/L - warn if missing)
@@ -1258,7 +1258,7 @@ Runs 29 checks:
 28. `team-settings.json` runtime enforcement hook is scaffolded and registered on the `Skill` matcher in `.claude/settings.json` (warn-level; skips when `team-settings.json` is absent — added in v1.21.0)
 29. No duplicate entries in `permissions.deny` list (warn if duplicates found)
 
-Checks 12-29 are skipped for Tier 0 projects.
+Checks 13-29 are skipped for Tier 0 projects. Check 12 (`output-style.md`) now runs for Tier 0 too, since output-style.md ships in every tier.
 
 **`--report` output**: machine-readable JSON with timestamp, cwd, summary (passed/warned/failed/skipped), and per-check details. Consumed by CI systems or external audit tools.
 

--- a/packages/cli/src/commands/doctor.js
+++ b/packages/cli/src/commands/doctor.js
@@ -214,10 +214,13 @@ const checks = [
   },
   {
     id: 'output-style-rule',
-    label: '.claude/rules/output-style.md present (tier M/L)',
+    label: '.claude/rules/output-style.md present (all tiers)',
     check: (cwd) => {
-      const hasPipeline = fs.existsSync(path.join(cwd, '.claude', 'rules', 'pipeline.md'));
-      if (!hasPipeline) return { pass: true, skip: true };
+      // output-style.md ships in every tier (0/S/M/L), so gate on the scaffold
+      // signal (settings.json) rather than pipeline.md - tier 0 has no pipeline
+      // but does ship output-style.md.
+      const isScaffold = fs.existsSync(path.join(cwd, '.claude', 'settings.json'));
+      if (!isScaffold) return { pass: true, skip: true };
       const exists = fs.existsSync(path.join(cwd, '.claude', 'rules', 'output-style.md'));
       return {
         pass: exists,

--- a/packages/cli/templates/common/rules/output-style.md
+++ b/packages/cli/templates/common/rules/output-style.md
@@ -6,6 +6,10 @@ description: Output style and communication rules — applies to all Claude resp
 
 These rules apply to every Claude response in this project, regardless of task type.
 
+## Language
+
+- Never translate code identifiers, file paths, commands, field names, env vars, or other system values - keep them verbatim, whatever language you respond in.
+
 ## Punctuation
 
 - Use `-` (hyphen) instead of `—` (em-dash) in all output. No exceptions.

--- a/packages/cli/test/integration/run.js
+++ b/packages/cli/test/integration/run.js
@@ -2680,6 +2680,35 @@ async function scenarioDoctorCrossFileValidation() {
       fail(`Tier ${tier} corrupt-security: expected warn/fail, got ${secStatus}`);
     }
   }
+
+  // Tier 0: output-style.md now ships in tier 0 and doctor validates it
+  // (gated on settings.json, not pipeline.md). It must pass, not skip.
+  {
+    const config0 = {
+      ...BASE,
+      tier: '0',
+      isDiscovery: true,
+      includePreCommit: false,
+      includeGithub: false,
+    };
+    const dir0 = await scaffold('doctor-xfile-tier-0-output-style', '0', config0);
+    fillStopHookTestCmd(dir0);
+    const status0 = getCheckStatus(runDoctor(dir0), 'output-style-rule');
+    if (status0 === 'pass') {
+      pass('Tier 0: output-style-rule = pass (validated, not skipped)');
+    } else {
+      fail(`Tier 0: output-style-rule = ${status0} (expected pass)`);
+    }
+
+    // Negative: remove the rule -> warn (not skip)
+    fs.rmSync(path.join(dir0, '.claude/rules/output-style.md'));
+    const status0b = getCheckStatus(runDoctor(dir0), 'output-style-rule');
+    if (status0b === 'warn') {
+      pass('Tier 0: output-style-rule = warn when output-style.md removed');
+    } else {
+      fail(`Tier 0: output-style-rule = ${status0b} (expected warn)`);
+    }
+  }
 }
 
 async function scenarioDocAuditPresent() {


### PR DESCRIPTION
Two governance follow-ups for the tier-0 output-style work (#230).

## 1. Language invariant (output-style.md, all tiers)

Adds one rule: never translate code identifiers, file paths, commands, field names, env vars, or other system values - keep them verbatim, whatever language Claude responds in. A universal invariant; the response-language preference stays on Claude's default (no wizard field, by design).

## 2. doctor validates output-style.md for tier 0

`output-style.md` now ships in every tier, but `doctor`'s check gated on `pipeline.md` (absent in tier 0), so tier 0's only rule file was scaffolded yet never validated. The check now gates on `.claude/settings.json` (the scaffold signal), so it runs for all tiers including tier 0. The M/L-only checks (claudemd-standards, pipeline-standards) still gate on pipeline.md. Label updated to "(all tiers)"; operational-guide updated to match.

## Tests

- Unit 585/585, integration 1170/0 - including 2 new tier-0 doctor assertions: pass when output-style.md is present, warn when it is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
