### PR TITLE
chore(release): promote auto-merge promotion fix to main

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -16,7 +16,10 @@ permissions:
 jobs:
   enable-auto-merge:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    # Auto-squash feature PRs into staging only. Promotion PRs into `main`
+    # (head = staging) are merged manually with a merge commit, so staging
+    # stays an ancestor of main and the two branches do not diverge.
+    if: github.event.pull_request.draft == false && github.event.pull_request.base.ref != 'main'
     steps:
       - name: Enable auto-merge
         run: gh pr merge "$PR_NUMBER" --auto --squash


### PR DESCRIPTION
Promotion (merge commit, not squash). Brings the auto-merge.yml fix to main so future promotions are no longer auto-squashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)