### PR TITLE
chore(vscode): bump extension to v0.1.0

### DIFF
--- a/packages/vscode-extension/package-lock.json
+++ b/packages/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tierward-vscode",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tierward-vscode",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "tierward-vscode",
   "displayName": "Tierward",
   "description": "Editor-native governance surfaces for Tierward: doctor health, skill/rule registry, and audit findings inside VS Code.",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "publisher": "marcoguillermaz",
   "icon": "resources/icon.png",
   "license": "MIT",


### PR DESCRIPTION
v0.0.1 already existed on the Marketplace. This is the first automated release under the Tierward name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)