### PR TITLE
chore(workflow): feature-branch flow off main, retire staging

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/packages/cli"
-    target-branch: "staging"
+    target-branch: "main"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -25,7 +25,7 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "staging"
+    target-branch: "main"
     schedule:
       interval: "monthly"
       timezone: "Europe/Rome"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, staging]
+    branches: [main]
   pull_request:
-    branches: [main, staging]
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -2,12 +2,12 @@ name: VS Code Extension
 
 on:
   push:
-    branches: [main, staging]
+    branches: [main]
     paths:
       - 'packages/vscode-extension/**'
       - '.github/workflows/vscode-extension.yml'
   pull_request:
-    branches: [main, staging]
+    branches: [main]
     paths:
       - 'packages/vscode-extension/**'
       - '.github/workflows/vscode-extension.yml'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,8 @@ cd tierward
 cd packages/cli && npm install
 ```
 
+**Branch flow.** Branch off `main`, push your branch, and open a PR back to `main`. PRs are squash-merged and the branch is deleted on merge, so keep each branch to one focused change. There is no long-lived integration branch; start every change from a fresh branch off `main`.
+
 **Run the CLI locally**:
 
 ```bash


### PR DESCRIPTION
Fixes the recurring merge conflicts (#243, #249, #250) caused by a long-lived `staging` branch fighting the repo's squash-merge + delete-branch model.

**Change:** short-lived feature branches off `main`.
- Dependabot `target-branch`: staging → main
- `ci.yml` / `vscode-extension.yml` triggers: `[main, staging]` → `[main]` (feature branches get CI via the PR trigger)
- CONTRIBUTING: documents the branch flow

Repo settings (squash-only, delete_branch_on_merge, auto-merge) are correct for this model and unchanged. This PR is itself made via a feature branch — dogfooding the new flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)