### PR TITLE
test(release): block plugin/package version drift

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tierward",
   "displayName": "Tierward",
-  "version": "1.33.1",
+  "version": "1.33.3",
   "description": "Governance skills for AI-assisted development: commit enforcement, architecture compliance, security audits, code quality, and humanized prose.",
   "author": {
     "name": "Marco Guillermaz",

--- a/packages/cli/test/unit/plugin-version-sync.test.js
+++ b/packages/cli/test/unit/plugin-version-sync.test.js
@@ -1,0 +1,28 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs-extra';
+import path from 'path';
+import { fileURLToPath } from 'node:url';
+
+// Release guard: the Claude Code marketplace plugin version must stay in lockstep
+// with the published CLI package. They drifted once (plugin.json 1.33.1 vs
+// package 1.33.3) because releases bump packages/cli/package.json but not
+// .claude-plugin/plugin.json. This test runs in the required CI checks, so a
+// mismatch BLOCKS the merge — a hard stop, not a reminder. On release, bump
+// .claude-plugin/plugin.json to match and re-publish the marketplace plugin.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../../../..');
+
+describe('marketplace plugin / CLI package version sync', () => {
+  it('.claude-plugin/plugin.json version equals packages/cli/package.json version', () => {
+    const pkg = fs.readJsonSync(path.join(repoRoot, 'packages/cli/package.json'));
+    const plugin = fs.readJsonSync(path.join(repoRoot, '.claude-plugin/plugin.json'));
+    assert.equal(
+      plugin.version,
+      pkg.version,
+      `.claude-plugin/plugin.json version (${plugin.version}) must equal ` +
+        `packages/cli/package.json version (${pkg.version}). Bump plugin.json and ` +
+        `re-publish the Claude Code marketplace plugin on release.`,
+    );
+  });
+});


### PR DESCRIPTION
Hard block (not a reminder) for the marketplace-plugin version drift Marco flagged. A unit test (runs in required CI checks) fails when `.claude-plugin/plugin.json` version != `packages/cli/package.json` version. Realigns plugin.json 1.33.1 → 1.33.3.

Verified: passes when aligned, fails when drift is reintroduced.

Follow-up (separate): bump plugin.json + marketplace.json sha in the release flow so alignment is automatic, not just enforced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)