### PR TITLE
chore(release): promote staging → main (staging-integration workflow)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/packages/cli"
-    target-branch: "main"
+    target-branch: "staging"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -25,7 +25,7 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "main"
+    target-branch: "staging"
     schedule:
       interval: "monthly"
       timezone: "Europe/Rome"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, staging]
   pull_request:
-    branches: [main]
+    branches: [main, staging]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -2,12 +2,12 @@ name: VS Code Extension
 
 on:
   push:
-    branches: [main]
+    branches: [main, staging]
     paths:
       - 'packages/vscode-extension/**'
       - '.github/workflows/vscode-extension.yml'
   pull_request:
-    branches: [main]
+    branches: [main, staging]
     paths:
       - 'packages/vscode-extension/**'
       - '.github/workflows/vscode-extension.yml'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,11 @@ cd tierward
 cd packages/cli && npm install
 ```
 
-**Branch flow.** Branch off `main`, push your branch, and open a PR back to `main`. PRs are squash-merged and the branch is deleted on merge, so keep each branch to one focused change. There is no long-lived integration branch; start every change from a fresh branch off `main`.
+**Branch flow.** `main` is released and stable; `staging` is the long-lived integration branch. Never commit to `main` directly. The only PRs into `main` are promotions from `staging`.
+
+For each change, branch off `staging` (a `feat|fix|chore/<slug>` branch, or a worktree via `./new-worktree.sh <type> <slug>`), do the work there, and open a PR back into `staging`. Feature PRs into `staging` are squash-merged. When `staging` is ready to ship, open a promotion PR from `staging` to `main` and merge it with a merge commit, not a squash: this keeps a shared history between the two branches. Squash promotion is what caused the recurring conflicts this flow replaces.
+
+**Worktrees.** `./new-worktree.sh <feat|fix|chore> <slug>` creates an isolated worktree in a sibling directory on a branch off `staging`. Each worktree is self-contained. Because `node_modules/` is gitignored, run `npm install` inside the worktree before you start, since a fresh checkout has no dependencies. Commit only on that worktree's branch, open the PR into `staging`, and once it merges, remove the worktree with `git worktree remove <dir>` to clean up.
 
 **Run the CLI locally**:
 

--- a/new-worktree.sh
+++ b/new-worktree.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Usage: ./new-worktree.sh <feat|fix|chore> <slug>
+# Creates a git worktree in a sibling directory with a branch off origin/staging.
+set -euo pipefail
+
+TYPE=${1:-}
+SLUG=${2:-}
+
+if [[ -z "$TYPE" || -z "$SLUG" ]]; then
+  echo "Usage: $0 <feat|fix|chore> <slug>" >&2
+  exit 1
+fi
+
+if [[ ! "$TYPE" =~ ^(feat|fix|chore)$ ]]; then
+  echo "Error: type must be feat, fix, or chore" >&2
+  exit 1
+fi
+
+BRANCH="${TYPE}/${SLUG}"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+REPO_NAME="$(basename "$REPO_ROOT")"
+WORKTREE_DIR="${REPO_ROOT}/../${REPO_NAME}-${SLUG}"
+
+git fetch origin staging
+
+if git show-ref --verify --quiet "refs/heads/${BRANCH}"; then
+  echo "Branch '${BRANCH}' already exists locally — attaching worktree to it."
+  git worktree add "${WORKTREE_DIR}" "${BRANCH}"
+else
+  git worktree add "${WORKTREE_DIR}" -b "${BRANCH}" origin/staging
+fi
+
+echo ""
+echo "Worktree: ${WORKTREE_DIR}"
+echo "Branch:   ${BRANCH}"
+echo ""
+echo "To open in a new Claude Code session:"
+echo "  claude \"${WORKTREE_DIR}\""


### PR DESCRIPTION
Promotion PR — **merge with a merge commit, not squash** (keeps staging an ancestor of main, preventing the squash-divergence conflicts).

Brings the restored staging-integration workflow to main: Dependabot → staging, CI on [main, staging], CONTRIBUTING branch-flow + worktree rules, tracked new-worktree.sh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)