### PR TITLE
chore(release): v1.33.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.33.1] — 2026-06-19
+
+### Added
+
+- **Language rule in `output-style.md` (all tiers).** Claude must never translate code identifiers, file paths, commands, field names, env vars, or other system values; they stay verbatim regardless of the response language. Shipped to every tier through the existing rule import. (#237, #238)
+
+### Fixed
+
+- **`doctor` now validates `output-style.md` on tier 0.** The `output-style-rule` check gated on `pipeline.md`, which tier 0 does not ship, so tier 0's only rule file was scaffolded but never checked. The gate is now `.claude/settings.json` (the scaffold signal), so the check covers every tier; the M/L-only standards checks still gate on `pipeline.md`. (#237, #238)
+
+---
+
 ## [1.33.0] — 2026-06-19
 
 ### Added

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tierward",
-  "version": "1.33.0",
+  "version": "1.33.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tierward",
-      "version": "1.33.0",
+      "version": "1.33.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tierward",
-  "version": "1.33.0",
+  "version": "1.33.1",
   "description": "Scaffold for legible, reviewable AI-assisted development",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Version bump 1.33.0 → 1.33.1 + CHANGELOG entry. Releases the two governance follow-ups (#237, #238): Language rule in output-style.md (all tiers) and doctor validating output-style.md on tier 0. No code changes beyond version/lock/CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)