### PR TITLE
chore(release): promote plugin auto-bump to main

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -31,7 +31,7 @@
         "source": "url",
         "url": "https://github.com/marcoguillermaz/Tierward.git",
         "ref": "main",
-        "sha": "44aa06764110bdf0c3e571d14eda222804c2ab0f"
+        "sha": "f580ca55b91ac671eb51b6159d7085571100a00e"
       }
     }
   ]

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "start": "node src/index.js",
     "dev": "node --watch src/index.js",
+    "preversion": "node ../../scripts/sync-plugin-version.mjs",
     "test": "node test/integration/run.js",
     "test:unit": "node --test 'test/unit/**/*.test.js'",
     "lint": "eslint src/ test/",


### PR DESCRIPTION
Promotion (merge commit). Activates auto-sync of plugin.json + marketplace sha on every `npm version` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)