### PR TITLE
fix(mcp): align server.json description with published registry version

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.marcoguillermaz/tierward",
-  "description": "Read a project's Tierward governance state from any MCP client: doctor report, team-settings policy, last arch-audit, and skill inventory.",
+  "description": "Read a Tierward project's governance state (doctor, team-settings, arch-audit, skills) over MCP.",
   "repository": {
     "url": "https://github.com/marcoguillermaz/Tierward",
     "source": "github"


### PR DESCRIPTION
The committed `server.json` on main has a 138-char description (over the MCP registry's 100-char limit), but the live registry listing has the corrected 96-char version. This happened because #250 auto-merged before the shortening commit. Aligns the repo to what's published, so re-running `mcp-publisher publish` from main won't 422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)