### PR TITLE
chore(release): promote v1.33.3 (MCP symlink fix) to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.33.3] — 2026-06-23
+
+### Fixed
+
+- **MCP server now starts when launched via a symlink** (`npx`, Claude Desktop). The `isMain` guard compared `import.meta.url` against `file://${process.argv[1]}`; with a symlinked `tierward-mcp` bin (or macOS `/var`→`/private/var`) the two differed, so the server never started and the process exited immediately. The published 1.33.2 server was non-functional on the primary install path; integration tests missed it because they launch the real source path. Now resolves real paths on both sides, with a symlink-launch regression guard in the integration suite.
+
+---
+
 ## [1.33.2] — 2026-06-23
 
 ### Added

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tierward",
-  "version": "1.33.2",
+  "version": "1.33.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tierward",
-      "version": "1.33.2",
+      "version": "1.33.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tierward",
-  "version": "1.33.2",
+  "version": "1.33.3",
   "description": "Scaffold for legible, reviewable AI-assisted development",
   "type": "module",
   "mcpName": "io.github.marcoguillermaz/tierward",

--- a/packages/cli/src/mcp/server.js
+++ b/packages/cli/src/mcp/server.js
@@ -3,7 +3,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
 import { execFileSync } from 'node:child_process';
-import { readFileSync, existsSync, readdirSync } from 'node:fs';
+import { readFileSync, existsSync, readdirSync, realpathSync } from 'node:fs';
 import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -338,8 +338,22 @@ export async function startStdio() {
   await server.connect(transport);
 }
 
-const isMain = import.meta.url === `file://${process.argv[1]}`;
-if (isMain) {
+// Robust "run as main" detection. The naive
+// `import.meta.url === file://${process.argv[1]}` breaks whenever argv[1] is a
+// symlink or a path alias — e.g. the `tierward-mcp` bin symlink used by npx and
+// Claude Desktop, or macOS resolving /var -> /private/var. In those cases the
+// guard was false, startStdio() never ran, and the process exited immediately
+// ("Server transport closed unexpectedly"). Resolve real paths on both sides.
+function isMainModule() {
+  if (!process.argv[1]) return false;
+  try {
+    return realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return false;
+  }
+}
+
+if (isMainModule()) {
   startStdio().catch((err) => {
     process.stderr.write(`tierward-mcp fatal: ${err.message}\n`);
     process.exit(1);

--- a/packages/cli/test/integration/run.js
+++ b/packages/cli/test/integration/run.js
@@ -4015,6 +4015,37 @@ async function scenarioMCPServer() {
     }
     await client2.close();
 
+    // Regression (v1.33.3): the server must start when launched via a SYMLINK,
+    // not only the real path. npx and Claude Desktop invoke the `tierward-mcp`
+    // bin symlink, and macOS resolves /var -> /private/var. The old isMain guard
+    // (`import.meta.url === file://${argv[1]}`) was false in those cases, so
+    // startStdio() never ran and the process exited immediately. Launch via a
+    // symlink and assert the server still connects and exposes its tools.
+    const symlinkPath = path.join(dir, 'tierward-mcp-symlink.js');
+    fs.symlinkSync(SERVER_PATH, symlinkPath);
+    const transport3 = new StdioClientTransport({
+      command: 'node',
+      args: [symlinkPath],
+      env: { ...process.env, TIERWARD_PROJECT_ROOT: dir },
+      stderr: 'pipe',
+    });
+    const client3 = new Client(
+      { name: 'tierward-integration-test-3', version: '0.0.1' },
+      { capabilities: {} },
+    );
+    await client3.connect(transport3);
+    const toolsViaSymlink = await client3.listTools();
+    if (toolsViaSymlink.tools.length === expected.length) {
+      pass(
+        `MCP server: starts via bin symlink (${toolsViaSymlink.tools.length} tools) - isMain symlink regression guard`,
+      );
+    } else {
+      fail(
+        `MCP server via symlink: expected ${expected.length} tools, got ${toolsViaSymlink.tools.length}`,
+      );
+    }
+    await client3.close();
+
     await client.close();
   } catch (err) {
     fail(`MCP server scenario: ${err.message}`);

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/marcoguillermaz/Tierward",
     "source": "github"
   },
-  "version": "1.33.2",
+  "version": "1.33.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "tierward",
-      "version": "1.33.2",
+      "version": "1.33.3",
       "runtimeHint": "npx",
       "runtimeArguments": [
         { "type": "named", "name": "--package", "value": "tierward" },


### PR DESCRIPTION
Promotion (merge commit). Ships the MCP server symlink-launch fix (v1.33.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)