### PR TITLE
chore(mcp): encode tierward-mcp bin in server.json runtimeArguments

### DIFF
--- a/server.json
+++ b/server.json
@@ -12,6 +12,11 @@
       "registryType": "npm",
       "identifier": "tierward",
       "version": "1.33.2",
+      "runtimeHint": "npx",
+      "runtimeArguments": [
+        { "type": "named", "name": "--package", "value": "tierward" },
+        { "type": "positional", "value": "tierward-mcp", "valueHint": "mcp-binary" }
+      ],
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Adds `runtimeHint: npx` + `runtimeArguments` so MCP clients run the non-default `tierward-mcp` bin (`npx -y --package=tierward tierward-mcp`) instead of the default `tierward` CLI. Best-effort encoding — verify in a real client post-publish, republish if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)